### PR TITLE
Fix Webpack React: Speeds up build time

### DIFF
--- a/packages/react/webpack/webpack.config.common.js
+++ b/packages/react/webpack/webpack.config.common.js
@@ -7,18 +7,18 @@ module.exports = {
     module: {
         rules: [
             {
-                test: /\.tsx?$/,
-                use: [
-                    { loader: 'ts-loader' },
-                ],
-                exclude: /node_modules/,
-            },
-            {
                 test: /.tsx$/,
                 loader: 'react-docgen-typescript-loader',
                 options: {
                     shouldExtractLiteralValuesFromEnum: true,
                 },
+                exclude: /node_modules/,
+            },
+            {
+                test: /\.tsx?$/,
+                use: [
+                    { loader: 'ts-loader' },
+                ],
                 exclude: /node_modules/,
             },
             {

--- a/packages/storybook/yarn.lock
+++ b/packages/storybook/yarn.lock
@@ -3603,9 +3603,9 @@ core-js@^3.0.1, core-js@^3.0.4:
   integrity sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw==
 
 core-js@^3.1.3:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
-  integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.2.tgz#ee2b1a60b50388d8ddcda8cdb44a92c7a9ea76df"
+  integrity sha512-bUTfqFWtNKWp73oNIfRkqwYZJeNT3lstzZcAkhhiuvDraRSgOH1/+F9ZklbpR4zpdKuo4cpXN8tKP7s61yjX+g==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## PR Description
J'ai changé l'ordre des loaders dans la config webpack du folder react. En mettant `ts-loader` avant `react-docgen-typescript-loader` le build time passe de _~70sec_ à _~8sec_.