### PR TITLE
fix(Datepicker): Apporte les changements demandés qui restaient du premier PR

### DIFF
--- a/packages/react/src/components/datepicker/calendar-header.tsx
+++ b/packages/react/src/components/datepicker/calendar-header.tsx
@@ -78,7 +78,7 @@ export function CalendarHeader({
     const { isMobile } = useDeviceContext();
 
     return (
-        <Wrapper isMobile={isMobile}>
+        <Wrapper isMobile={isMobile} data-testid="calendar-header">
             <StyledButton
                 aria-label={t('monthPreviousButtonLabel')}
                 data-testid="month-previous"

--- a/packages/react/src/components/datepicker/datepicker.test.tsx
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx
@@ -1,7 +1,6 @@
 import { getByTestId } from '@design-elements/test-utils/enzyme-selectors';
 import { mount } from 'enzyme';
 import React from 'react';
-import DatePicker from 'react-datepicker';
 
 import { renderWithProviders } from '../../test-utils/renderer';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
@@ -42,11 +41,35 @@ describe('Datepicker', () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
+    test('input value should format on blur', () => {
+        const wrapper = mount(ThemeWrapped(<Datepicker />));
+
+        getByTestId(wrapper, 'text-input').simulate('change', { target: { value: '2002 02 02' } });
+        getByTestId(wrapper, 'text-input').simulate('blur');
+
+        expect(getByTestId(wrapper, 'text-input').props().value).toBe('2002-02-02');
+    });
+
     test('calendar should be opened when startOpen prop is truthy', () => {
         const wrapper = mount(ThemeWrapped(<Datepicker startOpen/>));
-        const element = wrapper.find(DatePicker);
 
-        expect(element.props().open).toBeTruthy();
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeTruthy();
+    });
+
+    test('calendar should not open when input is clicked', () => {
+        const wrapper = mount(ThemeWrapped(<Datepicker />));
+
+        getByTestId(wrapper, 'text-input').simulate('click');
+
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeFalsy();
+    });
+
+    test('calendar should not open when input is focused', () => {
+        const wrapper = mount(ThemeWrapped(<Datepicker />));
+
+        getByTestId(wrapper, 'text-input').simulate('focus');
+
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeFalsy();
     });
 
     test('calendar should open when calendar button is clicked', () => {
@@ -54,8 +77,15 @@ describe('Datepicker', () => {
 
         getByTestId(wrapper, 'calendar-button').simulate('mousedown');
 
-        const element = wrapper.find(DatePicker);
-        expect(element.props().open).toBeTruthy();
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeTruthy();
+    });
+
+    test('calendar should close when calendar button is clicked (start open)', () => {
+        const wrapper = mount(ThemeWrapped(<Datepicker startOpen/>));
+
+        getByTestId(wrapper, 'calendar-button').simulate('mousedown');
+
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeFalsy();
     });
 
     test('calendar should open on calendar button keydown (Enter)', () => {
@@ -63,8 +93,7 @@ describe('Datepicker', () => {
 
         getByTestId(wrapper, 'calendar-button').simulate('keydown', { key: 'Enter' });
 
-        const element = wrapper.find(DatePicker);
-        expect(element.props().open).toBeTruthy();
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeTruthy();
     });
 
     test('calendar should open on calendar button keydown (Spacebar)', () => {
@@ -72,8 +101,7 @@ describe('Datepicker', () => {
 
         getByTestId(wrapper, 'calendar-button').simulate('keydown', { key: ' ' });
 
-        const element = wrapper.find(DatePicker);
-        expect(element.props().open).toBeTruthy();
+        expect(getByTestId(wrapper, 'calendar-header').exists()).toBeTruthy();
     });
 
     test('month select value should change when month-previous button is clicked', () => {
@@ -144,7 +172,7 @@ describe('Datepicker', () => {
     });
 
     test('matches snapshot (open, mobile)', () => {
-        const tree = renderWithProviders(<Datepicker label="date" open maxDate={new Date('2010-10-10, 12:00')}/>, 'mobile');
+        const tree = renderWithProviders(<Datepicker label="date" startOpen maxDate={new Date('2010-10-10, 12:00')}/>, 'mobile');
 
         expect(tree).toMatchSnapshot();
     });

--- a/packages/react/src/components/datepicker/datepicker.test.tsx.snap
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx.snap
@@ -243,9 +243,7 @@ input + .c1 {
   <div
     class="c2"
   >
-    <div
-      class="react-datepicker-wrapper"
-    >
+    <div>
       <div
         class="react-datepicker__input-container"
       >
@@ -258,17 +256,12 @@ input + .c1 {
         />
       </div>
     </div>
-    <div
-      aria-label="Fri May 05 1995"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    />
     <button
-      aria-label="Choose date, The selected date is 1995-05-05"
+      aria-label="Choose date. The selected date is 1995-05-05"
       class="c4"
       data-testid="calendar-button"
       tabindex="0"
+      type="button"
     >
       <svg
         color="currentColor"
@@ -537,17 +530,12 @@ input + .c1 {
         />
       </div>
     </div>
-    <div
-      aria-label="Choose Date"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    />
     <button
       aria-label="Choose date"
       class="c4"
       data-testid="calendar-button"
       tabindex="0"
+      type="button"
     >
       <svg
         color="currentColor"
@@ -815,18 +803,13 @@ input + .c1 {
         />
       </div>
     </div>
-    <div
-      aria-label="Choose Date"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    />
     <button
       aria-label="Choose date"
       class="c4"
       data-testid="calendar-button"
       disabled=""
       tabindex="0"
+      type="button"
     >
       <svg
         color="currentColor"
@@ -1107,17 +1090,12 @@ input + .c1 {
         />
       </div>
     </div>
-    <div
-      aria-label="Choose Date"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    />
     <button
       aria-label="Choose date"
       class="c4"
       data-testid="calendar-button"
       tabindex="0"
+      type="button"
     >
       <svg
         color="currentColor"
@@ -1381,6 +1359,470 @@ input + .c1 {
   <div
     class="c2"
   >
+    <div>
+      <div
+        class="react-datepicker__input-container"
+      >
+        <input
+          class="c3 datePickerInput"
+          data-testid="text-input"
+          placeholder="YYYY-MM-DD"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <button
+      aria-label="Choose date"
+      class="c4"
+      data-testid="calendar-button"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        color="currentColor"
+        focusable="false"
+        height="24"
+        width="24"
+      />
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Datepicker matches snapshot (open, desktop) 1`] = `
+.c1 {
+  color: #000000;
+  display: block;
+  font-size: 0.75rem;
+  font-weight: var(--font-normal);
+  -webkit-letter-spacing: 0.02rem;
+  -moz-letter-spacing: 0.02rem;
+  -ms-letter-spacing: 0.02rem;
+  letter-spacing: 0.02rem;
+  line-height: 1.25rem;
+  margin: 0;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+input + .c1 {
+  margin-left: var(--spacing-half);
+}
+
+.c0 {
+  margin: 0 0 var(--spacing-3x);
+}
+
+.c0 input,
+.c0 select,
+.c0 textarea {
+  border-color: #D9DDE2;
+}
+
+.c0:focus {
+  border-color: #0080A5;
+}
+
+.c12 {
+  display: none;
+  position: absolute;
+  width: 100%;
+}
+
+.c13 {
+  background-color: #FFFFFF;
+  border-radius: var(--border-radius);
+  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
+  list-style-type: none;
+  margin: 0;
+  max-height: 128px;
+  min-width: -webkit-fit-content;
+  min-width: -moz-fit-content;
+  min-width: fit-content;
+  overflow-y: auto;
+  padding: 0;
+  width: 100%;
+}
+
+.c13:focus {
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+  outline: none;
+}
+
+.c14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: inherit;
+  color: #000000;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 32px;
+  line-height: 32px;
+  overflow: hidden;
+  padding: 0 8px 0 var(--spacing-4x);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c14:hover,
+.c14:focus {
+  background-color: #D9DDE2;
+}
+
+.c8 {
+  position: relative;
+}
+
+.c9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFFFFF;
+  border: 1px solid #57666E;
+  border-radius: var(--border-radius);
+  box-shadow: none;
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  margin-top: 0;
+  padding-right: var(--spacing-1x);
+  width: 100%;
+}
+
+.c9:hover {
+  cursor: pointer;
+}
+
+.c9 svg {
+  color: #57666E;
+}
+
+.c10 {
+  background-color: #FFFFFF;
+  border: none;
+  border-radius: var(--border-radius);
+  box-sizing: border-box;
+  caret-color: transparent;
+  font-size: 0.875rem;
+  -webkit-letter-spacing: 0.4px;
+  -moz-letter-spacing: 0.4px;
+  -ms-letter-spacing: 0.4px;
+  letter-spacing: 0.4px;
+  max-height: 100%;
+  min-width: 0;
+  outline: none;
+  overflow: hidden;
+  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.c10:hover {
+  cursor: pointer;
+}
+
+.c10::-webkit-input-placeholder {
+  color: #57666E;
+  font-size: 0.875rem;
+}
+
+.c10::-moz-placeholder {
+  color: #57666E;
+  font-size: 0.875rem;
+}
+
+.c10:-ms-input-placeholder {
+  color: #57666E;
+  font-size: 0.875rem;
+}
+
+.c10::placeholder {
+  color: #57666E;
+  font-size: 0.875rem;
+}
+
+.c11 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 0 var(--spacing-3x);
+}
+
+.c4 > button {
+  background-color: #FFFFFF;
+  border: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0;
+}
+
+.c4 > button:focus {
+  outline: none;
+}
+
+.c4 > button:hover {
+  cursor: pointer;
+}
+
+.c5:focus {
+  border-radius: var(--border-radius);
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+}
+
+.c6 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c7 {
+  height: 32px;
+  width: 80px;
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2 .popper[data-placement^="bottom"] {
+  margin-top: 0;
+}
+
+.c2 .react-datepicker {
+  border: 1px solid #D9DDE2;
+  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
+  font-family: 'Open Sans',sans-serif;
+  padding: var(--spacing-3x) var(--spacing-2x);
+}
+
+.c2 .react-datepicker__day {
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  height: 32px;
+  line-height: 2rem;
+  margin: 0;
+  width: 32px;
+}
+
+.c2 .react-datepicker__day:hover {
+  background-color: #D9DDE2;
+  border-radius: 20px;
+}
+
+.c2 .react-datepicker__day:focus {
+  outline: none;
+}
+
+.c2 .react-datepicker__day--disabled {
+  color: #9CA7B4;
+}
+
+.c2 .react-datepicker__day--disabled:hover {
+  background-color: #FFFFFF;
+}
+
+.c2 .react-datepicker__day--keyboard-selected {
+  background-color: #FFFFFF;
+  border-radius: 20px;
+  box-sizing: border-box;
+  color: #000000;
+}
+
+.c2 .react-datepicker__day--keyboard-selected:focus {
+  border: 1px solid #0080A5;
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+}
+
+.c2 .react-datepicker__day-name {
+  font-size: 0.875rem;
+  font-weight: var(--font-bold);
+  line-height: 1.25rem;
+  margin: 0;
+  text-transform: uppercase;
+  width: 32px;
+}
+
+.c2 .react-datepicker__day--outside-month {
+  color: #57666E;
+}
+
+.c2 .react-datepicker__day--outside-month.react-datepicker__day--selected {
+  color: #FFFFFF;
+}
+
+.c2 .react-datepicker__day--selected {
+  background-color: #0080A5;
+  border-radius: 20px;
+}
+
+.c2 .react-datepicker__day--selected:focus {
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+}
+
+.c2 .react-datepicker__day--selected:hover {
+  color: #000000;
+}
+
+.c2 .react-datepicker__day--today {
+  color: #0080A5;
+  font-weight: var(--font-normal);
+}
+
+.c2 .react-datepicker__day--today.react-datepicker__day--selected {
+  color: #FFFFFF;
+}
+
+.c2 .react-datepicker__header {
+  background-color: #FFFFFF;
+  border-bottom: none;
+  margin-bottom: var(--spacing-half);
+  padding: 0;
+}
+
+.c2 .react-datepicker__month {
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.c2 .react-datepicker__portal {
+  background-color: rgba(0,0,0,0.5);
+}
+
+.c2 .react-datepicker__portal .react-datepicker__day-name {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  width: 40px;
+}
+
+.c2 .react-datepicker__portal .react-datepicker__day {
+  height: 40px;
+  line-height: 2.5rem;
+  width: 40px;
+}
+
+.c3.datePickerInput {
+  background-color: #FFFFFF;
+  border: 1px solid #57666E;
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 0.875rem;
+  height: 32px;
+  padding: var(--spacing-half) 0 var(--spacing-half) var(--spacing-1x);
+  width: 109px;
+}
+
+.c3.datePickerInput:focus {
+  border: 1px solid #0080A5;
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+  outline: none;
+}
+
+.c3.datePickerInput:focus {
+  border: 1px solid #0080A5;
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+  outline: none;
+}
+
+.c3.datePickerInput:focus {
+  border: 1px solid #0080A5;
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+  outline: none;
+}
+
+.c3.datePickerInput:focus {
+  border: 1px solid #0080A5;
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+  outline: none;
+}
+
+.c15 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFFFFF;
+  border: 1px solid #57666E;
+  border-left: none;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+  box-sizing: border-box;
+  color: #57666E;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 32px;
+}
+
+.c15:hover {
+  background-color: #D9DDE2;
+}
+
+.c15:focus {
+  border: 1px solid #0080A5;
+  border-left: none;
+  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
+  outline: none;
+  z-index: 10;
+}
+
+<div
+  class="c0"
+>
+  <label
+    class="c1"
+  >
+    date
+  </label>
+  <div
+    class="c2"
+  >
     <div
       class="react-datepicker-wrapper"
     >
@@ -1397,16 +1839,7 @@ input + .c1 {
       </div>
     </div>
     <div
-      aria-label="Choose Date"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    />
-    <button
-      aria-label="Choose date"
-      class="c4"
-      data-testid="calendar-button"
-      tabindex="0"
+      class="react-datepicker__tab-loop"
     >
       <div
         class="react-datepicker__tab-loop__start"
@@ -1418,7 +1851,11 @@ input + .c1 {
       >
         <div>
           <div
+            aria-label="Choose date"
+            aria-live="polite"
+            aria-modal="true"
             class="react-datepicker"
+            role="dialog"
           >
             <div
               class="react-datepicker__month-container"
@@ -1428,9 +1865,11 @@ input + .c1 {
               >
                 <div
                   class="c4"
+                  data-testid="calendar-header"
                 >
                   <button
                     aria-label="Go to previous month"
+                    class="c5"
                     data-testid="month-previous"
                   >
                     <svg
@@ -1441,34 +1880,34 @@ input + .c1 {
                     />
                   </button>
                   <div
-                    class="c5"
+                    class="c6"
                   >
                     <div
-                      class="c6"
+                      class="c7"
                       style="margin-right:8px"
                     >
                       <div
-                        class="c0 c7"
+                        class="c0 c8"
                       >
                         <div
                           aria-expanded="false"
                           aria-haspopup="listbox"
                           aria-owns="listbox_undefined"
-                          class="c8"
+                          class="c9"
                           data-testid="input-wrapper"
                         >
                           <input
                             aria-autocomplete="list"
                             aria-controls="listbox_undefined"
                             aria-multiline="false"
-                            class="c9"
+                            class="c10"
                             data-testid="input"
                             placeholder="Select an option"
                             type="text"
                             value=""
                           />
                           <button
-                            class="c10"
+                            class="c11"
                             data-testid="arrow"
                             tabindex="-1"
                             type="button"
@@ -1482,19 +1921,19 @@ input + .c1 {
                           </button>
                         </div>
                         <div
-                          class="c11"
+                          class="c12"
                           role="listbox"
                           tabindex="-1"
                         >
                           <ul
-                            class="c12"
+                            class="c13"
                             role="presentation"
                             tabindex="0"
                           >
                             <li
                               aria-label="Jan"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_january"
                               role="option"
                             >
@@ -1503,7 +1942,7 @@ input + .c1 {
                             <li
                               aria-label="Feb"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_february"
                               role="option"
                             >
@@ -1512,7 +1951,7 @@ input + .c1 {
                             <li
                               aria-label="Mar"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_march"
                               role="option"
                             >
@@ -1521,7 +1960,7 @@ input + .c1 {
                             <li
                               aria-label="Apr"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_april"
                               role="option"
                             >
@@ -1530,7 +1969,7 @@ input + .c1 {
                             <li
                               aria-label="May"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_may"
                               role="option"
                             >
@@ -1539,7 +1978,7 @@ input + .c1 {
                             <li
                               aria-label="Jun"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_june"
                               role="option"
                             >
@@ -1548,7 +1987,7 @@ input + .c1 {
                             <li
                               aria-label="Jul"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_july"
                               role="option"
                             >
@@ -1557,7 +1996,7 @@ input + .c1 {
                             <li
                               aria-label="Aug"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_august"
                               role="option"
                             >
@@ -1566,7 +2005,7 @@ input + .c1 {
                             <li
                               aria-label="Sep"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_september"
                               role="option"
                             >
@@ -1575,7 +2014,7 @@ input + .c1 {
                             <li
                               aria-label="Oct"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_october"
                               role="option"
                             >
@@ -1584,7 +2023,7 @@ input + .c1 {
                             <li
                               aria-label="Nov"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_november"
                               role="option"
                             >
@@ -1593,7 +2032,7 @@ input + .c1 {
                             <li
                               aria-label="Dec"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_december"
                               role="option"
                             >
@@ -1604,30 +2043,30 @@ input + .c1 {
                       </div>
                     </div>
                     <div
-                      class="c6"
+                      class="c7"
                     >
                       <div
-                        class="c0 c7"
+                        class="c0 c8"
                       >
                         <div
                           aria-expanded="false"
                           aria-haspopup="listbox"
                           aria-owns="listbox_undefined"
-                          class="c8"
+                          class="c9"
                           data-testid="input-wrapper"
                         >
                           <input
                             aria-autocomplete="list"
                             aria-controls="listbox_undefined"
                             aria-multiline="false"
-                            class="c9"
+                            class="c10"
                             data-testid="input"
                             placeholder="Select an option"
                             type="text"
                             value=""
                           />
                           <button
-                            class="c10"
+                            class="c11"
                             data-testid="arrow"
                             tabindex="-1"
                             type="button"
@@ -1641,19 +2080,19 @@ input + .c1 {
                           </button>
                         </div>
                         <div
-                          class="c11"
+                          class="c12"
                           role="listbox"
                           tabindex="-1"
                         >
                           <ul
-                            class="c12"
+                            class="c13"
                             role="presentation"
                             tabindex="0"
                           >
                             <li
                               aria-label="1920"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1920"
                               role="option"
                             >
@@ -1662,7 +2101,7 @@ input + .c1 {
                             <li
                               aria-label="1921"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1921"
                               role="option"
                             >
@@ -1671,7 +2110,7 @@ input + .c1 {
                             <li
                               aria-label="1922"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1922"
                               role="option"
                             >
@@ -1680,7 +2119,7 @@ input + .c1 {
                             <li
                               aria-label="1923"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1923"
                               role="option"
                             >
@@ -1689,7 +2128,7 @@ input + .c1 {
                             <li
                               aria-label="1924"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1924"
                               role="option"
                             >
@@ -1698,7 +2137,7 @@ input + .c1 {
                             <li
                               aria-label="1925"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1925"
                               role="option"
                             >
@@ -1707,7 +2146,7 @@ input + .c1 {
                             <li
                               aria-label="1926"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1926"
                               role="option"
                             >
@@ -1716,7 +2155,7 @@ input + .c1 {
                             <li
                               aria-label="1927"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1927"
                               role="option"
                             >
@@ -1725,7 +2164,7 @@ input + .c1 {
                             <li
                               aria-label="1928"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1928"
                               role="option"
                             >
@@ -1734,7 +2173,7 @@ input + .c1 {
                             <li
                               aria-label="1929"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1929"
                               role="option"
                             >
@@ -1743,7 +2182,7 @@ input + .c1 {
                             <li
                               aria-label="1930"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1930"
                               role="option"
                             >
@@ -1752,7 +2191,7 @@ input + .c1 {
                             <li
                               aria-label="1931"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1931"
                               role="option"
                             >
@@ -1761,7 +2200,7 @@ input + .c1 {
                             <li
                               aria-label="1932"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1932"
                               role="option"
                             >
@@ -1770,7 +2209,7 @@ input + .c1 {
                             <li
                               aria-label="1933"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1933"
                               role="option"
                             >
@@ -1779,7 +2218,7 @@ input + .c1 {
                             <li
                               aria-label="1934"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1934"
                               role="option"
                             >
@@ -1788,7 +2227,7 @@ input + .c1 {
                             <li
                               aria-label="1935"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1935"
                               role="option"
                             >
@@ -1797,7 +2236,7 @@ input + .c1 {
                             <li
                               aria-label="1936"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1936"
                               role="option"
                             >
@@ -1806,7 +2245,7 @@ input + .c1 {
                             <li
                               aria-label="1937"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1937"
                               role="option"
                             >
@@ -1815,7 +2254,7 @@ input + .c1 {
                             <li
                               aria-label="1938"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1938"
                               role="option"
                             >
@@ -1824,7 +2263,7 @@ input + .c1 {
                             <li
                               aria-label="1939"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1939"
                               role="option"
                             >
@@ -1833,7 +2272,7 @@ input + .c1 {
                             <li
                               aria-label="1940"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1940"
                               role="option"
                             >
@@ -1842,7 +2281,7 @@ input + .c1 {
                             <li
                               aria-label="1941"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1941"
                               role="option"
                             >
@@ -1851,7 +2290,7 @@ input + .c1 {
                             <li
                               aria-label="1942"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1942"
                               role="option"
                             >
@@ -1860,7 +2299,7 @@ input + .c1 {
                             <li
                               aria-label="1943"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1943"
                               role="option"
                             >
@@ -1869,7 +2308,7 @@ input + .c1 {
                             <li
                               aria-label="1944"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1944"
                               role="option"
                             >
@@ -1878,7 +2317,7 @@ input + .c1 {
                             <li
                               aria-label="1945"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1945"
                               role="option"
                             >
@@ -1887,7 +2326,7 @@ input + .c1 {
                             <li
                               aria-label="1946"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1946"
                               role="option"
                             >
@@ -1896,7 +2335,7 @@ input + .c1 {
                             <li
                               aria-label="1947"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1947"
                               role="option"
                             >
@@ -1905,7 +2344,7 @@ input + .c1 {
                             <li
                               aria-label="1948"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1948"
                               role="option"
                             >
@@ -1914,7 +2353,7 @@ input + .c1 {
                             <li
                               aria-label="1949"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1949"
                               role="option"
                             >
@@ -1923,7 +2362,7 @@ input + .c1 {
                             <li
                               aria-label="1950"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1950"
                               role="option"
                             >
@@ -1932,7 +2371,7 @@ input + .c1 {
                             <li
                               aria-label="1951"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1951"
                               role="option"
                             >
@@ -1941,7 +2380,7 @@ input + .c1 {
                             <li
                               aria-label="1952"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1952"
                               role="option"
                             >
@@ -1950,7 +2389,7 @@ input + .c1 {
                             <li
                               aria-label="1953"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1953"
                               role="option"
                             >
@@ -1959,7 +2398,7 @@ input + .c1 {
                             <li
                               aria-label="1954"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1954"
                               role="option"
                             >
@@ -1968,7 +2407,7 @@ input + .c1 {
                             <li
                               aria-label="1955"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1955"
                               role="option"
                             >
@@ -1977,7 +2416,7 @@ input + .c1 {
                             <li
                               aria-label="1956"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1956"
                               role="option"
                             >
@@ -1986,7 +2425,7 @@ input + .c1 {
                             <li
                               aria-label="1957"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1957"
                               role="option"
                             >
@@ -1995,7 +2434,7 @@ input + .c1 {
                             <li
                               aria-label="1958"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1958"
                               role="option"
                             >
@@ -2004,7 +2443,7 @@ input + .c1 {
                             <li
                               aria-label="1959"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1959"
                               role="option"
                             >
@@ -2013,7 +2452,7 @@ input + .c1 {
                             <li
                               aria-label="1960"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1960"
                               role="option"
                             >
@@ -2022,7 +2461,7 @@ input + .c1 {
                             <li
                               aria-label="1961"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1961"
                               role="option"
                             >
@@ -2031,7 +2470,7 @@ input + .c1 {
                             <li
                               aria-label="1962"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1962"
                               role="option"
                             >
@@ -2040,7 +2479,7 @@ input + .c1 {
                             <li
                               aria-label="1963"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1963"
                               role="option"
                             >
@@ -2049,7 +2488,7 @@ input + .c1 {
                             <li
                               aria-label="1964"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1964"
                               role="option"
                             >
@@ -2058,7 +2497,7 @@ input + .c1 {
                             <li
                               aria-label="1965"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1965"
                               role="option"
                             >
@@ -2067,7 +2506,7 @@ input + .c1 {
                             <li
                               aria-label="1966"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1966"
                               role="option"
                             >
@@ -2076,7 +2515,7 @@ input + .c1 {
                             <li
                               aria-label="1967"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1967"
                               role="option"
                             >
@@ -2085,7 +2524,7 @@ input + .c1 {
                             <li
                               aria-label="1968"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1968"
                               role="option"
                             >
@@ -2094,7 +2533,7 @@ input + .c1 {
                             <li
                               aria-label="1969"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1969"
                               role="option"
                             >
@@ -2103,7 +2542,7 @@ input + .c1 {
                             <li
                               aria-label="1970"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1970"
                               role="option"
                             >
@@ -2112,7 +2551,7 @@ input + .c1 {
                             <li
                               aria-label="1971"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1971"
                               role="option"
                             >
@@ -2121,7 +2560,7 @@ input + .c1 {
                             <li
                               aria-label="1972"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1972"
                               role="option"
                             >
@@ -2130,7 +2569,7 @@ input + .c1 {
                             <li
                               aria-label="1973"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1973"
                               role="option"
                             >
@@ -2139,7 +2578,7 @@ input + .c1 {
                             <li
                               aria-label="1974"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1974"
                               role="option"
                             >
@@ -2148,7 +2587,7 @@ input + .c1 {
                             <li
                               aria-label="1975"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1975"
                               role="option"
                             >
@@ -2157,7 +2596,7 @@ input + .c1 {
                             <li
                               aria-label="1976"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1976"
                               role="option"
                             >
@@ -2166,7 +2605,7 @@ input + .c1 {
                             <li
                               aria-label="1977"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1977"
                               role="option"
                             >
@@ -2175,7 +2614,7 @@ input + .c1 {
                             <li
                               aria-label="1978"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1978"
                               role="option"
                             >
@@ -2184,7 +2623,7 @@ input + .c1 {
                             <li
                               aria-label="1979"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1979"
                               role="option"
                             >
@@ -2193,7 +2632,7 @@ input + .c1 {
                             <li
                               aria-label="1980"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1980"
                               role="option"
                             >
@@ -2202,7 +2641,7 @@ input + .c1 {
                             <li
                               aria-label="1981"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1981"
                               role="option"
                             >
@@ -2211,7 +2650,7 @@ input + .c1 {
                             <li
                               aria-label="1982"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1982"
                               role="option"
                             >
@@ -2220,7 +2659,7 @@ input + .c1 {
                             <li
                               aria-label="1983"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1983"
                               role="option"
                             >
@@ -2229,7 +2668,7 @@ input + .c1 {
                             <li
                               aria-label="1984"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1984"
                               role="option"
                             >
@@ -2238,7 +2677,7 @@ input + .c1 {
                             <li
                               aria-label="1985"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1985"
                               role="option"
                             >
@@ -2247,7 +2686,7 @@ input + .c1 {
                             <li
                               aria-label="1986"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1986"
                               role="option"
                             >
@@ -2256,7 +2695,7 @@ input + .c1 {
                             <li
                               aria-label="1987"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1987"
                               role="option"
                             >
@@ -2265,7 +2704,7 @@ input + .c1 {
                             <li
                               aria-label="1988"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1988"
                               role="option"
                             >
@@ -2274,7 +2713,7 @@ input + .c1 {
                             <li
                               aria-label="1989"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1989"
                               role="option"
                             >
@@ -2283,7 +2722,7 @@ input + .c1 {
                             <li
                               aria-label="1990"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1990"
                               role="option"
                             >
@@ -2292,7 +2731,7 @@ input + .c1 {
                             <li
                               aria-label="1991"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1991"
                               role="option"
                             >
@@ -2301,7 +2740,7 @@ input + .c1 {
                             <li
                               aria-label="1992"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1992"
                               role="option"
                             >
@@ -2310,7 +2749,7 @@ input + .c1 {
                             <li
                               aria-label="1993"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1993"
                               role="option"
                             >
@@ -2319,7 +2758,7 @@ input + .c1 {
                             <li
                               aria-label="1994"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1994"
                               role="option"
                             >
@@ -2328,7 +2767,7 @@ input + .c1 {
                             <li
                               aria-label="1995"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1995"
                               role="option"
                             >
@@ -2337,7 +2776,7 @@ input + .c1 {
                             <li
                               aria-label="1996"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1996"
                               role="option"
                             >
@@ -2346,7 +2785,7 @@ input + .c1 {
                             <li
                               aria-label="1997"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1997"
                               role="option"
                             >
@@ -2355,7 +2794,7 @@ input + .c1 {
                             <li
                               aria-label="1998"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1998"
                               role="option"
                             >
@@ -2364,7 +2803,7 @@ input + .c1 {
                             <li
                               aria-label="1999"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_1999"
                               role="option"
                             >
@@ -2373,7 +2812,7 @@ input + .c1 {
                             <li
                               aria-label="2000"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2000"
                               role="option"
                             >
@@ -2382,7 +2821,7 @@ input + .c1 {
                             <li
                               aria-label="2001"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2001"
                               role="option"
                             >
@@ -2391,7 +2830,7 @@ input + .c1 {
                             <li
                               aria-label="2002"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2002"
                               role="option"
                             >
@@ -2400,7 +2839,7 @@ input + .c1 {
                             <li
                               aria-label="2003"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2003"
                               role="option"
                             >
@@ -2409,7 +2848,7 @@ input + .c1 {
                             <li
                               aria-label="2004"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2004"
                               role="option"
                             >
@@ -2418,7 +2857,7 @@ input + .c1 {
                             <li
                               aria-label="2005"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2005"
                               role="option"
                             >
@@ -2427,7 +2866,7 @@ input + .c1 {
                             <li
                               aria-label="2006"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2006"
                               role="option"
                             >
@@ -2436,7 +2875,7 @@ input + .c1 {
                             <li
                               aria-label="2007"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2007"
                               role="option"
                             >
@@ -2445,7 +2884,7 @@ input + .c1 {
                             <li
                               aria-label="2008"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2008"
                               role="option"
                             >
@@ -2454,7 +2893,7 @@ input + .c1 {
                             <li
                               aria-label="2009"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2009"
                               role="option"
                             >
@@ -2463,7 +2902,7 @@ input + .c1 {
                             <li
                               aria-label="2010"
                               aria-selected="false"
-                              class="c13"
+                              class="c14"
                               id="undefined_2010"
                               role="option"
                             >
@@ -2476,6 +2915,7 @@ input + .c1 {
                   </div>
                   <button
                     aria-label="Go to next month"
+                    class="c5"
                     data-testid="month-next"
                     disabled=""
                   >
@@ -2944,2020 +3384,11 @@ input + .c1 {
       />
     </div>
     <button
-      class="c14"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
-  </div>
-</div>
-`;
-
-exports[`Datepicker matches snapshot (open, desktop) 1`] = `
-.c1 {
-  color: #000000;
-  display: block;
-  font-size: 0.75rem;
-  font-weight: var(--font-normal);
-  -webkit-letter-spacing: 0.02rem;
-  -moz-letter-spacing: 0.02rem;
-  -ms-letter-spacing: 0.02rem;
-  letter-spacing: 0.02rem;
-  line-height: 1.25rem;
-  margin: 0;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-}
-
-input + .c1 {
-  margin-left: var(--spacing-half);
-}
-
-.c0 {
-  margin: 0 0 var(--spacing-3x);
-}
-
-.c0 input,
-.c0 select,
-.c0 textarea {
-  border-color: #D9DDE2;
-}
-
-.c0:focus {
-  border-color: #0080A5;
-}
-
-.c12 {
-  display: none;
-  position: absolute;
-  width: 100%;
-}
-
-.c13 {
-  background-color: #FFFFFF;
-  border-radius: var(--border-radius);
-  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  list-style-type: none;
-  margin: 0;
-  max-height: 128px;
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
-  overflow-y: auto;
-  padding: 0;
-  width: 100%;
-}
-
-.c13:focus {
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-  outline: none;
-}
-
-.c14 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: inherit;
-  color: #000000;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-  height: 32px;
-  line-height: 32px;
-  overflow: hidden;
-  padding: 0 8px 0 var(--spacing-4x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.c14:hover,
-.c14:focus {
-  background-color: #D9DDE2;
-}
-
-.c8 {
-  position: relative;
-}
-
-.c9 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #FFFFFF;
-  border: 1px solid #57666E;
-  border-radius: var(--border-radius);
-  box-shadow: none;
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 32px;
-  margin-top: 0;
-  padding-right: var(--spacing-1x);
-  width: 100%;
-}
-
-.c9:hover {
-  cursor: pointer;
-}
-
-.c9 svg {
-  color: #57666E;
-}
-
-.c10 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.4px;
-  -moz-letter-spacing: 0.4px;
-  -ms-letter-spacing: 0.4px;
-  letter-spacing: 0.4px;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c10:hover {
-  cursor: pointer;
-}
-
-.c10::-webkit-input-placeholder {
-  color: #57666E;
-  font-size: 0.875rem;
-}
-
-.c10::-moz-placeholder {
-  color: #57666E;
-  font-size: 0.875rem;
-}
-
-.c10:-ms-input-placeholder {
-  color: #57666E;
-  font-size: 0.875rem;
-}
-
-.c10::placeholder {
-  color: #57666E;
-  font-size: 0.875rem;
-}
-
-.c11 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding: 0 0 var(--spacing-3x);
-}
-
-.c4 > button {
-  background-color: #FFFFFF;
-  border: none;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding: 0;
-}
-
-.c4 > button:focus {
-  outline: none;
-}
-
-.c4 > button:hover {
-  cursor: pointer;
-}
-
-.c5:focus {
-  border-radius: var(--border-radius);
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-}
-
-.c6 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c7 {
-  height: 32px;
-  width: 80px;
-}
-
-.c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c2 .popper[data-placement^="bottom"] {
-  margin-top: 0;
-}
-
-.c2 .react-datepicker {
-  border: 1px solid #D9DDE2;
-  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
-  padding: var(--spacing-3x) var(--spacing-2x);
-}
-
-.c2 .react-datepicker__day {
-  border: 1px solid transparent;
-  box-sizing: border-box;
-  height: 32px;
-  line-height: 2rem;
-  margin: 0;
-  width: 32px;
-}
-
-.c2 .react-datepicker__day:hover {
-  background-color: #D9DDE2;
-  border-radius: 20px;
-}
-
-.c2 .react-datepicker__day:focus {
-  outline: none;
-}
-
-.c2 .react-datepicker__day--disabled {
-  color: #9CA7B4;
-}
-
-.c2 .react-datepicker__day--disabled:hover {
-  background-color: #FFFFFF;
-}
-
-.c2 .react-datepicker__day--keyboard-selected {
-  background-color: #FFFFFF;
-  border-radius: 20px;
-  box-sizing: border-box;
-  color: #000000;
-}
-
-.c2 .react-datepicker__day--keyboard-selected:focus {
-  border: 1px solid #0080A5;
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-}
-
-.c2 .react-datepicker__day-name {
-  font-size: 0.875rem;
-  font-weight: var(--font-bold);
-  line-height: 1.25rem;
-  margin: 0;
-  text-transform: uppercase;
-  width: 32px;
-}
-
-.c2 .react-datepicker__day--outside-month {
-  color: #57666E;
-}
-
-.c2 .react-datepicker__day--outside-month.react-datepicker__day--selected {
-  color: #FFFFFF;
-}
-
-.c2 .react-datepicker__day--selected {
-  background-color: #0080A5;
-  border-radius: 20px;
-}
-
-.c2 .react-datepicker__day--selected:focus {
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-}
-
-.c2 .react-datepicker__day--selected:hover {
-  color: #000000;
-}
-
-.c2 .react-datepicker__day--today {
-  color: #0080A5;
-  font-weight: var(--font-normal);
-}
-
-.c2 .react-datepicker__day--today.react-datepicker__day--selected {
-  color: #FFFFFF;
-}
-
-.c2 .react-datepicker__header {
-  background-color: #FFFFFF;
-  border-bottom: none;
-  margin-bottom: var(--spacing-half);
-  padding: 0;
-}
-
-.c2 .react-datepicker__month {
-  font-size: 0.875rem;
-  margin: 0;
-}
-
-.c2 .react-datepicker__portal {
-  background-color: rgba(0,0,0,0.5);
-}
-
-.c2 .react-datepicker__portal .react-datepicker__day-name {
-  font-size: 1rem;
-  line-height: 1.5rem;
-  width: 40px;
-}
-
-.c2 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
-  line-height: 2.5rem;
-  width: 40px;
-}
-
-.c3.datePickerInput {
-  background-color: #FFFFFF;
-  border: 1px solid #57666E;
-  border-radius: var(--border-radius) 0 0 var(--border-radius);
-  box-sizing: border-box;
-  font-family: inherit;
-  font-size: 0.875rem;
-  height: 32px;
-  padding: var(--spacing-half) 0 var(--spacing-half) var(--spacing-1x);
-  width: 109px;
-}
-
-.c3.datePickerInput:focus {
-  border: 1px solid #0080A5;
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-  outline: none;
-}
-
-.c3.datePickerInput:focus {
-  border: 1px solid #0080A5;
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-  outline: none;
-}
-
-.c3.datePickerInput:focus {
-  border: 1px solid #0080A5;
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-  outline: none;
-}
-
-.c3.datePickerInput:focus {
-  border: 1px solid #0080A5;
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-  outline: none;
-}
-
-.c15 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #FFFFFF;
-  border: 1px solid #57666E;
-  border-left: none;
-  border-radius: 0 var(--border-radius) var(--border-radius) 0;
-  box-sizing: border-box;
-  color: #57666E;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: 32px;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 32px;
-}
-
-.c15:hover {
-  background-color: #D9DDE2;
-}
-
-.c15:focus {
-  border: 1px solid #0080A5;
-  border-left: none;
-  box-shadow: 0 0 0 2px rgba(0,128,165,0.4);
-  outline: none;
-  z-index: 10;
-}
-
-<div
-  class="c0"
->
-  <label
-    class="c1"
-  >
-    date
-  </label>
-  <div
-    class="c2"
-  >
-    <div
-      class="react-datepicker-wrapper"
-    >
-      <div
-        class="react-datepicker__input-container"
-      >
-        <input
-          class="c3 datePickerInput"
-          data-testid="text-input"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      aria-label="Choose Date"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    >
-      <div
-        class="react-datepicker__tab-loop"
-      >
-        <div
-          class="react-datepicker__tab-loop__start"
-          tabindex="0"
-        />
-        <div
-          class="react-datepicker-popper popper"
-          style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
-        >
-          <div>
-            <div
-              class="react-datepicker"
-            >
-              <div
-                class="react-datepicker__month-container"
-              >
-                <div
-                  class="react-datepicker__header react-datepicker__header--custom"
-                >
-                  <div
-                    class="c4"
-                  >
-                    <button
-                      aria-label="Go to previous month"
-                      class="c5"
-                      data-testid="month-previous"
-                    >
-                      <svg
-                        color="currentColor"
-                        focusable="false"
-                        height="16"
-                        width="16"
-                      />
-                    </button>
-                    <div
-                      class="c6"
-                    >
-                      <div
-                        class="c7"
-                        style="margin-right:8px"
-                      >
-                        <div
-                          class="c0 c8"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="listbox_undefined"
-                            class="c9"
-                            data-testid="input-wrapper"
-                          >
-                            <input
-                              aria-autocomplete="list"
-                              aria-controls="listbox_undefined"
-                              aria-multiline="false"
-                              class="c10"
-                              data-testid="input"
-                              placeholder="Select an option"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              class="c11"
-                              data-testid="arrow"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <svg
-                                color="currentColor"
-                                focusable="false"
-                                height="16"
-                                width="16"
-                              />
-                            </button>
-                          </div>
-                          <div
-                            class="c12"
-                            role="listbox"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="c13"
-                              role="presentation"
-                              tabindex="0"
-                            >
-                              <li
-                                aria-label="Jan"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_january"
-                                role="option"
-                              >
-                                Jan
-                              </li>
-                              <li
-                                aria-label="Feb"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_february"
-                                role="option"
-                              >
-                                Feb
-                              </li>
-                              <li
-                                aria-label="Mar"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_march"
-                                role="option"
-                              >
-                                Mar
-                              </li>
-                              <li
-                                aria-label="Apr"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_april"
-                                role="option"
-                              >
-                                Apr
-                              </li>
-                              <li
-                                aria-label="May"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_may"
-                                role="option"
-                              >
-                                May
-                              </li>
-                              <li
-                                aria-label="Jun"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_june"
-                                role="option"
-                              >
-                                Jun
-                              </li>
-                              <li
-                                aria-label="Jul"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_july"
-                                role="option"
-                              >
-                                Jul
-                              </li>
-                              <li
-                                aria-label="Aug"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_august"
-                                role="option"
-                              >
-                                Aug
-                              </li>
-                              <li
-                                aria-label="Sep"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_september"
-                                role="option"
-                              >
-                                Sep
-                              </li>
-                              <li
-                                aria-label="Oct"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_october"
-                                role="option"
-                              >
-                                Oct
-                              </li>
-                              <li
-                                aria-label="Nov"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_november"
-                                role="option"
-                              >
-                                Nov
-                              </li>
-                              <li
-                                aria-label="Dec"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_december"
-                                role="option"
-                              >
-                                Dec
-                              </li>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="c7"
-                      >
-                        <div
-                          class="c0 c8"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="listbox_undefined"
-                            class="c9"
-                            data-testid="input-wrapper"
-                          >
-                            <input
-                              aria-autocomplete="list"
-                              aria-controls="listbox_undefined"
-                              aria-multiline="false"
-                              class="c10"
-                              data-testid="input"
-                              placeholder="Select an option"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              class="c11"
-                              data-testid="arrow"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <svg
-                                color="currentColor"
-                                focusable="false"
-                                height="16"
-                                width="16"
-                              />
-                            </button>
-                          </div>
-                          <div
-                            class="c12"
-                            role="listbox"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="c13"
-                              role="presentation"
-                              tabindex="0"
-                            >
-                              <li
-                                aria-label="1920"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1920"
-                                role="option"
-                              >
-                                1920
-                              </li>
-                              <li
-                                aria-label="1921"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1921"
-                                role="option"
-                              >
-                                1921
-                              </li>
-                              <li
-                                aria-label="1922"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1922"
-                                role="option"
-                              >
-                                1922
-                              </li>
-                              <li
-                                aria-label="1923"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1923"
-                                role="option"
-                              >
-                                1923
-                              </li>
-                              <li
-                                aria-label="1924"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1924"
-                                role="option"
-                              >
-                                1924
-                              </li>
-                              <li
-                                aria-label="1925"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1925"
-                                role="option"
-                              >
-                                1925
-                              </li>
-                              <li
-                                aria-label="1926"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1926"
-                                role="option"
-                              >
-                                1926
-                              </li>
-                              <li
-                                aria-label="1927"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1927"
-                                role="option"
-                              >
-                                1927
-                              </li>
-                              <li
-                                aria-label="1928"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1928"
-                                role="option"
-                              >
-                                1928
-                              </li>
-                              <li
-                                aria-label="1929"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1929"
-                                role="option"
-                              >
-                                1929
-                              </li>
-                              <li
-                                aria-label="1930"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1930"
-                                role="option"
-                              >
-                                1930
-                              </li>
-                              <li
-                                aria-label="1931"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1931"
-                                role="option"
-                              >
-                                1931
-                              </li>
-                              <li
-                                aria-label="1932"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1932"
-                                role="option"
-                              >
-                                1932
-                              </li>
-                              <li
-                                aria-label="1933"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1933"
-                                role="option"
-                              >
-                                1933
-                              </li>
-                              <li
-                                aria-label="1934"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1934"
-                                role="option"
-                              >
-                                1934
-                              </li>
-                              <li
-                                aria-label="1935"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1935"
-                                role="option"
-                              >
-                                1935
-                              </li>
-                              <li
-                                aria-label="1936"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1936"
-                                role="option"
-                              >
-                                1936
-                              </li>
-                              <li
-                                aria-label="1937"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1937"
-                                role="option"
-                              >
-                                1937
-                              </li>
-                              <li
-                                aria-label="1938"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1938"
-                                role="option"
-                              >
-                                1938
-                              </li>
-                              <li
-                                aria-label="1939"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1939"
-                                role="option"
-                              >
-                                1939
-                              </li>
-                              <li
-                                aria-label="1940"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1940"
-                                role="option"
-                              >
-                                1940
-                              </li>
-                              <li
-                                aria-label="1941"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1941"
-                                role="option"
-                              >
-                                1941
-                              </li>
-                              <li
-                                aria-label="1942"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1942"
-                                role="option"
-                              >
-                                1942
-                              </li>
-                              <li
-                                aria-label="1943"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1943"
-                                role="option"
-                              >
-                                1943
-                              </li>
-                              <li
-                                aria-label="1944"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1944"
-                                role="option"
-                              >
-                                1944
-                              </li>
-                              <li
-                                aria-label="1945"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1945"
-                                role="option"
-                              >
-                                1945
-                              </li>
-                              <li
-                                aria-label="1946"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1946"
-                                role="option"
-                              >
-                                1946
-                              </li>
-                              <li
-                                aria-label="1947"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1947"
-                                role="option"
-                              >
-                                1947
-                              </li>
-                              <li
-                                aria-label="1948"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1948"
-                                role="option"
-                              >
-                                1948
-                              </li>
-                              <li
-                                aria-label="1949"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1949"
-                                role="option"
-                              >
-                                1949
-                              </li>
-                              <li
-                                aria-label="1950"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1950"
-                                role="option"
-                              >
-                                1950
-                              </li>
-                              <li
-                                aria-label="1951"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1951"
-                                role="option"
-                              >
-                                1951
-                              </li>
-                              <li
-                                aria-label="1952"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1952"
-                                role="option"
-                              >
-                                1952
-                              </li>
-                              <li
-                                aria-label="1953"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1953"
-                                role="option"
-                              >
-                                1953
-                              </li>
-                              <li
-                                aria-label="1954"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1954"
-                                role="option"
-                              >
-                                1954
-                              </li>
-                              <li
-                                aria-label="1955"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1955"
-                                role="option"
-                              >
-                                1955
-                              </li>
-                              <li
-                                aria-label="1956"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1956"
-                                role="option"
-                              >
-                                1956
-                              </li>
-                              <li
-                                aria-label="1957"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1957"
-                                role="option"
-                              >
-                                1957
-                              </li>
-                              <li
-                                aria-label="1958"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1958"
-                                role="option"
-                              >
-                                1958
-                              </li>
-                              <li
-                                aria-label="1959"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1959"
-                                role="option"
-                              >
-                                1959
-                              </li>
-                              <li
-                                aria-label="1960"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1960"
-                                role="option"
-                              >
-                                1960
-                              </li>
-                              <li
-                                aria-label="1961"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1961"
-                                role="option"
-                              >
-                                1961
-                              </li>
-                              <li
-                                aria-label="1962"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1962"
-                                role="option"
-                              >
-                                1962
-                              </li>
-                              <li
-                                aria-label="1963"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1963"
-                                role="option"
-                              >
-                                1963
-                              </li>
-                              <li
-                                aria-label="1964"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1964"
-                                role="option"
-                              >
-                                1964
-                              </li>
-                              <li
-                                aria-label="1965"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1965"
-                                role="option"
-                              >
-                                1965
-                              </li>
-                              <li
-                                aria-label="1966"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1966"
-                                role="option"
-                              >
-                                1966
-                              </li>
-                              <li
-                                aria-label="1967"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1967"
-                                role="option"
-                              >
-                                1967
-                              </li>
-                              <li
-                                aria-label="1968"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1968"
-                                role="option"
-                              >
-                                1968
-                              </li>
-                              <li
-                                aria-label="1969"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1969"
-                                role="option"
-                              >
-                                1969
-                              </li>
-                              <li
-                                aria-label="1970"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1970"
-                                role="option"
-                              >
-                                1970
-                              </li>
-                              <li
-                                aria-label="1971"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1971"
-                                role="option"
-                              >
-                                1971
-                              </li>
-                              <li
-                                aria-label="1972"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1972"
-                                role="option"
-                              >
-                                1972
-                              </li>
-                              <li
-                                aria-label="1973"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1973"
-                                role="option"
-                              >
-                                1973
-                              </li>
-                              <li
-                                aria-label="1974"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1974"
-                                role="option"
-                              >
-                                1974
-                              </li>
-                              <li
-                                aria-label="1975"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1975"
-                                role="option"
-                              >
-                                1975
-                              </li>
-                              <li
-                                aria-label="1976"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1976"
-                                role="option"
-                              >
-                                1976
-                              </li>
-                              <li
-                                aria-label="1977"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1977"
-                                role="option"
-                              >
-                                1977
-                              </li>
-                              <li
-                                aria-label="1978"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1978"
-                                role="option"
-                              >
-                                1978
-                              </li>
-                              <li
-                                aria-label="1979"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1979"
-                                role="option"
-                              >
-                                1979
-                              </li>
-                              <li
-                                aria-label="1980"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1980"
-                                role="option"
-                              >
-                                1980
-                              </li>
-                              <li
-                                aria-label="1981"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1981"
-                                role="option"
-                              >
-                                1981
-                              </li>
-                              <li
-                                aria-label="1982"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1982"
-                                role="option"
-                              >
-                                1982
-                              </li>
-                              <li
-                                aria-label="1983"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1983"
-                                role="option"
-                              >
-                                1983
-                              </li>
-                              <li
-                                aria-label="1984"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1984"
-                                role="option"
-                              >
-                                1984
-                              </li>
-                              <li
-                                aria-label="1985"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1985"
-                                role="option"
-                              >
-                                1985
-                              </li>
-                              <li
-                                aria-label="1986"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1986"
-                                role="option"
-                              >
-                                1986
-                              </li>
-                              <li
-                                aria-label="1987"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1987"
-                                role="option"
-                              >
-                                1987
-                              </li>
-                              <li
-                                aria-label="1988"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1988"
-                                role="option"
-                              >
-                                1988
-                              </li>
-                              <li
-                                aria-label="1989"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1989"
-                                role="option"
-                              >
-                                1989
-                              </li>
-                              <li
-                                aria-label="1990"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1990"
-                                role="option"
-                              >
-                                1990
-                              </li>
-                              <li
-                                aria-label="1991"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1991"
-                                role="option"
-                              >
-                                1991
-                              </li>
-                              <li
-                                aria-label="1992"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1992"
-                                role="option"
-                              >
-                                1992
-                              </li>
-                              <li
-                                aria-label="1993"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1993"
-                                role="option"
-                              >
-                                1993
-                              </li>
-                              <li
-                                aria-label="1994"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1994"
-                                role="option"
-                              >
-                                1994
-                              </li>
-                              <li
-                                aria-label="1995"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1995"
-                                role="option"
-                              >
-                                1995
-                              </li>
-                              <li
-                                aria-label="1996"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1996"
-                                role="option"
-                              >
-                                1996
-                              </li>
-                              <li
-                                aria-label="1997"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1997"
-                                role="option"
-                              >
-                                1997
-                              </li>
-                              <li
-                                aria-label="1998"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1998"
-                                role="option"
-                              >
-                                1998
-                              </li>
-                              <li
-                                aria-label="1999"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1999"
-                                role="option"
-                              >
-                                1999
-                              </li>
-                              <li
-                                aria-label="2000"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2000"
-                                role="option"
-                              >
-                                2000
-                              </li>
-                              <li
-                                aria-label="2001"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2001"
-                                role="option"
-                              >
-                                2001
-                              </li>
-                              <li
-                                aria-label="2002"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2002"
-                                role="option"
-                              >
-                                2002
-                              </li>
-                              <li
-                                aria-label="2003"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2003"
-                                role="option"
-                              >
-                                2003
-                              </li>
-                              <li
-                                aria-label="2004"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2004"
-                                role="option"
-                              >
-                                2004
-                              </li>
-                              <li
-                                aria-label="2005"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2005"
-                                role="option"
-                              >
-                                2005
-                              </li>
-                              <li
-                                aria-label="2006"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2006"
-                                role="option"
-                              >
-                                2006
-                              </li>
-                              <li
-                                aria-label="2007"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2007"
-                                role="option"
-                              >
-                                2007
-                              </li>
-                              <li
-                                aria-label="2008"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2008"
-                                role="option"
-                              >
-                                2008
-                              </li>
-                              <li
-                                aria-label="2009"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2009"
-                                role="option"
-                              >
-                                2009
-                              </li>
-                              <li
-                                aria-label="2010"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2010"
-                                role="option"
-                              >
-                                2010
-                              </li>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <button
-                      aria-label="Go to next month"
-                      class="c5"
-                      data-testid="month-next"
-                      disabled=""
-                    >
-                      <svg
-                        color="currentColor"
-                        focusable="false"
-                        height="16"
-                        width="16"
-                      />
-                    </button>
-                  </div>
-                  <div
-                    class="react-datepicker__day-names"
-                  >
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Su
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Mo
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Tu
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      We
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Th
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Fr
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Sa
-                    </div>
-                  </div>
-                </div>
-                <div
-                  aria-label="month  2010-10"
-                  class="react-datepicker__month"
-                >
-                  <div
-                    class="react-datepicker__week"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Sunday, September 26th, 2010"
-                      class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      26
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Monday, September 27th, 2010"
-                      class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      27
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Tuesday, September 28th, 2010"
-                      class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      28
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Wednesday, September 29th, 2010"
-                      class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      29
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Thursday, September 30th, 2010"
-                      class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      30
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Friday, October 1st, 2010"
-                      class="react-datepicker__day react-datepicker__day--001"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      1
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Saturday, October 2nd, 2010"
-                      class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      2
-                    </div>
-                  </div>
-                  <div
-                    class="react-datepicker__week"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Sunday, October 3rd, 2010"
-                      class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      3
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Monday, October 4th, 2010"
-                      class="react-datepicker__day react-datepicker__day--004"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      4
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Tuesday, October 5th, 2010"
-                      class="react-datepicker__day react-datepicker__day--005"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      5
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Wednesday, October 6th, 2010"
-                      class="react-datepicker__day react-datepicker__day--006"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      6
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Thursday, October 7th, 2010"
-                      class="react-datepicker__day react-datepicker__day--007"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      7
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Friday, October 8th, 2010"
-                      class="react-datepicker__day react-datepicker__day--008"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      8
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Saturday, October 9th, 2010"
-                      class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      9
-                    </div>
-                  </div>
-                  <div
-                    class="react-datepicker__week"
-                  >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Sunday, October 10th, 2010"
-                      class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="0"
-                    >
-                      10
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, October 11th, 2010"
-                      class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      11
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, October 12th, 2010"
-                      class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      12
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, October 13th, 2010"
-                      class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      13
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, October 14th, 2010"
-                      class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      14
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, October 15th, 2010"
-                      class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      15
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, October 16th, 2010"
-                      class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      16
-                    </div>
-                  </div>
-                  <div
-                    class="react-datepicker__week"
-                  >
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Sunday, October 17th, 2010"
-                      class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      17
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, October 18th, 2010"
-                      class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      18
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, October 19th, 2010"
-                      class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      19
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, October 20th, 2010"
-                      class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      20
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, October 21st, 2010"
-                      class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      21
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, October 22nd, 2010"
-                      class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      22
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, October 23rd, 2010"
-                      class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      23
-                    </div>
-                  </div>
-                  <div
-                    class="react-datepicker__week"
-                  >
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Sunday, October 24th, 2010"
-                      class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      24
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, October 25th, 2010"
-                      class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      25
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, October 26th, 2010"
-                      class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      26
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, October 27th, 2010"
-                      class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      27
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, October 28th, 2010"
-                      class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      28
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, October 29th, 2010"
-                      class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      29
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, October 30th, 2010"
-                      class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      30
-                    </div>
-                  </div>
-                  <div
-                    class="react-datepicker__week"
-                  >
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Sunday, October 31st, 2010"
-                      class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      31
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, November 1st, 2010"
-                      class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      1
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, November 2nd, 2010"
-                      class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      2
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, November 3rd, 2010"
-                      class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      3
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, November 4th, 2010"
-                      class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      4
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, November 5th, 2010"
-                      class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      5
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, November 6th, 2010"
-                      class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      6
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="react-datepicker__tab-loop__end"
-          tabindex="0"
-        />
-      </div>
-    </div>
-    <button
       aria-label="Choose date"
       class="c15"
       data-testid="calendar-button"
       tabindex="0"
+      type="button"
     >
       <svg
         color="currentColor"
@@ -5405,1566 +3836,1549 @@ input + .c1 {
   <div
     class="c2"
   >
-    <div
-      class="react-datepicker-wrapper"
-    >
+    <div>
       <div
         class="react-datepicker__input-container"
       >
         <input
-          class="c3 datePickerInput"
+          class="c3 datePickerInput react-datepicker-ignore-onclickoutside"
           data-testid="text-input"
           placeholder="YYYY-MM-DD"
           type="text"
           value=""
         />
       </div>
-    </div>
-    <div
-      aria-label="Choose Date"
-      aria-live="polite"
-      aria-modal="true"
-      role="dialog"
-    >
       <div
-        class="react-datepicker__tab-loop"
+        class="react-datepicker__portal"
       >
-        <div
-          class="react-datepicker__tab-loop__start"
-          tabindex="0"
-        />
-        <div
-          class="react-datepicker-popper popper"
-          style="position:absolute;top:0;left:0;opacity:0;pointer-events:none"
-        >
-          <div>
+        <div>
+          <div
+            aria-label="Choose date"
+            aria-live="polite"
+            aria-modal="true"
+            class="react-datepicker"
+            role="dialog"
+          >
             <div
-              class="react-datepicker"
+              class="react-datepicker__month-container"
             >
               <div
-                class="react-datepicker__month-container"
+                class="react-datepicker__header react-datepicker__header--custom"
               >
                 <div
-                  class="react-datepicker__header react-datepicker__header--custom"
+                  class="c4"
+                  data-testid="calendar-header"
+                >
+                  <button
+                    aria-label="Go to previous month"
+                    class="c5"
+                    data-testid="month-previous"
+                  >
+                    <svg
+                      color="currentColor"
+                      focusable="false"
+                      height="26"
+                      width="26"
+                    />
+                  </button>
+                  <div
+                    class="c6"
+                  >
+                    <div
+                      class="c7"
+                      style="margin-right:8px"
+                    >
+                      <div
+                        class="c0 c8"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="listbox_undefined"
+                          class="c9"
+                          data-testid="input-wrapper"
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-controls="listbox_undefined"
+                            aria-multiline="false"
+                            class="c10"
+                            data-testid="input"
+                            placeholder="Select an option"
+                            type="text"
+                            value=""
+                          />
+                          <button
+                            class="c11"
+                            data-testid="arrow"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <svg
+                              color="currentColor"
+                              focusable="false"
+                              height="24"
+                              width="24"
+                            />
+                          </button>
+                        </div>
+                        <div
+                          class="c12"
+                          role="listbox"
+                          tabindex="-1"
+                        >
+                          <ul
+                            class="c13"
+                            role="presentation"
+                            tabindex="0"
+                          >
+                            <li
+                              aria-label="Jan"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_january"
+                              role="option"
+                            >
+                              Jan
+                            </li>
+                            <li
+                              aria-label="Feb"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_february"
+                              role="option"
+                            >
+                              Feb
+                            </li>
+                            <li
+                              aria-label="Mar"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_march"
+                              role="option"
+                            >
+                              Mar
+                            </li>
+                            <li
+                              aria-label="Apr"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_april"
+                              role="option"
+                            >
+                              Apr
+                            </li>
+                            <li
+                              aria-label="May"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_may"
+                              role="option"
+                            >
+                              May
+                            </li>
+                            <li
+                              aria-label="Jun"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_june"
+                              role="option"
+                            >
+                              Jun
+                            </li>
+                            <li
+                              aria-label="Jul"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_july"
+                              role="option"
+                            >
+                              Jul
+                            </li>
+                            <li
+                              aria-label="Aug"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_august"
+                              role="option"
+                            >
+                              Aug
+                            </li>
+                            <li
+                              aria-label="Sep"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_september"
+                              role="option"
+                            >
+                              Sep
+                            </li>
+                            <li
+                              aria-label="Oct"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_october"
+                              role="option"
+                            >
+                              Oct
+                            </li>
+                            <li
+                              aria-label="Nov"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_november"
+                              role="option"
+                            >
+                              Nov
+                            </li>
+                            <li
+                              aria-label="Dec"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_december"
+                              role="option"
+                            >
+                              Dec
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                    <div
+                      class="c7"
+                    >
+                      <div
+                        class="c0 c8"
+                      >
+                        <div
+                          aria-expanded="false"
+                          aria-haspopup="listbox"
+                          aria-owns="listbox_undefined"
+                          class="c9"
+                          data-testid="input-wrapper"
+                        >
+                          <input
+                            aria-autocomplete="list"
+                            aria-controls="listbox_undefined"
+                            aria-multiline="false"
+                            class="c10"
+                            data-testid="input"
+                            placeholder="Select an option"
+                            type="text"
+                            value=""
+                          />
+                          <button
+                            class="c11"
+                            data-testid="arrow"
+                            tabindex="-1"
+                            type="button"
+                          >
+                            <svg
+                              color="currentColor"
+                              focusable="false"
+                              height="24"
+                              width="24"
+                            />
+                          </button>
+                        </div>
+                        <div
+                          class="c12"
+                          role="listbox"
+                          tabindex="-1"
+                        >
+                          <ul
+                            class="c13"
+                            role="presentation"
+                            tabindex="0"
+                          >
+                            <li
+                              aria-label="1920"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1920"
+                              role="option"
+                            >
+                              1920
+                            </li>
+                            <li
+                              aria-label="1921"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1921"
+                              role="option"
+                            >
+                              1921
+                            </li>
+                            <li
+                              aria-label="1922"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1922"
+                              role="option"
+                            >
+                              1922
+                            </li>
+                            <li
+                              aria-label="1923"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1923"
+                              role="option"
+                            >
+                              1923
+                            </li>
+                            <li
+                              aria-label="1924"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1924"
+                              role="option"
+                            >
+                              1924
+                            </li>
+                            <li
+                              aria-label="1925"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1925"
+                              role="option"
+                            >
+                              1925
+                            </li>
+                            <li
+                              aria-label="1926"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1926"
+                              role="option"
+                            >
+                              1926
+                            </li>
+                            <li
+                              aria-label="1927"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1927"
+                              role="option"
+                            >
+                              1927
+                            </li>
+                            <li
+                              aria-label="1928"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1928"
+                              role="option"
+                            >
+                              1928
+                            </li>
+                            <li
+                              aria-label="1929"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1929"
+                              role="option"
+                            >
+                              1929
+                            </li>
+                            <li
+                              aria-label="1930"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1930"
+                              role="option"
+                            >
+                              1930
+                            </li>
+                            <li
+                              aria-label="1931"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1931"
+                              role="option"
+                            >
+                              1931
+                            </li>
+                            <li
+                              aria-label="1932"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1932"
+                              role="option"
+                            >
+                              1932
+                            </li>
+                            <li
+                              aria-label="1933"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1933"
+                              role="option"
+                            >
+                              1933
+                            </li>
+                            <li
+                              aria-label="1934"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1934"
+                              role="option"
+                            >
+                              1934
+                            </li>
+                            <li
+                              aria-label="1935"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1935"
+                              role="option"
+                            >
+                              1935
+                            </li>
+                            <li
+                              aria-label="1936"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1936"
+                              role="option"
+                            >
+                              1936
+                            </li>
+                            <li
+                              aria-label="1937"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1937"
+                              role="option"
+                            >
+                              1937
+                            </li>
+                            <li
+                              aria-label="1938"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1938"
+                              role="option"
+                            >
+                              1938
+                            </li>
+                            <li
+                              aria-label="1939"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1939"
+                              role="option"
+                            >
+                              1939
+                            </li>
+                            <li
+                              aria-label="1940"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1940"
+                              role="option"
+                            >
+                              1940
+                            </li>
+                            <li
+                              aria-label="1941"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1941"
+                              role="option"
+                            >
+                              1941
+                            </li>
+                            <li
+                              aria-label="1942"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1942"
+                              role="option"
+                            >
+                              1942
+                            </li>
+                            <li
+                              aria-label="1943"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1943"
+                              role="option"
+                            >
+                              1943
+                            </li>
+                            <li
+                              aria-label="1944"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1944"
+                              role="option"
+                            >
+                              1944
+                            </li>
+                            <li
+                              aria-label="1945"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1945"
+                              role="option"
+                            >
+                              1945
+                            </li>
+                            <li
+                              aria-label="1946"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1946"
+                              role="option"
+                            >
+                              1946
+                            </li>
+                            <li
+                              aria-label="1947"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1947"
+                              role="option"
+                            >
+                              1947
+                            </li>
+                            <li
+                              aria-label="1948"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1948"
+                              role="option"
+                            >
+                              1948
+                            </li>
+                            <li
+                              aria-label="1949"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1949"
+                              role="option"
+                            >
+                              1949
+                            </li>
+                            <li
+                              aria-label="1950"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1950"
+                              role="option"
+                            >
+                              1950
+                            </li>
+                            <li
+                              aria-label="1951"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1951"
+                              role="option"
+                            >
+                              1951
+                            </li>
+                            <li
+                              aria-label="1952"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1952"
+                              role="option"
+                            >
+                              1952
+                            </li>
+                            <li
+                              aria-label="1953"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1953"
+                              role="option"
+                            >
+                              1953
+                            </li>
+                            <li
+                              aria-label="1954"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1954"
+                              role="option"
+                            >
+                              1954
+                            </li>
+                            <li
+                              aria-label="1955"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1955"
+                              role="option"
+                            >
+                              1955
+                            </li>
+                            <li
+                              aria-label="1956"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1956"
+                              role="option"
+                            >
+                              1956
+                            </li>
+                            <li
+                              aria-label="1957"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1957"
+                              role="option"
+                            >
+                              1957
+                            </li>
+                            <li
+                              aria-label="1958"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1958"
+                              role="option"
+                            >
+                              1958
+                            </li>
+                            <li
+                              aria-label="1959"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1959"
+                              role="option"
+                            >
+                              1959
+                            </li>
+                            <li
+                              aria-label="1960"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1960"
+                              role="option"
+                            >
+                              1960
+                            </li>
+                            <li
+                              aria-label="1961"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1961"
+                              role="option"
+                            >
+                              1961
+                            </li>
+                            <li
+                              aria-label="1962"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1962"
+                              role="option"
+                            >
+                              1962
+                            </li>
+                            <li
+                              aria-label="1963"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1963"
+                              role="option"
+                            >
+                              1963
+                            </li>
+                            <li
+                              aria-label="1964"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1964"
+                              role="option"
+                            >
+                              1964
+                            </li>
+                            <li
+                              aria-label="1965"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1965"
+                              role="option"
+                            >
+                              1965
+                            </li>
+                            <li
+                              aria-label="1966"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1966"
+                              role="option"
+                            >
+                              1966
+                            </li>
+                            <li
+                              aria-label="1967"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1967"
+                              role="option"
+                            >
+                              1967
+                            </li>
+                            <li
+                              aria-label="1968"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1968"
+                              role="option"
+                            >
+                              1968
+                            </li>
+                            <li
+                              aria-label="1969"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1969"
+                              role="option"
+                            >
+                              1969
+                            </li>
+                            <li
+                              aria-label="1970"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1970"
+                              role="option"
+                            >
+                              1970
+                            </li>
+                            <li
+                              aria-label="1971"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1971"
+                              role="option"
+                            >
+                              1971
+                            </li>
+                            <li
+                              aria-label="1972"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1972"
+                              role="option"
+                            >
+                              1972
+                            </li>
+                            <li
+                              aria-label="1973"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1973"
+                              role="option"
+                            >
+                              1973
+                            </li>
+                            <li
+                              aria-label="1974"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1974"
+                              role="option"
+                            >
+                              1974
+                            </li>
+                            <li
+                              aria-label="1975"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1975"
+                              role="option"
+                            >
+                              1975
+                            </li>
+                            <li
+                              aria-label="1976"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1976"
+                              role="option"
+                            >
+                              1976
+                            </li>
+                            <li
+                              aria-label="1977"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1977"
+                              role="option"
+                            >
+                              1977
+                            </li>
+                            <li
+                              aria-label="1978"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1978"
+                              role="option"
+                            >
+                              1978
+                            </li>
+                            <li
+                              aria-label="1979"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1979"
+                              role="option"
+                            >
+                              1979
+                            </li>
+                            <li
+                              aria-label="1980"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1980"
+                              role="option"
+                            >
+                              1980
+                            </li>
+                            <li
+                              aria-label="1981"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1981"
+                              role="option"
+                            >
+                              1981
+                            </li>
+                            <li
+                              aria-label="1982"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1982"
+                              role="option"
+                            >
+                              1982
+                            </li>
+                            <li
+                              aria-label="1983"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1983"
+                              role="option"
+                            >
+                              1983
+                            </li>
+                            <li
+                              aria-label="1984"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1984"
+                              role="option"
+                            >
+                              1984
+                            </li>
+                            <li
+                              aria-label="1985"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1985"
+                              role="option"
+                            >
+                              1985
+                            </li>
+                            <li
+                              aria-label="1986"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1986"
+                              role="option"
+                            >
+                              1986
+                            </li>
+                            <li
+                              aria-label="1987"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1987"
+                              role="option"
+                            >
+                              1987
+                            </li>
+                            <li
+                              aria-label="1988"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1988"
+                              role="option"
+                            >
+                              1988
+                            </li>
+                            <li
+                              aria-label="1989"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1989"
+                              role="option"
+                            >
+                              1989
+                            </li>
+                            <li
+                              aria-label="1990"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1990"
+                              role="option"
+                            >
+                              1990
+                            </li>
+                            <li
+                              aria-label="1991"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1991"
+                              role="option"
+                            >
+                              1991
+                            </li>
+                            <li
+                              aria-label="1992"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1992"
+                              role="option"
+                            >
+                              1992
+                            </li>
+                            <li
+                              aria-label="1993"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1993"
+                              role="option"
+                            >
+                              1993
+                            </li>
+                            <li
+                              aria-label="1994"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1994"
+                              role="option"
+                            >
+                              1994
+                            </li>
+                            <li
+                              aria-label="1995"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1995"
+                              role="option"
+                            >
+                              1995
+                            </li>
+                            <li
+                              aria-label="1996"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1996"
+                              role="option"
+                            >
+                              1996
+                            </li>
+                            <li
+                              aria-label="1997"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1997"
+                              role="option"
+                            >
+                              1997
+                            </li>
+                            <li
+                              aria-label="1998"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1998"
+                              role="option"
+                            >
+                              1998
+                            </li>
+                            <li
+                              aria-label="1999"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_1999"
+                              role="option"
+                            >
+                              1999
+                            </li>
+                            <li
+                              aria-label="2000"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2000"
+                              role="option"
+                            >
+                              2000
+                            </li>
+                            <li
+                              aria-label="2001"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2001"
+                              role="option"
+                            >
+                              2001
+                            </li>
+                            <li
+                              aria-label="2002"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2002"
+                              role="option"
+                            >
+                              2002
+                            </li>
+                            <li
+                              aria-label="2003"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2003"
+                              role="option"
+                            >
+                              2003
+                            </li>
+                            <li
+                              aria-label="2004"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2004"
+                              role="option"
+                            >
+                              2004
+                            </li>
+                            <li
+                              aria-label="2005"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2005"
+                              role="option"
+                            >
+                              2005
+                            </li>
+                            <li
+                              aria-label="2006"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2006"
+                              role="option"
+                            >
+                              2006
+                            </li>
+                            <li
+                              aria-label="2007"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2007"
+                              role="option"
+                            >
+                              2007
+                            </li>
+                            <li
+                              aria-label="2008"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2008"
+                              role="option"
+                            >
+                              2008
+                            </li>
+                            <li
+                              aria-label="2009"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2009"
+                              role="option"
+                            >
+                              2009
+                            </li>
+                            <li
+                              aria-label="2010"
+                              aria-selected="false"
+                              class="c14"
+                              id="undefined_2010"
+                              role="option"
+                            >
+                              2010
+                            </li>
+                          </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <button
+                    aria-label="Go to next month"
+                    class="c5"
+                    data-testid="month-next"
+                    disabled=""
+                  >
+                    <svg
+                      color="currentColor"
+                      focusable="false"
+                      height="24"
+                      width="24"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="react-datepicker__day-names"
                 >
                   <div
-                    class="c4"
+                    class="react-datepicker__day-name"
                   >
-                    <button
-                      aria-label="Go to previous month"
-                      class="c5"
-                      data-testid="month-previous"
-                    >
-                      <svg
-                        color="currentColor"
-                        focusable="false"
-                        height="26"
-                        width="26"
-                      />
-                    </button>
-                    <div
-                      class="c6"
-                    >
-                      <div
-                        class="c7"
-                        style="margin-right:8px"
-                      >
-                        <div
-                          class="c0 c8"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="listbox_undefined"
-                            class="c9"
-                            data-testid="input-wrapper"
-                          >
-                            <input
-                              aria-autocomplete="list"
-                              aria-controls="listbox_undefined"
-                              aria-multiline="false"
-                              class="c10"
-                              data-testid="input"
-                              placeholder="Select an option"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              class="c11"
-                              data-testid="arrow"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <svg
-                                color="currentColor"
-                                focusable="false"
-                                height="24"
-                                width="24"
-                              />
-                            </button>
-                          </div>
-                          <div
-                            class="c12"
-                            role="listbox"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="c13"
-                              role="presentation"
-                              tabindex="0"
-                            >
-                              <li
-                                aria-label="Jan"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_january"
-                                role="option"
-                              >
-                                Jan
-                              </li>
-                              <li
-                                aria-label="Feb"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_february"
-                                role="option"
-                              >
-                                Feb
-                              </li>
-                              <li
-                                aria-label="Mar"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_march"
-                                role="option"
-                              >
-                                Mar
-                              </li>
-                              <li
-                                aria-label="Apr"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_april"
-                                role="option"
-                              >
-                                Apr
-                              </li>
-                              <li
-                                aria-label="May"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_may"
-                                role="option"
-                              >
-                                May
-                              </li>
-                              <li
-                                aria-label="Jun"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_june"
-                                role="option"
-                              >
-                                Jun
-                              </li>
-                              <li
-                                aria-label="Jul"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_july"
-                                role="option"
-                              >
-                                Jul
-                              </li>
-                              <li
-                                aria-label="Aug"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_august"
-                                role="option"
-                              >
-                                Aug
-                              </li>
-                              <li
-                                aria-label="Sep"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_september"
-                                role="option"
-                              >
-                                Sep
-                              </li>
-                              <li
-                                aria-label="Oct"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_october"
-                                role="option"
-                              >
-                                Oct
-                              </li>
-                              <li
-                                aria-label="Nov"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_november"
-                                role="option"
-                              >
-                                Nov
-                              </li>
-                              <li
-                                aria-label="Dec"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_december"
-                                role="option"
-                              >
-                                Dec
-                              </li>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                      <div
-                        class="c7"
-                      >
-                        <div
-                          class="c0 c8"
-                        >
-                          <div
-                            aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="listbox_undefined"
-                            class="c9"
-                            data-testid="input-wrapper"
-                          >
-                            <input
-                              aria-autocomplete="list"
-                              aria-controls="listbox_undefined"
-                              aria-multiline="false"
-                              class="c10"
-                              data-testid="input"
-                              placeholder="Select an option"
-                              type="text"
-                              value=""
-                            />
-                            <button
-                              class="c11"
-                              data-testid="arrow"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <svg
-                                color="currentColor"
-                                focusable="false"
-                                height="24"
-                                width="24"
-                              />
-                            </button>
-                          </div>
-                          <div
-                            class="c12"
-                            role="listbox"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="c13"
-                              role="presentation"
-                              tabindex="0"
-                            >
-                              <li
-                                aria-label="1920"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1920"
-                                role="option"
-                              >
-                                1920
-                              </li>
-                              <li
-                                aria-label="1921"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1921"
-                                role="option"
-                              >
-                                1921
-                              </li>
-                              <li
-                                aria-label="1922"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1922"
-                                role="option"
-                              >
-                                1922
-                              </li>
-                              <li
-                                aria-label="1923"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1923"
-                                role="option"
-                              >
-                                1923
-                              </li>
-                              <li
-                                aria-label="1924"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1924"
-                                role="option"
-                              >
-                                1924
-                              </li>
-                              <li
-                                aria-label="1925"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1925"
-                                role="option"
-                              >
-                                1925
-                              </li>
-                              <li
-                                aria-label="1926"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1926"
-                                role="option"
-                              >
-                                1926
-                              </li>
-                              <li
-                                aria-label="1927"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1927"
-                                role="option"
-                              >
-                                1927
-                              </li>
-                              <li
-                                aria-label="1928"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1928"
-                                role="option"
-                              >
-                                1928
-                              </li>
-                              <li
-                                aria-label="1929"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1929"
-                                role="option"
-                              >
-                                1929
-                              </li>
-                              <li
-                                aria-label="1930"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1930"
-                                role="option"
-                              >
-                                1930
-                              </li>
-                              <li
-                                aria-label="1931"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1931"
-                                role="option"
-                              >
-                                1931
-                              </li>
-                              <li
-                                aria-label="1932"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1932"
-                                role="option"
-                              >
-                                1932
-                              </li>
-                              <li
-                                aria-label="1933"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1933"
-                                role="option"
-                              >
-                                1933
-                              </li>
-                              <li
-                                aria-label="1934"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1934"
-                                role="option"
-                              >
-                                1934
-                              </li>
-                              <li
-                                aria-label="1935"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1935"
-                                role="option"
-                              >
-                                1935
-                              </li>
-                              <li
-                                aria-label="1936"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1936"
-                                role="option"
-                              >
-                                1936
-                              </li>
-                              <li
-                                aria-label="1937"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1937"
-                                role="option"
-                              >
-                                1937
-                              </li>
-                              <li
-                                aria-label="1938"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1938"
-                                role="option"
-                              >
-                                1938
-                              </li>
-                              <li
-                                aria-label="1939"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1939"
-                                role="option"
-                              >
-                                1939
-                              </li>
-                              <li
-                                aria-label="1940"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1940"
-                                role="option"
-                              >
-                                1940
-                              </li>
-                              <li
-                                aria-label="1941"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1941"
-                                role="option"
-                              >
-                                1941
-                              </li>
-                              <li
-                                aria-label="1942"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1942"
-                                role="option"
-                              >
-                                1942
-                              </li>
-                              <li
-                                aria-label="1943"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1943"
-                                role="option"
-                              >
-                                1943
-                              </li>
-                              <li
-                                aria-label="1944"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1944"
-                                role="option"
-                              >
-                                1944
-                              </li>
-                              <li
-                                aria-label="1945"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1945"
-                                role="option"
-                              >
-                                1945
-                              </li>
-                              <li
-                                aria-label="1946"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1946"
-                                role="option"
-                              >
-                                1946
-                              </li>
-                              <li
-                                aria-label="1947"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1947"
-                                role="option"
-                              >
-                                1947
-                              </li>
-                              <li
-                                aria-label="1948"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1948"
-                                role="option"
-                              >
-                                1948
-                              </li>
-                              <li
-                                aria-label="1949"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1949"
-                                role="option"
-                              >
-                                1949
-                              </li>
-                              <li
-                                aria-label="1950"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1950"
-                                role="option"
-                              >
-                                1950
-                              </li>
-                              <li
-                                aria-label="1951"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1951"
-                                role="option"
-                              >
-                                1951
-                              </li>
-                              <li
-                                aria-label="1952"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1952"
-                                role="option"
-                              >
-                                1952
-                              </li>
-                              <li
-                                aria-label="1953"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1953"
-                                role="option"
-                              >
-                                1953
-                              </li>
-                              <li
-                                aria-label="1954"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1954"
-                                role="option"
-                              >
-                                1954
-                              </li>
-                              <li
-                                aria-label="1955"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1955"
-                                role="option"
-                              >
-                                1955
-                              </li>
-                              <li
-                                aria-label="1956"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1956"
-                                role="option"
-                              >
-                                1956
-                              </li>
-                              <li
-                                aria-label="1957"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1957"
-                                role="option"
-                              >
-                                1957
-                              </li>
-                              <li
-                                aria-label="1958"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1958"
-                                role="option"
-                              >
-                                1958
-                              </li>
-                              <li
-                                aria-label="1959"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1959"
-                                role="option"
-                              >
-                                1959
-                              </li>
-                              <li
-                                aria-label="1960"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1960"
-                                role="option"
-                              >
-                                1960
-                              </li>
-                              <li
-                                aria-label="1961"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1961"
-                                role="option"
-                              >
-                                1961
-                              </li>
-                              <li
-                                aria-label="1962"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1962"
-                                role="option"
-                              >
-                                1962
-                              </li>
-                              <li
-                                aria-label="1963"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1963"
-                                role="option"
-                              >
-                                1963
-                              </li>
-                              <li
-                                aria-label="1964"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1964"
-                                role="option"
-                              >
-                                1964
-                              </li>
-                              <li
-                                aria-label="1965"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1965"
-                                role="option"
-                              >
-                                1965
-                              </li>
-                              <li
-                                aria-label="1966"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1966"
-                                role="option"
-                              >
-                                1966
-                              </li>
-                              <li
-                                aria-label="1967"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1967"
-                                role="option"
-                              >
-                                1967
-                              </li>
-                              <li
-                                aria-label="1968"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1968"
-                                role="option"
-                              >
-                                1968
-                              </li>
-                              <li
-                                aria-label="1969"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1969"
-                                role="option"
-                              >
-                                1969
-                              </li>
-                              <li
-                                aria-label="1970"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1970"
-                                role="option"
-                              >
-                                1970
-                              </li>
-                              <li
-                                aria-label="1971"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1971"
-                                role="option"
-                              >
-                                1971
-                              </li>
-                              <li
-                                aria-label="1972"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1972"
-                                role="option"
-                              >
-                                1972
-                              </li>
-                              <li
-                                aria-label="1973"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1973"
-                                role="option"
-                              >
-                                1973
-                              </li>
-                              <li
-                                aria-label="1974"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1974"
-                                role="option"
-                              >
-                                1974
-                              </li>
-                              <li
-                                aria-label="1975"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1975"
-                                role="option"
-                              >
-                                1975
-                              </li>
-                              <li
-                                aria-label="1976"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1976"
-                                role="option"
-                              >
-                                1976
-                              </li>
-                              <li
-                                aria-label="1977"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1977"
-                                role="option"
-                              >
-                                1977
-                              </li>
-                              <li
-                                aria-label="1978"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1978"
-                                role="option"
-                              >
-                                1978
-                              </li>
-                              <li
-                                aria-label="1979"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1979"
-                                role="option"
-                              >
-                                1979
-                              </li>
-                              <li
-                                aria-label="1980"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1980"
-                                role="option"
-                              >
-                                1980
-                              </li>
-                              <li
-                                aria-label="1981"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1981"
-                                role="option"
-                              >
-                                1981
-                              </li>
-                              <li
-                                aria-label="1982"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1982"
-                                role="option"
-                              >
-                                1982
-                              </li>
-                              <li
-                                aria-label="1983"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1983"
-                                role="option"
-                              >
-                                1983
-                              </li>
-                              <li
-                                aria-label="1984"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1984"
-                                role="option"
-                              >
-                                1984
-                              </li>
-                              <li
-                                aria-label="1985"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1985"
-                                role="option"
-                              >
-                                1985
-                              </li>
-                              <li
-                                aria-label="1986"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1986"
-                                role="option"
-                              >
-                                1986
-                              </li>
-                              <li
-                                aria-label="1987"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1987"
-                                role="option"
-                              >
-                                1987
-                              </li>
-                              <li
-                                aria-label="1988"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1988"
-                                role="option"
-                              >
-                                1988
-                              </li>
-                              <li
-                                aria-label="1989"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1989"
-                                role="option"
-                              >
-                                1989
-                              </li>
-                              <li
-                                aria-label="1990"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1990"
-                                role="option"
-                              >
-                                1990
-                              </li>
-                              <li
-                                aria-label="1991"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1991"
-                                role="option"
-                              >
-                                1991
-                              </li>
-                              <li
-                                aria-label="1992"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1992"
-                                role="option"
-                              >
-                                1992
-                              </li>
-                              <li
-                                aria-label="1993"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1993"
-                                role="option"
-                              >
-                                1993
-                              </li>
-                              <li
-                                aria-label="1994"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1994"
-                                role="option"
-                              >
-                                1994
-                              </li>
-                              <li
-                                aria-label="1995"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1995"
-                                role="option"
-                              >
-                                1995
-                              </li>
-                              <li
-                                aria-label="1996"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1996"
-                                role="option"
-                              >
-                                1996
-                              </li>
-                              <li
-                                aria-label="1997"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1997"
-                                role="option"
-                              >
-                                1997
-                              </li>
-                              <li
-                                aria-label="1998"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1998"
-                                role="option"
-                              >
-                                1998
-                              </li>
-                              <li
-                                aria-label="1999"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_1999"
-                                role="option"
-                              >
-                                1999
-                              </li>
-                              <li
-                                aria-label="2000"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2000"
-                                role="option"
-                              >
-                                2000
-                              </li>
-                              <li
-                                aria-label="2001"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2001"
-                                role="option"
-                              >
-                                2001
-                              </li>
-                              <li
-                                aria-label="2002"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2002"
-                                role="option"
-                              >
-                                2002
-                              </li>
-                              <li
-                                aria-label="2003"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2003"
-                                role="option"
-                              >
-                                2003
-                              </li>
-                              <li
-                                aria-label="2004"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2004"
-                                role="option"
-                              >
-                                2004
-                              </li>
-                              <li
-                                aria-label="2005"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2005"
-                                role="option"
-                              >
-                                2005
-                              </li>
-                              <li
-                                aria-label="2006"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2006"
-                                role="option"
-                              >
-                                2006
-                              </li>
-                              <li
-                                aria-label="2007"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2007"
-                                role="option"
-                              >
-                                2007
-                              </li>
-                              <li
-                                aria-label="2008"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2008"
-                                role="option"
-                              >
-                                2008
-                              </li>
-                              <li
-                                aria-label="2009"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2009"
-                                role="option"
-                              >
-                                2009
-                              </li>
-                              <li
-                                aria-label="2010"
-                                aria-selected="false"
-                                class="c14"
-                                id="undefined_2010"
-                                role="option"
-                              >
-                                2010
-                              </li>
-                            </ul>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <button
-                      aria-label="Go to next month"
-                      class="c5"
-                      data-testid="month-next"
-                      disabled=""
-                    >
-                      <svg
-                        color="currentColor"
-                        focusable="false"
-                        height="24"
-                        width="24"
-                      />
-                    </button>
+                    Su
                   </div>
                   <div
-                    class="react-datepicker__day-names"
+                    class="react-datepicker__day-name"
                   >
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Su
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Mo
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Tu
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      We
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Th
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Fr
-                    </div>
-                    <div
-                      class="react-datepicker__day-name"
-                    >
-                      Sa
-                    </div>
+                    Mo
+                  </div>
+                  <div
+                    class="react-datepicker__day-name"
+                  >
+                    Tu
+                  </div>
+                  <div
+                    class="react-datepicker__day-name"
+                  >
+                    We
+                  </div>
+                  <div
+                    class="react-datepicker__day-name"
+                  >
+                    Th
+                  </div>
+                  <div
+                    class="react-datepicker__day-name"
+                  >
+                    Fr
+                  </div>
+                  <div
+                    class="react-datepicker__day-name"
+                  >
+                    Sa
+                  </div>
+                </div>
+              </div>
+              <div
+                aria-label="month  2010-10"
+                class="react-datepicker__month"
+              >
+                <div
+                  class="react-datepicker__week"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Sunday, September 26th, 2010"
+                    class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    26
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Monday, September 27th, 2010"
+                    class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    27
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Tuesday, September 28th, 2010"
+                    class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    28
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Wednesday, September 29th, 2010"
+                    class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    29
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Thursday, September 30th, 2010"
+                    class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    30
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Friday, October 1st, 2010"
+                    class="react-datepicker__day react-datepicker__day--001"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    1
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Saturday, October 2nd, 2010"
+                    class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    2
                   </div>
                 </div>
                 <div
-                  aria-label="month  2010-10"
-                  class="react-datepicker__month"
+                  class="react-datepicker__week"
                 >
                   <div
-                    class="react-datepicker__week"
+                    aria-disabled="false"
+                    aria-label="Choose Sunday, October 3rd, 2010"
+                    class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
                   >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Sunday, September 26th, 2010"
-                      class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      26
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Monday, September 27th, 2010"
-                      class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      27
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Tuesday, September 28th, 2010"
-                      class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      28
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Wednesday, September 29th, 2010"
-                      class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      29
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Thursday, September 30th, 2010"
-                      class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      30
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Friday, October 1st, 2010"
-                      class="react-datepicker__day react-datepicker__day--001"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      1
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Saturday, October 2nd, 2010"
-                      class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      2
-                    </div>
+                    3
                   </div>
                   <div
-                    class="react-datepicker__week"
+                    aria-disabled="false"
+                    aria-label="Choose Monday, October 4th, 2010"
+                    class="react-datepicker__day react-datepicker__day--004"
+                    role="button"
+                    tabindex="-1"
                   >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Sunday, October 3rd, 2010"
-                      class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      3
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Monday, October 4th, 2010"
-                      class="react-datepicker__day react-datepicker__day--004"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      4
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Tuesday, October 5th, 2010"
-                      class="react-datepicker__day react-datepicker__day--005"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      5
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Wednesday, October 6th, 2010"
-                      class="react-datepicker__day react-datepicker__day--006"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      6
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Thursday, October 7th, 2010"
-                      class="react-datepicker__day react-datepicker__day--007"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      7
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Friday, October 8th, 2010"
-                      class="react-datepicker__day react-datepicker__day--008"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      8
-                    </div>
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Saturday, October 9th, 2010"
-                      class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      9
-                    </div>
+                    4
                   </div>
                   <div
-                    class="react-datepicker__week"
+                    aria-disabled="false"
+                    aria-label="Choose Tuesday, October 5th, 2010"
+                    class="react-datepicker__day react-datepicker__day--005"
+                    role="button"
+                    tabindex="-1"
                   >
-                    <div
-                      aria-disabled="false"
-                      aria-label="Choose Sunday, October 10th, 2010"
-                      class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="0"
-                    >
-                      10
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, October 11th, 2010"
-                      class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      11
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, October 12th, 2010"
-                      class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      12
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, October 13th, 2010"
-                      class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      13
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, October 14th, 2010"
-                      class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      14
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, October 15th, 2010"
-                      class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      15
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, October 16th, 2010"
-                      class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      16
-                    </div>
+                    5
                   </div>
                   <div
-                    class="react-datepicker__week"
+                    aria-disabled="false"
+                    aria-label="Choose Wednesday, October 6th, 2010"
+                    class="react-datepicker__day react-datepicker__day--006"
+                    role="button"
+                    tabindex="-1"
                   >
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Sunday, October 17th, 2010"
-                      class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      17
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, October 18th, 2010"
-                      class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      18
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, October 19th, 2010"
-                      class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      19
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, October 20th, 2010"
-                      class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      20
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, October 21st, 2010"
-                      class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      21
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, October 22nd, 2010"
-                      class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      22
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, October 23rd, 2010"
-                      class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      23
-                    </div>
+                    6
                   </div>
                   <div
-                    class="react-datepicker__week"
+                    aria-disabled="false"
+                    aria-label="Choose Thursday, October 7th, 2010"
+                    class="react-datepicker__day react-datepicker__day--007"
+                    role="button"
+                    tabindex="-1"
                   >
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Sunday, October 24th, 2010"
-                      class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      24
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, October 25th, 2010"
-                      class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      25
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, October 26th, 2010"
-                      class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      26
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, October 27th, 2010"
-                      class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      27
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, October 28th, 2010"
-                      class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      28
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, October 29th, 2010"
-                      class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      29
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, October 30th, 2010"
-                      class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      30
-                    </div>
+                    7
                   </div>
                   <div
-                    class="react-datepicker__week"
+                    aria-disabled="false"
+                    aria-label="Choose Friday, October 8th, 2010"
+                    class="react-datepicker__day react-datepicker__day--008"
+                    role="button"
+                    tabindex="-1"
                   >
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Sunday, October 31st, 2010"
-                      class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      31
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Monday, November 1st, 2010"
-                      class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      1
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Tuesday, November 2nd, 2010"
-                      class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      2
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Wednesday, November 3rd, 2010"
-                      class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      3
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Thursday, November 4th, 2010"
-                      class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      4
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Friday, November 5th, 2010"
-                      class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      5
-                    </div>
-                    <div
-                      aria-disabled="true"
-                      aria-label="Not available Saturday, November 6th, 2010"
-                      class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
-                      role="button"
-                      tabindex="-1"
-                    >
-                      6
-                    </div>
+                    8
+                  </div>
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Saturday, October 9th, 2010"
+                    class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    9
+                  </div>
+                </div>
+                <div
+                  class="react-datepicker__week"
+                >
+                  <div
+                    aria-disabled="false"
+                    aria-label="Choose Sunday, October 10th, 2010"
+                    class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="0"
+                  >
+                    10
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Monday, October 11th, 2010"
+                    class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    11
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Tuesday, October 12th, 2010"
+                    class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    12
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Wednesday, October 13th, 2010"
+                    class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    13
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Thursday, October 14th, 2010"
+                    class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    14
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Friday, October 15th, 2010"
+                    class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    15
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Saturday, October 16th, 2010"
+                    class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    16
+                  </div>
+                </div>
+                <div
+                  class="react-datepicker__week"
+                >
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Sunday, October 17th, 2010"
+                    class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    17
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Monday, October 18th, 2010"
+                    class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    18
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Tuesday, October 19th, 2010"
+                    class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    19
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Wednesday, October 20th, 2010"
+                    class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    20
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Thursday, October 21st, 2010"
+                    class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    21
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Friday, October 22nd, 2010"
+                    class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    22
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Saturday, October 23rd, 2010"
+                    class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    23
+                  </div>
+                </div>
+                <div
+                  class="react-datepicker__week"
+                >
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Sunday, October 24th, 2010"
+                    class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    24
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Monday, October 25th, 2010"
+                    class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    25
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Tuesday, October 26th, 2010"
+                    class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    26
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Wednesday, October 27th, 2010"
+                    class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    27
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Thursday, October 28th, 2010"
+                    class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    28
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Friday, October 29th, 2010"
+                    class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    29
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Saturday, October 30th, 2010"
+                    class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    30
+                  </div>
+                </div>
+                <div
+                  class="react-datepicker__week"
+                >
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Sunday, October 31st, 2010"
+                    class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    31
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Monday, November 1st, 2010"
+                    class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    1
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Tuesday, November 2nd, 2010"
+                    class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    2
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Wednesday, November 3rd, 2010"
+                    class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    3
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Thursday, November 4th, 2010"
+                    class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    4
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Friday, November 5th, 2010"
+                    class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    5
+                  </div>
+                  <div
+                    aria-disabled="true"
+                    aria-label="Not available Saturday, November 6th, 2010"
+                    class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
+                    role="button"
+                    tabindex="-1"
+                  >
+                    6
                   </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div
-          class="react-datepicker__tab-loop__end"
-          tabindex="0"
-        />
       </div>
     </div>
     <button
@@ -6972,6 +5386,7 @@ input + .c1 {
       class="c15"
       data-testid="calendar-button"
       tabindex="0"
+      type="button"
     >
       <svg
         color="currentColor"

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -291,6 +291,7 @@ export function Datepicker({
     const monthsOptions = useMemo(() => getLocaleMonthsOptions(currentLocale), [currentLocale]);
     const yearsOptions = useMemo(() => getYearsOptions(minDate, maxDate), [minDate, maxDate]);
     const id = useMemo(uuid, []);
+    const calendarRef = useRef<HTMLDivElement>(null);
     const dateInputRef = useRef<DatePicker>(null);
     const calendarButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -302,7 +303,9 @@ export function Datepicker({
 
     function handleCalendarKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
         if (event.key === 'Escape') {
+            event.stopPropagation();
             dateInputRef.current?.setOpen(false);
+            calendarButtonRef.current?.focus();
         }
     }
 
@@ -312,10 +315,11 @@ export function Datepicker({
 
     function focusCalendarDate(): void {
         setTimeout(() => {
-            const dateToFocus: HTMLDivElement | null =
-                document.querySelector('.react-datepicker__day[tabindex="0"]');
+            const dateToFocus =
+                calendarRef.current?.querySelector('.react-datepicker__day[tabindex="0"]') as HTMLDivElement;
+
             if (dateToFocus) dateToFocus.focus();
-        }, 10);
+        }, 0);
     }
 
     function handleCalendarButtonMouseDown(): void {
@@ -328,7 +332,7 @@ export function Datepicker({
     }
 
     function handleCalendarButtonKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
-        if (event.key === 'Enter' || event.key === ' ' /* Spacebar */) {
+        if (event.key === 'Enter' || event.key === ' ' /* Spacebar */) {
             dateInputRef.current?.setOpen(true);
             focusCalendarDate();
         }
@@ -390,6 +394,18 @@ export function Datepicker({
                             {...customHeaderProps}
                         />
                     )}
+                    calendarContainer={({ children }) => (
+                        <div
+                            aria-label={selectedDate?.toLocaleDateString(locale) || t('calendarContainerLabel')}
+                            aria-live="polite"
+                            aria-modal={true}
+                            className="react-datepicker"
+                            role="dialog"
+                            ref={calendarRef}
+                        >
+                            {children}
+                        </div>
+                    )}
                     className="datePickerInput"
                     dateFormat={dateFormat || getLocaleDateFormat(currentLocale)}
                     disabled={disabled}
@@ -405,16 +421,6 @@ export function Datepicker({
                     open={open}
                     placeholderText={getPlaceholder}
                     popperClassName="popper"
-                    popperContainer={({ children }) => (
-                        <div
-                            aria-label={selectedDate?.toDateString() || 'Choose Date'}
-                            aria-live="polite"
-                            aria-modal={true}
-                            role="dialog"
-                        >
-                            {children}
-                        </div>
-                    )}
                     preventOpenOnFocus
                     selected={selectedDate}
                     showPopperArrow={false}
@@ -424,8 +430,7 @@ export function Datepicker({
                     {...props}
                 />
                 <CalendarButton
-                    type="button"
-                    aria-label={selectedDate ? `Choose date, The selected date is ${selectedDate}` : 'Choose date'}
+                    aria-label={selectedDate ? `${t('calendarButtonSelectedLabel')} ${selectedDate.toLocaleDateString(locale)}` : t('calendarButtonLabel')}
                     data-testid="calendar-button"
                     type="button"
                     disabled={disabled}

--- a/packages/react/src/i18n/translations.ts
+++ b/packages/react/src/i18n/translations.ts
@@ -1,6 +1,9 @@
 export const Translations = {
     en: {
         datepicker: {
+            calendarButtonLabel: 'Choose date',
+            calendarButtonSelectedLabel: 'Choose date. The selected date is',
+            calendarContainerLabel: 'Choose date',
             validationErrorMessage: 'Invalid date',
             monthPreviousButtonLabel: 'Go to previous month',
             monthNextButtonLabel: 'Go to next month',
@@ -37,6 +40,9 @@ export const Translations = {
     },
     fr: {
         datepicker: {
+            calendarButtonLabel: 'Choisissez une date',
+            calendarButtonSelectedLabel: 'Choisissez une date. La date sélectionnée est',
+            calendarContainerLabel: 'Choisissez une date',
             validationErrorMessage: 'Date non valide',
             monthPreviousButtonLabel: 'Aller au mois précédent',
             monthNextButtonLabel: 'Aller au mois suivant',

--- a/packages/storybook/yarn.lock
+++ b/packages/storybook/yarn.lock
@@ -2430,10 +2430,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
-"@equisoft/design-elements-react@^2.0.3-alpha.16":
-  version "2.0.3-alpha.16"
-  resolved "https://registry.yarnpkg.com/@equisoft/design-elements-react/-/design-elements-react-2.0.3-alpha.16.tgz#b249d80c08516b6c1a42a74da97ede77b6d51236"
-  integrity sha512-EZEkwlUh7dQtZ0dHwOKm8BOedXB7cm34Y6yo3TOBCM3k2ZMgeMm+wCztDJYwXiBZENR5urhgdGdVJPgfyBzK3g==
+"@equisoft/design-elements-react@^2.0.3-alpha.17":
+  version "2.0.3-alpha.17"
+  resolved "https://registry.yarnpkg.com/@equisoft/design-elements-react/-/design-elements-react-2.0.3-alpha.17.tgz#089d1245b5a3e8e63ade2e7bd175b6835065cb32"
+  integrity sha512-cRUPPfkIL40adLKwttVEllEmnVVydrZxePcbIHb6JrQE+TGlXYNxE5GMgj6QvP2mnl0peANu0XyYvRXU05+jKw==
   dependencies:
     date-fns "^2.14.0"
     feather-icons "^4.21.0"
@@ -2442,10 +2442,10 @@
     react-swipeable "~5.5.0"
     uuid "^3.3.3"
 
-"@equisoft/design-elements-web@^2.0.3-alpha.16":
-  version "2.0.3-alpha.16"
-  resolved "https://registry.yarnpkg.com/@equisoft/design-elements-web/-/design-elements-web-2.0.3-alpha.16.tgz#798a5adbcc94fb9376c02bfbf4d0e415f304de1e"
-  integrity sha512-JYU0uj7Aoyzaxpt+ZUQvNvDnZQnO7n5+lS/LLuHAnnmC1dOpZIsyOnfsdg/68+Ew3+LfRE51Mo0KresPt9zpsg==
+"@equisoft/design-elements-web@^2.0.3-alpha.17":
+  version "2.0.3-alpha.17"
+  resolved "https://registry.yarnpkg.com/@equisoft/design-elements-web/-/design-elements-web-2.0.3-alpha.17.tgz#b7ff84460ec907267c8af58f48c9b85a814cb000"
+  integrity sha512-Q0gvpEHs2rTNz427uRQaTYGz6OzCc8HWYMq47QOvE1/KUCL2s18m5jtgzvC4YCaL+KIb1ks38ZDAth6o9PqYog==
 
 "@equisoft/tslint-config-react@^0.0.3":
   version "0.0.3"


### PR DESCRIPTION
## PR Description
Ce PR apporte les changements qui restaient à apporter au Datepicker. Aussi, le `onBlur` ne fonctionnait plus, j'ai donc apporté les changements pour fixer ça.
[Lien vers l'ancien PR](https://github.com/kronostechnologies/design-elements/pull/132)

## Requested changes de l'ancien PR ( @LarryMatte )
> ### Clavier
> * Quand tu navigues avec le _Tab_, après avoir eu le focus sur l'input au prochain hit du _tab_ tu devrais tomber sur le bouton icon qui a l'icône du calendrier. (_enter_ et _space_ vont trigger le calendrier).

Done

> * _Esc_ devrait fermer le dialog du calendrier lorsqu'il est ouvert.

Done

> * Quand le calendrier est ouvert, tu peux naviguer avec le tab mais on ne voit pas où se trouve le focus, à corriger.

Done

> * Quand le calendrier est ouvert et que tu sélectionnes la date avec _Enter_ ou _Space_, le dialog devrait se fermer et le focus devrait être sur le bouton icon.

Done

> * Le bouton "home" (fn + left arrow sur mac) devrait déplacer le focus sur la 1ere journée de la semaine. Présentement, ca change d'année.
> * Le bouton "end" (fn + right arrow sur mac) devrait déplacer le focus sur la derniere journée de la semaine. Présentement, ca change d'année et la date dans les inputs ne s'update pas.
> * _shift + page up_ (fn + up arrow) devrait changer la date à l'année précédente (garde même journée & même mois )
> * _shift + page down_ (fn + up down) devrait changer la date à l'année suivante (garde même journée & même mois )

Tout ces events sont déjà pris en charge par la lib, mais ils n'ont pas les comportements désirés. Changer ces events demanderais de reproduire leur solution et apporter nos comportements. Le problème c'est qu'on va se binder sur des implementation details qui risquent de changer dans les updates à venir. Les comportements actuels:

- **Home**: change la date à l'année précédente
- **End**: Change la date à l'année suivante
- **Page Up**: Change la date au mois précédent
- **Page Down**: Change la date au mois suivant

> ### Accessibility
> * `aria-label="Chose date"` sur le bouton icon lorsqu'il n'y a pas de date de sélectionné.
>   `aria-label="Chose date,  The selected date is (afficher la date)"` lorsqu'il y a une date de selectionné.
> * `role="dialog"` sur le dialog (calendrier ouvert).
> * `aria-modal="true"` sur le dialog.
> * `aria-labelledby="id_dialog-label"` sur le dialog.
> * `aria-live="polite"` sur le dialog.

Done

> * `aria-selected="true"` sur la journée qui est sélectionné i.e. celle que la date se trouve dans l'input.
> * `role="grid"` sur la div qui englobe les journées.
> * `aria-label="le label"` sur la div qui englobe les journées.
> 
> Voir: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/datepicker-dialog.html

Les 3 derniers points ne peuvent pas être comblés, car je n'ai pas accès à ces éléments via la lib.

> ### Autres
> * Je ne sais pas si c'est causé par storybook mais il est coupé par son conteneur:
> 
> <img alt="Date-picker_overflow" width="309" src="https://user-images.githubusercontent.com/3722754/88547762-29476e00-cfec-11ea-9f17-b6d69d384c96.png">

C'est causé par storybook. Le container de la story doit avoir overflow hidden. Ça cause aussi des problème avec l'affiche des stories du component side-drawer.

> Je ne sais pas c'est quoi le **Start open** mais si c'est pour qu'il soit ouvert par default quand nous entrons dans la page, ca ne fonctionne pas de mon côté.

J'ai fixé la fonctionnalité dans ce PR:
https://github.com/kronostechnologies/design-elements/pull/135

Ça devrait maintenant fonctionner.
