### PR TITLE
feat: Add Heading component - QLT-50

### DIFF
--- a/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
+++ b/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Global Navigation Matches snapshot 1`] = `
   position: relative;
 }
 
-.c2.moreMenu:hover .sc-bTvRPi {
+.c2.moreMenu:hover .sc-dacFzL {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/react/src/components/heading/heading.test.tsx
+++ b/packages/react/src/components/heading/heading.test.tsx
@@ -1,0 +1,45 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { renderWithProviders } from '@design-elements/test-utils/renderer';
+import { Heading, Tag, Type } from './heading';
+
+interface TestCases {
+    type: Type;
+    tag: Tag;
+}
+
+const testCases: TestCases[] = [
+    { type: 'xlarge', tag: 'h1' },
+    { type: 'large', tag: 'h2' },
+    { type: 'medium', tag: 'h3' },
+    { type: 'small', tag: 'h4' },
+]
+
+describe('Heading', () => {
+    testCases.forEach(({ type, tag }) => {
+        test(`should return a ${tag} element when type is set to ${type}`, () => {
+            const wrapper = mount(<Heading type={type}>Heading</Heading>);
+
+            expect(wrapper.find(tag)).toHaveLength(1);
+        })
+
+        test(`matches snapshot (${type})`, () => {
+            const tree = renderWithProviders(<Heading type={type}>Heading</Heading>)
+
+            expect(tree).toMatchSnapshot();
+        })
+    })
+
+    test('overwrites default html tag when tag prop is set', () => {
+        const wrapper = mount(<Heading type="xlarge" tag="h3"/>);
+
+        expect(wrapper.find('h3')).toHaveLength(1);
+    })
+
+    test('matches snapshot (no margin)', () => {
+        const tree = renderWithProviders(<Heading type="medium" noMargin>Heading</Heading>)
+
+        expect(tree).toMatchSnapshot();
+    })
+})

--- a/packages/react/src/components/heading/heading.test.tsx.snap
+++ b/packages/react/src/components/heading/heading.test.tsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Heading matches snapshot (large) 1`] = `
+.c0 {
+  font-size: 1.5rem;
+  font-weight: var(--font-normal);
+  line-height: 2.25rem;
+  margin: var(--spacing-3x) 0;
+}
+
+<h2
+  class="c0"
+>
+  Heading
+</h2>
+`;
+
+exports[`Heading matches snapshot (medium) 1`] = `
+.c0 {
+  font-size: 1.25rem;
+  font-weight: var(--font-normal);
+  line-height: 2rem;
+  margin: var(--spacing-3x) 0;
+}
+
+<h3
+  class="c0"
+>
+  Heading
+</h3>
+`;
+
+exports[`Heading matches snapshot (no margin) 1`] = `
+.c0 {
+  font-size: 1.25rem;
+  font-weight: var(--font-normal);
+  line-height: 2rem;
+  margin: 0;
+}
+
+<h3
+  class="c0"
+>
+  Heading
+</h3>
+`;
+
+exports[`Heading matches snapshot (small) 1`] = `
+.c0 {
+  font-size: 1rem;
+  font-weight: var(--font-normal);
+  line-height: 1.5rem;
+  margin: var(--spacing-3x) 0;
+}
+
+<h4
+  class="c0"
+>
+  Heading
+</h4>
+`;
+
+exports[`Heading matches snapshot (xlarge) 1`] = `
+.c0 {
+  font-size: 2rem;
+  font-weight: var(--font-normal);
+  line-height: 3rem;
+  margin: var(--spacing-4x) 0;
+}
+
+<h1
+  class="c0"
+>
+  Heading
+</h1>
+`;

--- a/packages/react/src/components/heading/heading.tsx
+++ b/packages/react/src/components/heading/heading.tsx
@@ -1,0 +1,82 @@
+import React, { ReactElement, ReactNode } from 'react';
+import styled, { DefaultTheme, StyledComponent } from 'styled-components';
+
+export type Type = 'xlarge' | 'large' | 'medium' | 'small';
+export type Tag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+interface HeadingProps {
+    bold?: boolean;
+    children?: ReactNode;
+    className?: string;
+    noMargin?: boolean;
+    tag?: Tag;
+    type: Type;
+}
+
+interface StyledHeadingProps {
+    bold?: boolean;
+    noMargin?: boolean;
+}
+
+const HeadingXlarge = styled.h1<StyledHeadingProps>`
+    font-size: 2rem;
+    font-weight: var(--font-normal);
+    line-height: 3rem;
+    margin: ${({ noMargin }) => noMargin ? '0' : 'var(--spacing-4x) 0'};
+`;
+
+const HeadingLarge = styled.h2<StyledHeadingProps>`
+    font-size: 1.5rem;
+    font-weight: ${({ bold }) => bold ? 'var(--font-semi-bold)' : 'var(--font-normal)'};
+    line-height: 2.25rem;
+    margin: ${({ noMargin }) => noMargin ? '0' : 'var(--spacing-3x) 0'};
+`;
+
+const HeadingMedium = styled.h3<StyledHeadingProps>`
+    font-size: 1.25rem;
+    font-weight: ${({ bold }) => bold ? 'var(--font-semi-bold)' : 'var(--font-normal)'};
+    line-height: 2rem;
+    margin: ${({ noMargin }) => noMargin ? '0' : 'var(--spacing-3x) 0'};
+`;
+
+const HeadingSmall = styled.h4<StyledHeadingProps>`
+    font-size: 1rem;
+    font-weight: ${({ bold }) => bold ? 'var(--font-semi-bold)' : 'var(--font-normal)'};
+    line-height: 1.5rem;
+    margin: ${({ noMargin }) => noMargin ? '0' : 'var(--spacing-3x) 0'};
+`;
+
+export function Heading({
+    bold,
+    className,
+    children,
+    noMargin,
+    tag,
+    type
+}: HeadingProps): ReactElement {
+    const HeadingComponent = getComponent(type);
+
+    return (
+        <HeadingComponent
+            as={tag}
+            bold={bold}
+            className={className}
+            noMargin={noMargin}
+        >
+            {children}
+        </HeadingComponent>
+    );
+}
+
+function getComponent(type: Type): StyledComponent<'h1' | 'h2' | 'h3' | 'h4', DefaultTheme, StyledHeadingProps, never> {
+    switch (type) {
+        case 'xlarge':
+            return HeadingXlarge;
+        case 'large':
+            return HeadingLarge;
+        case 'medium':
+            return HeadingMedium;
+        case 'small':
+            return HeadingSmall;
+    }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -32,6 +32,7 @@ export * from './components/carousel/carousel';
 export { Chooser } from './components/choosers/chooser';
 export { EnsoSpinner } from './components/enso-spinner/enso-spinner';
 export { ExternalLink } from './components/external-link/external-link';
+export { Heading } from './components/heading/heading';
 export { ApplicationMenu } from './components/application-menu/application-menu';
 export * from './components/global-navigation/global-navigation';
 export { Icon } from './components/icon/icon';

--- a/packages/storybook/stories/heading.stories.tsx
+++ b/packages/storybook/stories/heading.stories.tsx
@@ -1,0 +1,27 @@
+import { Heading } from '@equisoft/design-elements-react';
+import React from 'react';
+
+export default {
+    title: 'Heading',
+    component: Heading,
+};
+
+export const normal = () => (
+    <>
+        <Heading type="xlarge">Heading (Xlarge)</Heading>
+        <Heading type="large">Heading (Large)</Heading>
+        <Heading type="large" bold>Heading (Large bold)</Heading>
+        <Heading type="medium">Heading (Medium)</Heading>
+        <Heading type="medium" bold>Heading (Medium bold)</Heading>
+        <Heading type="small">Heading (Small)</Heading>
+        <Heading type="small" bold>Heading (Small bold)</Heading>
+    </>
+);
+
+export const withoutMargins = () => (
+    <Heading type="medium" noMargin>Heading (Medium)</Heading>
+);
+
+export const withDifferentTag = () => (
+    <Heading type="medium" tag="h4">Heading (Medium)</Heading>
+);


### PR DESCRIPTION
## PR Description
Ce PR ajoute le component Heading.
[Lien vers le ticket Jira](https://jira.equisoft.com/browse/QLT-50?workflowName=Software+Simplified+Workflow+for+Project+QLT&stepId=6)

### Notes de développement
Le component assigne un tag HTML par défaut tout dépendant de la prop `type` définie. Si le user veut avoir les styles d'un certain type avec un tag HTML différent de celui qui est assigné par défaut, il peut passer la prop `tag` qui vient overwrite le tag HTML.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] The CircleCI build is successful.