### PR TITLE
Fix Headband color for Edge

### DIFF
--- a/packages/react/src/components/headband/equisoft-default.tsx
+++ b/packages/react/src/components/headband/equisoft-default.tsx
@@ -11,9 +11,9 @@ const tabletMin = `${(breakpoints.tablet / 16)}rem`;
 
 const Header = styled.header`
   align-items: center;
-  background: rgba(1, 38, 57, 1);
+  background: #012639;
   box-sizing: border-box;
-  color: rgba(255, 255, 255);
+  color: #fff;
   display: flex;
   justify-content: space-between;
   min-height: 2.75rem;

--- a/packages/react/src/components/headband/headband.test.tsx.snap
+++ b/packages/react/src/components/headband/headband.test.tsx.snap
@@ -6,9 +6,9 @@ exports[`Headband Matches the snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: rgba(1,38,57,1);
+  background: #012639;
   box-sizing: border-box;
-  color: rgba(255,255,255);
+  color: #fff;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;


### PR DESCRIPTION
## PR Description
Chrome et Firefox semblent patcher le manque du canal alpha, mais pas Edge, alors le texte est illisible.

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] The CircleCI build is successful.