### PR TITLE
Adds non-inherited font-* properties to the form elements

### DIFF
--- a/packages/web/style/forms.scss
+++ b/packages/web/style/forms.scss
@@ -1,0 +1,11 @@
+// Need this because `font-*` properties are not inherited to the form
+// elemements.
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+}


### PR DESCRIPTION
* Les éléments de formulaire n'héritent pas des propriétés CSS relatives à la typographie.
* J'ai donc ajouté une feuille SCSS contenant des règles sur les éléments de formulaires, contenant les propriétés `font-family` ainsi que `font-size`.

Une autre solution serait d'utiliser le paquet npm `normalize.css`.

Merci!