### PR TITLE
chore: Remove uuid dependency

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,8 +41,7 @@
     "react-shadow": "^19.0.1",
     "react-swipeable": "~6.0.1",
     "react-table": "^7.6.2",
-    "stream-browserify": "^3.0.0",
-    "uuid": "^3.4.0"
+    "stream-browserify": "^3.0.0"
   },
   "peerDependencies": {
     "i18next": "^19",
@@ -71,7 +70,6 @@
     "@types/react-test-renderer": "^17.0.0",
     "@types/styled-components": "^5.1.7",
     "@types/testing-library__react-hooks": "^3.4.1",
-    "@types/uuid": "^3.4.9",
     "@typescript-eslint/eslint-plugin": "^4.11.0",
     "@typescript-eslint/parser": "^4.11.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.4.1",

--- a/packages/react/src/components/choose-input/choose-input.test.tsx
+++ b/packages/react/src/components/choose-input/choose-input.test.tsx
@@ -5,7 +5,7 @@ import { doNothing } from '../../test-utils/callbacks';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { ChooseInput } from './choose-input';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('Choose Input', () => {
     test('onChange Callback is called when changed', () => {

--- a/packages/react/src/components/choose-input/choose-input.tsx
+++ b/packages/react/src/components/choose-input/choose-input.tsx
@@ -1,7 +1,7 @@
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, { ChangeEvent, ReactNode } from 'react';
 
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 import { hiddenStyle } from '../visually-hidden/styles/visuallyhidden';
 import { Label } from './styles/choose';
 

--- a/packages/react/src/components/choosers/chooser.test.tsx
+++ b/packages/react/src/components/choosers/chooser.test.tsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { Chooser } from './chooser';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('Chooser', () => {
     const maritalStatus = [

--- a/packages/react/src/components/datepicker/datepicker.test.tsx
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx
@@ -3,7 +3,7 @@ import { actAndWaitForEffects, mountWithTheme, renderWithProviders } from '@desi
 import React, { RefObject } from 'react';
 import { Datepicker, DatepickerHandles } from './datepicker';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('Datepicker', () => {
     test('onChange callback is called when input changed', () => {

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from '@design-elements/i18n/i18n';
 import { Theme } from '@design-elements/themes/theme';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import { enCA, enUS, frCA } from 'date-fns/locale';
 import React, {
     FocusEvent,
@@ -17,7 +18,6 @@ import React, {
 import DatePicker, { ReactDatePickerProps, registerLocale } from 'react-datepicker';
 import datepickerCss from 'react-datepicker/dist/react-datepicker.min.css';
 import styled, { createGlobalStyle } from 'styled-components';
-import uuid from 'uuid/v4';
 
 import { Button } from '../buttons/button';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';

--- a/packages/react/src/components/listbox/listbox.test.tsx
+++ b/packages/react/src/components/listbox/listbox.test.tsx
@@ -3,7 +3,7 @@ import { mountWithTheme, renderWithTheme, shallowWithTheme } from '@design-eleme
 import React from 'react';
 import { Listbox } from './listbox';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 const options = [
     {

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -1,3 +1,4 @@
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, {
     forwardRef,
     KeyboardEvent,
@@ -10,7 +11,6 @@ import React, {
     useState,
 } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
 import { Icon } from '../icon/icon';
 

--- a/packages/react/src/components/modal/modal-dialog.test.tsx
+++ b/packages/react/src/components/modal/modal-dialog.test.tsx
@@ -5,7 +5,7 @@ import { doNothing } from '../../test-utils/callbacks';
 import { DeviceType } from '../device-context-provider/device-context-provider';
 import { ModalDialog, ModalDialogProps } from './modal-dialog';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 type ModalDialogPropsLite = Omit<ModalDialogProps, 'ariaDescribedby' | 'ariaHideApp' | 'onRequestClose'>;
 

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '@design-elements/i18n/i18n';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, { ReactElement, ReactNode, Ref, useMemo, useRef } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 
 import { Button } from '../buttons/button';
 import { DeviceContextProps, useDeviceContext } from '../device-context-provider/device-context-provider';

--- a/packages/react/src/components/money-input/money-input.test.tsx
+++ b/packages/react/src/components/money-input/money-input.test.tsx
@@ -4,7 +4,7 @@ import renderer from 'react-test-renderer';
 import { themeProvider, ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { MoneyInput } from './money-input';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 function simulateValueChange(input: HTMLInputElement, value: String): void {
     fireEvent.focus(input);

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx
@@ -4,7 +4,7 @@ import React, { ReactElement } from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { NavMenuButton } from './nav-menu-button';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 function setup(children: ReactElement): ReactElement {
     return (

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from '@design-elements/i18n/i18n';
 import { Theme } from '@design-elements/themes/theme';
 import React, { KeyboardEvent, ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import { AbstractButton } from '../buttons/abstract-button';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
 import { Icon } from '../icon/icon';

--- a/packages/react/src/components/nav-menu/nav-menu.test.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.test.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { NavMenu } from './nav-menu';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 const options = [
     {

--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -1,7 +1,7 @@
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, { forwardRef, KeyboardEvent, ReactElement, Ref, RefObject, useEffect, useMemo } from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 import { DeviceContextProps, useDeviceContext } from '../device-context-provider/device-context-provider';
 
 const List = styled.ul`

--- a/packages/react/src/components/option-button/option-button.test.tsx
+++ b/packages/react/src/components/option-button/option-button.test.tsx
@@ -3,7 +3,7 @@ import renderer from 'react-test-renderer';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { OptionButton } from './option-button';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('Option Button', () => {
     test('Is checked', () => {

--- a/packages/react/src/components/option-button/option-button.tsx
+++ b/packages/react/src/components/option-button/option-button.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, VoidFunctionComponent } from 'react';
 
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 
 const Input = styled.input`
     ${(props) => `

--- a/packages/react/src/components/search/search-contextual.test.tsx
+++ b/packages/react/src/components/search/search-contextual.test.tsx
@@ -5,7 +5,7 @@ import { doNothing } from '../../test-utils/callbacks';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { SearchContextual } from './search-contextual';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('Search Contextual', () => {
     test('onChange Callback is called when changed', () => {

--- a/packages/react/src/components/search/search-input.tsx
+++ b/packages/react/src/components/search/search-input.tsx
@@ -1,11 +1,11 @@
 import { useTranslation } from '@design-elements/i18n/i18n';
 import { Theme } from '@design-elements/themes/theme';
 import { focus } from '@design-elements/utils/css-state';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import SearchIcon from 'feather-icons/dist/icons/search.svg';
 import XIcon from 'feather-icons/dist/icons/x.svg';
 import React, { ChangeEvent, KeyboardEvent, useCallback, useMemo, useState, VoidFunctionComponent } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 import { SearchButton } from '../buttons/search-button';
 import { Label } from '../label/label';
 import { inputsStyle } from '../text-input/styles/inputs';

--- a/packages/react/src/components/search/search.test.tsx
+++ b/packages/react/src/components/search/search.test.tsx
@@ -6,7 +6,7 @@ import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { SearchButton } from '../buttons/search-button';
 import { SearchGlobal } from './search-global';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('SearchGlobal', () => {
     test('Search callback is called when search button is clicked', () => {

--- a/packages/react/src/components/select/select.test.tsx
+++ b/packages/react/src/components/select/select.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { ThemeWrapper } from '../theme-wrapper/theme-wrapper';
 import { Select } from './select';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 const provinces = [
     { value: 'on', label: 'Ontario' },

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from '@design-elements/i18n/i18n';
 import { Theme } from '@design-elements/themes/theme';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, {
     ChangeEvent,
     KeyboardEvent,
@@ -11,7 +12,6 @@ import React, {
     useState,
 } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 
 import { ChooseInput } from '../choose-input/choose-input';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -1,6 +1,6 @@
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, { KeyboardEvent, ReactElement, ReactNode, useReducer, useState } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 
 import { IconName } from '../icon/icon';
 import { TabButton } from './tab-button';

--- a/packages/react/src/components/text-area/text-area.test.tsx
+++ b/packages/react/src/components/text-area/text-area.test.tsx
@@ -5,7 +5,7 @@ import { doNothing } from '../../test-utils/callbacks';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { TextArea } from './text-area';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('TextArea', () => {
     const defaultProps = {

--- a/packages/react/src/components/text-area/text-area.tsx
+++ b/packages/react/src/components/text-area/text-area.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from '@design-elements/i18n/i18n';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, { ChangeEvent, FocusEvent, ReactElement, useState } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 
 import { FieldContainer } from '../field-container/field-container';
 import { inputsStyle } from '../text-input/styles/inputs';

--- a/packages/react/src/components/text-input/text-input.test.tsx
+++ b/packages/react/src/components/text-input/text-input.test.tsx
@@ -6,7 +6,7 @@ import { mountWithTheme } from '../../test-utils/renderer';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
 import { TextInput } from './text-input';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('TextInput', () => {
     const initialProps = {

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -1,15 +1,16 @@
 import { useTranslation } from '@design-elements/i18n/i18n';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, {
     ChangeEvent,
     DetailedHTMLProps,
     FocusEvent,
     InputHTMLAttributes,
-    ReactElement, useCallback,
+    ReactElement,
+    useCallback,
     useMemo,
     useState,
 } from 'react';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 
 import { FieldContainer } from '../field-container/field-container';
 import { inputsStyle } from './styles/inputs';

--- a/packages/react/src/components/tooltip/tooltip.test.tsx
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx
@@ -2,7 +2,7 @@ import { renderWithProviders } from '@design-elements/test-utils/renderer';
 import React from 'react';
 import { Tooltip, TooltipArrow, TooltipContainer } from './tooltip';
 
-jest.mock('uuid/v4');
+jest.mock('@design-elements/utils/uuid');
 
 describe('Tooltip', () => {
     test('Has default desktop styles', () => {

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -1,4 +1,5 @@
 import { focus } from '@design-elements/utils/css-state';
+import { v4 as uuid } from '@design-elements/utils/uuid';
 import React, {
     KeyboardEvent as ReactKeyboardEvent,
     MouseEvent,
@@ -11,7 +12,6 @@ import React, {
 } from 'react';
 import TooltipTrigger, { TooltipTriggerProps } from 'react-popper-tooltip';
 import styled from 'styled-components';
-import uuid from 'uuid/v4';
 import { useTheme } from '../../hooks/use-theme';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
 import { Icon } from '../icon/icon';

--- a/packages/react/src/utils/uuid.ts
+++ b/packages/react/src/utils/uuid.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-bitwise */
+function v4Replacer(substring: string): string {
+    const value = Number(substring);
+    const randomValue: number = value ^ globalThis.crypto.getRandomValues(new Uint8Array(1))[0];
+    return ((randomValue % 16) >> (value / 4)).toString(16);
+}
+
+// Source : https://gist.github.com/jed/982883#gistcomment-1615714
+export function v4(): string {
+    return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, v4Replacer);
+}

--- a/packages/react/test/setup.ts
+++ b/packages/react/test/setup.ts
@@ -1,5 +1,6 @@
-import { configure } from 'enzyme';
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17';
+import * as crypto from 'crypto';
+import { configure } from 'enzyme';
 // tslint:disable-next-line:no-import-side-effect
 import 'jest-styled-components';
 import React from 'react';
@@ -15,3 +16,21 @@ jest.mock('@design-elements/styles/body.scss', () => ({
     unuse: jest.fn(),
     toString: () => 'body {}',
 }));
+
+type BufferType =
+    Int8Array
+    | Int16Array
+    | Int32Array
+    | Uint8Array
+    | Uint16Array
+    | Uint32Array
+    | Uint8ClampedArray
+    | Float32Array
+    | Float64Array
+    | DataView
+    | null;
+globalThis.crypto = {
+    getRandomValues: function getRandomValues<T extends BufferType>(buffer: T): T {
+        return crypto.randomFillSync(buffer as NodeJS.ArrayBufferView) as T;
+    },
+} as Crypto;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,7 +1980,6 @@ __metadata:
     "@types/react-test-renderer": ^17.0.0
     "@types/styled-components": ^5.1.7
     "@types/testing-library__react-hooks": ^3.4.1
-    "@types/uuid": ^3.4.9
     "@typescript-eslint/eslint-plugin": ^4.11.0
     "@typescript-eslint/parser": ^4.11.0
     "@wojtekmaj/enzyme-adapter-react-17": ^0.4.1
@@ -2027,7 +2026,6 @@ __metadata:
     ts-loader: ^8.0.12
     tsconfig-paths-webpack-plugin: ~3.3.0
     typescript: ^4.1.3
-    uuid: ^3.4.0
     webpack: ^5.11.0
     webpack-cli: ^4.2.0
     webpack-merge: ^5.7.3
@@ -3921,13 +3919,6 @@ __metadata:
   version: 2.0.3
   resolution: "@types/unist@npm:2.0.3"
   checksum: 42e0dc4ac75a27c4bb91a3f8e82edfd8819cacb6edda08bdfb436700ea01a587faa30017fde744b0a0b33825f5e37686398c1eb5b664cabc3a72a6b3757f85a5
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^3.4.9":
-  version: 3.4.9
-  resolution: "@types/uuid@npm:3.4.9"
-  checksum: bc70640658b90c6ed88636f6b181e9cb74d7b13f27d924ac3c52ac73eaeb2e693653ab66a0d7d18e8b1c4022cd369c9cae28694fd586bce8b3b15dd68bea98ad
   languageName: node
   linkType: hard
 
@@ -18454,7 +18445,7 @@ typescript@^4.1.3:
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.1.0, uuid@npm:^3.3.2, uuid@npm:^3.3.3, uuid@npm:^3.4.0":
+"uuid@npm:^3.1.0, uuid@npm:^3.3.2, uuid@npm:^3.3.3":
   version: 3.4.0
   resolution: "uuid@npm:3.4.0"
   bin:


### PR DESCRIPTION
`uuid` dépend de quelques libs nodes, dont `crypto`. Pour simplifier le travail sur le tree-shaking, je l'ai retiré pour remplacer par une implémentation custom. Aussi c'était plus compliqué avec webpack 5, qui ne mets plus les polyfills par défaut.