### PR TITLE
feat: Trigger Datepicker update when startDate prop changes

### DIFF
--- a/packages/react/src/components/datepicker/datepicker.test.tsx
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx
@@ -72,6 +72,15 @@ describe('Datepicker', () => {
         expect(getByTestId(wrapper, 'text-input').props().value).toBe('2002-02-02');
     });
 
+    test('input value should format when startDate changes', () => {
+        const wrapper = mount(ThemeWrapped(<Datepicker startDate={new Date('2010-10-10, 12:00')} />));
+
+        wrapper.setProps({ children: <Datepicker startDate={new Date('2020-10-20, 12:00')} /> });
+        wrapper.update();
+
+        expect(getByTestId(wrapper, 'text-input').props().value).toBe('2020-10-20');
+    });
+
     test('calendar should be opened when startOpen prop is truthy', () => {
         const wrapper = mount(ThemeWrapped(<Datepicker startOpen/>));
 

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -338,6 +338,10 @@ export function Datepicker({
         }
     }, [ firstDayOfWeek ]);
 
+    useEffect(() => {
+        startDate && setSelectedDate(startDate);
+    }, [ startDate ]);
+
     function handleCalendarKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
         if (event.key === 'Escape') {
             event.stopPropagation();

--- a/packages/storybook/yarn.lock
+++ b/packages/storybook/yarn.lock
@@ -2252,10 +2252,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz#622a72bebd1e3f48d921563b4b60a762295a81fc"
   integrity sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA==
 
-"@equisoft/design-elements-react@^2.0.3-alpha.41":
-  version "2.0.3-alpha.41"
-  resolved "https://registry.yarnpkg.com/@equisoft/design-elements-react/-/design-elements-react-2.0.3-alpha.41.tgz#909a73a5ea471c67bd84879402c4c636f04bafb3"
-  integrity sha512-dGEqcx3EsofynY9FmEseniIj9fl742n6+ycISflrxndCoh2L6WKKHDl5JUmPGxjMi66B44s0zn6uAVHArmaPaQ==
+"@equisoft/design-elements-react@^2.0.3-alpha.42":
+  version "2.0.3-alpha.42"
+  resolved "https://registry.yarnpkg.com/@equisoft/design-elements-react/-/design-elements-react-2.0.3-alpha.42.tgz#616b37761d5898f67487e8c07538a1b3678a2297"
+  integrity sha512-bmE5cKSCLLZUgYR17/Z+u+7EVqw4J8ktGzSXnsF8cusxDR+6npJtJtU3gYU223cjxH81ZWBKTc7INhsuJvxV4w==
   dependencies:
     date-fns "^2.14.0"
     feather-icons "^4.21.0"


### PR DESCRIPTION
## PR Description
Ce PR permet de changer la valeur du Datepicker sans passer en mode _controlled_. La modification de la prop `startDate` permet maintenant de changer la date sélectionnée dans le Datepicker.