### PR TITLE
refactor(Links): Optimize use of styled-components

### DIFF
--- a/packages/react/src/components/external-link/external-link.test.tsx
+++ b/packages/react/src/components/external-link/external-link.test.tsx
@@ -12,6 +12,7 @@ describe('External Link', () => {
         wrapper.find(ExternalLink).simulate('click');
         expect(callback).toHaveBeenCalledTimes(1);
     });
+
     test('matches snapshot', () => {
         const tree = renderWithProviders(
             <ExternalLink href="https://www.google.ca/" label="External Link" />,
@@ -19,21 +20,32 @@ describe('External Link', () => {
 
         expect(tree).toMatchSnapshot();
     });
-    test('with icon matches snapshot', () => {
+
+    test('matches snapshot (label and icon)', () => {
         const tree = renderWithProviders(
             <ExternalLink href="#" label="External Link" iconName="mail" />,
         );
 
         expect(tree).toMatchSnapshot();
     });
-    test('without href matches snapshot', () => {
+
+    test('matches snapshot (only icon)', () => {
+        const tree = renderWithProviders(
+            <ExternalLink href="#" iconName="mail" />,
+        );
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('matches snapshot (without href)', () => {
         const tree = renderWithProviders(
             <ExternalLink label="External Link" iconName="mail" />,
         );
 
         expect(tree).toMatchSnapshot();
     });
-    test('disabled matches snapshot', () => {
+
+    test('matches snapshot (disabled)', () => {
         const tree = renderWithProviders(
             <ExternalLink href="#" label="External Link" disabled />,
         );

--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`External Link disabled matches snapshot 1`] = `
+exports[`External Link matches snapshot (disabled) 1`] = `
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,51 +19,219 @@ exports[`External Link disabled matches snapshot 1`] = `
   margin-right: var(--spacing-1x);
 }
 
-.c0.iconOnly svg {
-  margin: 0;
+.c0:focus {
+  outline: none;
 }
 
-.c0.external {
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
   color: #7fbfd2;
 }
 
-.c0.external:focus {
-  outline: none;
+.c1:visited {
+  color: #094C6C;
 }
 
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #9ca7b4;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+.c1:visited svg {
+  color: #094C6C;
 }
 
 <a
   aria-disabled="true"
-  class="c0 external"
+  class="c0 c1"
   disabled=""
+  type="external"
 >
+  External Link
+</a>
+`;
+
+exports[`External Link matches snapshot (label and icon) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: var(--spacing-1x);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #0080A5;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:visited {
+  color: #094C6C;
+}
+
+.c1:visited svg {
+  color: #094C6C;
+}
+
+<a
+  aria-disabled="false"
+  class="c0 c1"
+  href="#"
+  type="external"
+>
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
+  External Link
+</a>
+`;
+
+exports[`External Link matches snapshot (only icon) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: 0;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #0080A5;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:visited {
+  color: #094C6C;
+}
+
+.c1:visited svg {
+  color: #094C6C;
+}
+
+<a
+  aria-disabled="false"
+  class="c0 c1"
+  href="#"
+  type="external"
+>
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
+</a>
+`;
+
+exports[`External Link matches snapshot (without href) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: var(--spacing-1x);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #0080A5;
+}
+
+.c1:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c1:visited {
+  color: #094C6C;
+}
+
+.c1:visited svg {
+  color: #094C6C;
+}
+
+<a
+  aria-disabled="false"
+  class="c0 c1"
+  href=""
+  type="external"
+>
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
   External Link
 </a>
 `;
@@ -87,238 +255,39 @@ exports[`External Link matches snapshot 1`] = `
   margin-right: var(--spacing-1x);
 }
 
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
+.c0:focus {
   outline: none;
 }
 
-.c0.external:focus {
+.c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #0080A566;
   box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
 }
 
-.c0.external:hover {
+.c1 {
+  color: #0080A5;
+}
+
+.c1:hover {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c0.external:visited {
-  color: #094c6c;
+.c1:visited {
+  color: #094C6C;
 }
 
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
+.c1:visited svg {
+  color: #094C6C;
 }
 
 <a
   aria-disabled="false"
-  class="c0 external"
+  class="c0 c1"
   href="https://www.google.ca/"
+  type="external"
 >
-  External Link
-</a>
-`;
-
-exports[`External Link with icon matches snapshot 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 svg {
-  margin-right: var(--spacing-1x);
-}
-
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
-  outline: none;
-}
-
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
-}
-
-<a
-  aria-disabled="false"
-  class="c0 external"
-  href="#"
->
-  <svg
-    color="currentColor"
-    focusable="false"
-    height="16"
-    width="16"
-  />
-  External Link
-</a>
-`;
-
-exports[`External Link without href matches snapshot 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 svg {
-  margin-right: var(--spacing-1x);
-}
-
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
-  outline: none;
-}
-
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
-}
-
-<a
-  aria-disabled="false"
-  class="c0 external"
-  href=""
->
-  <svg
-    color="currentColor"
-    focusable="false"
-    height="16"
-    width="16"
-  />
   External Link
 </a>
 `;

--- a/packages/react/src/components/external-link/external-link.tsx
+++ b/packages/react/src/components/external-link/external-link.tsx
@@ -1,7 +1,24 @@
 import React, { MouseEvent, ReactElement, useCallback } from 'react';
+import styled from 'styled-components';
 
 import { Icon, IconName } from '../icon/icon';
 import { StyledLink } from '../route-link/styles/styled-link';
+
+const Link = styled(StyledLink)`
+    color: ${({ disabled, theme }) => (disabled ? '#7fbfd2' : theme.main['primary-1.1'])};
+
+    &:hover {
+        ${({ disabled }) => (disabled ? '' : 'text-decoration: underline')};
+    }
+
+    &:visited {
+        color: ${({ theme }) => theme.main['primary-3']};
+
+        svg {
+            color: ${({ theme }) => theme.main['primary-3']};
+        }
+    }
+`;
 
 interface ExternalLinkProps {
     className?: string;
@@ -25,16 +42,18 @@ export function ExternalLink({
     }, [href, onClick]);
 
     return (
-        <StyledLink
+        <Link
             aria-disabled={disabled ? 'true' : 'false'}
-            className={['external', className, !label && 'iconOnly'].filter(Boolean).join(' ')}
+            className={className}
             disabled={disabled}
+            $hasLabel={!!label}
             href={disabled ? undefined : href}
             onClick={disabled ? undefined : handleClick}
             target={target}
+            type="external"
         >
             {iconName && <Icon name={iconName} size="16" />}
             {label}
-        </StyledLink>
+        </Link>
     );
 }

--- a/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
+++ b/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Global Navigation Matches snapshot 1`] = `
   position: relative;
 }
 
-.c2.moreMenu:hover .sc-GTWni {
+.c2.moreMenu:hover .sc-bXDlPE {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/react/src/components/route-link/route-link.test.tsx
+++ b/packages/react/src/components/route-link/route-link.test.tsx
@@ -21,21 +21,24 @@ describe('Route Link', () => {
 
         expect(tree).toMatchSnapshot();
     });
-    test('with icon matches snapshot (NavLink)', () => {
+
+    test('matches snapshot (NavLink | label and icon)', () => {
         const tree = renderWithRouter(
             ThemeWrapped(<RouteLink routerLink={NavLink} href="/test" label="Navigation Link" iconName="mail" />),
         );
 
         expect(tree).toMatchSnapshot();
     });
-    test('only icon matches snapshot (NavLink)', () => {
+
+    test('matches snapshot (NavLink | only icon)', () => {
         const tree = renderWithRouter(
             ThemeWrapped(<RouteLink routerLink={NavLink} href="/test" iconName="mail" />),
         );
 
         expect(tree).toMatchSnapshot();
     });
-    test('disabled matches snapshot (NavLink)', () => {
+
+    test('matches snapshot (NavLink | disabled)', () => {
         const tree = renderWithRouter(
             ThemeWrapped(<RouteLink routerLink={NavLink} href="/test" label="Navigation Link" disabled />),
         );
@@ -50,21 +53,24 @@ describe('Route Link', () => {
 
         expect(tree).toMatchSnapshot();
     });
-    test('with icon matches snapshot (Link)', () => {
+
+    test('matches snapshot (Link | label and icon)', () => {
         const tree = renderWithRouter(
             ThemeWrapped(<RouteLink routerLink={Link} href="/test" label="Navigation Link" iconName="mail" />),
         );
 
         expect(tree).toMatchSnapshot();
     });
-    test('only icon matches snapshot (Link)', () => {
+
+    test('matches snapshot (Link | only icon)', () => {
         const tree = renderWithRouter(
             ThemeWrapped(<RouteLink routerLink={Link} href="/test" iconName="mail" />),
         );
 
         expect(tree).toMatchSnapshot();
     });
-    test('disabled matches snapshot (Link)', () => {
+
+    test('matches snapshot (Link | disabled)', () => {
         const tree = renderWithRouter(
             ThemeWrapped(<RouteLink routerLink={Link} href="/test" label="Navigation Link" disabled />),
         );

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Route Link disabled matches snapshot (Link) 1`] = `
+exports[`Route Link matches snapshot (Link | disabled) 1`] = `
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -19,62 +19,43 @@ exports[`Route Link disabled matches snapshot (Link) 1`] = `
   margin-right: var(--spacing-1x);
 }
 
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #7fbfd2;
-}
-
-.c0.external:focus {
+.c0:focus {
   outline: none;
 }
 
-.c0.external:focus {
+.c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #0080A566;
   box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
 }
 
-.c0.external:visited {
-  color: #094c6c;
+.c1 {
+  color: #9CA7B4;
 }
 
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #9ca7b4;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+.c1[disabled] {
+  pointer-events: none;
 }
 
 <a
   aria-disabled="true"
-  class="c0 navigation"
+  class="c0 c1"
   disabled=""
+  href="/test"
+  tabindex="-1"
+  type="route"
 >
   Navigation Link
 </a>
 `;
 
-exports[`Route Link disabled matches snapshot (NavLink) 1`] = `
+exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: default;
+  cursor: pointer;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -87,52 +68,105 @@ exports[`Route Link disabled matches snapshot (NavLink) 1`] = `
   margin-right: var(--spacing-1x);
 }
 
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #7fbfd2;
-}
-
-.c0.external:focus {
+.c0:focus {
   outline: none;
 }
 
-.c0.external:focus {
+.c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #0080A566;
   box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
 }
 
-.c0.external:visited {
-  color: #094c6c;
+.c1 {
+  color: #57666E;
 }
 
-.c0.external:visited svg {
-  color: #094c6c;
+.c1:hover {
+  color: #000000;
 }
 
-.c0.navigation {
-  color: #9ca7b4;
+.c1.active {
+  color: #0080A5;
 }
 
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+.c1[disabled] {
+  pointer-events: none;
 }
 
 <a
-  aria-disabled="true"
-  class="c0 navigation"
-  disabled=""
+  class="c0 c1"
+  href="/test"
+  tabindex="0"
+  type="route"
 >
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
   Navigation Link
+</a>
+`;
+
+exports[`Route Link matches snapshot (Link | only icon) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: 0;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #57666E;
+}
+
+.c1:hover {
+  color: #000000;
+}
+
+.c1.active {
+  color: #0080A5;
+}
+
+.c1[disabled] {
+  pointer-events: none;
+}
+
+<a
+  class="c0 c1"
+  href="/test"
+  tabindex="0"
+  type="route"
+>
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
 </a>
 `;
 
@@ -155,64 +189,209 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   margin-right: var(--spacing-1x);
 }
 
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
+.c0:focus {
   outline: none;
 }
 
-.c0.external:focus {
+.c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #0080A566;
   box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
 }
 
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+.c1 {
+  color: #57666E;
 }
 
-.c0.external:visited {
-  color: #094c6c;
+.c1:hover {
+  color: #000000;
 }
 
-.c0.external:visited svg {
-  color: #094c6c;
+.c1.active {
+  color: #0080A5;
 }
 
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
+.c1[disabled] {
+  pointer-events: none;
 }
 
 <a
-  class="c0 navigation"
+  class="c0 c1"
   href="/test"
+  tabindex="0"
+  type="route"
 >
   Navigation Link
+</a>
+`;
+
+exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: default;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: var(--spacing-1x);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #9CA7B4;
+}
+
+.c1[disabled] {
+  pointer-events: none;
+}
+
+<a
+  aria-disabled="true"
+  class="c0 c1"
+  disabled=""
+  href="/test"
+  tabindex="-1"
+  type="route"
+>
+  Navigation Link
+</a>
+`;
+
+exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: var(--spacing-1x);
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #57666E;
+}
+
+.c1:hover {
+  color: #000000;
+}
+
+.c1.active {
+  color: #0080A5;
+}
+
+.c1[disabled] {
+  pointer-events: none;
+}
+
+<a
+  class="c0 c1"
+  href="/test"
+  tabindex="0"
+  type="route"
+>
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
+  Navigation Link
+</a>
+`;
+
+exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c0 svg {
+  margin-right: 0;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+.c1 {
+  color: #57666E;
+}
+
+.c1:hover {
+  color: #000000;
+}
+
+.c1.active {
+  color: #0080A5;
+}
+
+.c1[disabled] {
+  pointer-events: none;
+}
+
+<a
+  class="c0 c1"
+  href="/test"
+  tabindex="0"
+  type="route"
+>
+  <svg
+    color="currentColor"
+    focusable="false"
+    height="16"
+    width="16"
+  />
 </a>
 `;
 
@@ -235,405 +414,38 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   margin-right: var(--spacing-1x);
 }
 
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
+.c0:focus {
   outline: none;
 }
 
-.c0.external:focus {
+.c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #0080A566;
   box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
 }
 
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
+.c1 {
+  color: #57666E;
 }
 
-.c0.external:visited {
-  color: #094c6c;
+.c1:hover {
+  color: #000000;
 }
 
-.c0.external:visited svg {
-  color: #094c6c;
+.c1.active {
+  color: #0080A5;
 }
 
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
+.c1[disabled] {
+  pointer-events: none;
 }
 
 <a
-  class="c0 navigation"
+  class="c0 c1"
   href="/test"
+  tabindex="0"
+  type="route"
 >
-  Navigation Link
-</a>
-`;
-
-exports[`Route Link only icon matches snapshot (Link) 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 svg {
-  margin-right: var(--spacing-1x);
-}
-
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
-  outline: none;
-}
-
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
-}
-
-<a
-  class="c0 navigation iconOnly"
-  href="/test"
->
-  <svg
-    color="currentColor"
-    focusable="false"
-    height="16"
-    width="16"
-  />
-</a>
-`;
-
-exports[`Route Link only icon matches snapshot (NavLink) 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 svg {
-  margin-right: var(--spacing-1x);
-}
-
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
-  outline: none;
-}
-
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
-}
-
-<a
-  class="c0 navigation iconOnly"
-  href="/test"
->
-  <svg
-    color="currentColor"
-    focusable="false"
-    height="16"
-    width="16"
-  />
-</a>
-`;
-
-exports[`Route Link with icon matches snapshot (Link) 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 svg {
-  margin-right: var(--spacing-1x);
-}
-
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
-  outline: none;
-}
-
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
-}
-
-<a
-  class="c0 navigation"
-  href="/test"
->
-  <svg
-    color="currentColor"
-    focusable="false"
-    height="16"
-    width="16"
-  />
-  Navigation Link
-</a>
-`;
-
-exports[`Route Link with icon matches snapshot (NavLink) 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-}
-
-.c0 svg {
-  margin-right: var(--spacing-1x);
-}
-
-.c0.iconOnly svg {
-  margin: 0;
-}
-
-.c0.external {
-  color: #0080a5;
-}
-
-.c0.external:focus {
-  outline: none;
-}
-
-.c0.external:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.external:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.c0.external:visited {
-  color: #094c6c;
-}
-
-.c0.external:visited svg {
-  color: #094c6c;
-}
-
-.c0.navigation {
-  color: #57666e;
-}
-
-.c0.navigation:focus {
-  outline: none;
-}
-
-.c0.navigation:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-.c0.navigation:hover {
-  color: #000;
-}
-
-.c0.navigation.active {
-  color: #0080a5;
-}
-
-<a
-  class="c0 navigation"
-  href="/test"
->
-  <svg
-    color="currentColor"
-    focusable="false"
-    height="16"
-    width="16"
-  />
   Navigation Link
 </a>
 `;

--- a/packages/react/src/components/route-link/route-link.tsx
+++ b/packages/react/src/components/route-link/route-link.tsx
@@ -1,8 +1,25 @@
 import React, { ReactElement } from 'react';
+import styled from 'styled-components';
 
 import { NavLink } from 'react-router-dom';
 import { Icon, IconName } from '../icon/icon';
 import { StyledLink } from './styles/styled-link';
+
+const Link = styled(StyledLink)`
+    color: ${({ disabled, theme }) => (disabled ? theme.greys['mid-grey'] : theme.greys['dark-grey'])};
+
+    &:hover {
+        ${({ disabled, theme }) => (disabled ? '' : `color: ${theme.greys.black};`)}
+    }
+
+    &.active {
+        ${({ disabled, theme }) => (disabled ? '' : `color: ${theme.main['primary-1.1']};`)}
+    }
+
+    &[disabled] {
+        pointer-events: none;
+    }
+`;
 
 type Nav = typeof NavLink;
 
@@ -23,27 +40,20 @@ interface LinkProps {
 export function RouteLink({
     className, disabled, exact, href, iconName, label, routerLink,
 }: LinkProps): ReactElement {
-    const getClassNames = (): string => ['navigation', className, !label && 'iconOnly'].filter(Boolean).join(' ');
-
-    return disabled ? (
-        <StyledLink
-            disabled={disabled}
-            aria-disabled="true"
-            className={getClassNames()}
-        >
-            {iconName && <Icon name={iconName} size="16" />}
-            {label}
-        </StyledLink>
-    ) : (
-        <StyledLink
+    return (
+        <Link
+            aria-disabled={disabled}
             as={routerLink}
-            className={getClassNames()}
+            className={className}
             disabled={disabled}
             exact={exact}
+            $hasLabel={!!label}
+            tabIndex={disabled ? -1 : 0}
             to={href}
+            type="route"
         >
             {iconName && <Icon name={iconName} size="16" />}
             {label}
-        </StyledLink>
+        </Link>
     );
 }

--- a/packages/react/src/components/route-link/styles/styled-link.tsx
+++ b/packages/react/src/components/route-link/styles/styled-link.tsx
@@ -1,11 +1,15 @@
 import { focus } from '@design-elements/utils/css-state';
 import styled from 'styled-components';
 
+type Type = 'external' | 'route';
+
 interface ContainerProps {
     activeClassName?: string;
     disabled?: boolean;
     exact?: boolean;
+    $hasLabel: boolean;
     to?: string;
+    type: Type;
 }
 
 export const StyledLink = styled.a<ContainerProps>`
@@ -15,42 +19,8 @@ export const StyledLink = styled.a<ContainerProps>`
     text-decoration: none;
 
     svg {
-        margin-right: var(--spacing-1x);
+        margin-right: ${({ $hasLabel }) => ($hasLabel ? 'var(--spacing-1x)' : '0')};
     }
 
-    &.iconOnly svg {
-        margin: 0;
-    }
-
-    &.external {
-        color: ${(props) => (props.disabled ? '#7fbfd2' : '#0080a5')};
-
-        ${focus};
-
-        &:hover {
-            ${(props) => (props.disabled ? '' : 'text-decoration: underline')};
-        }
-
-        &:visited {
-            color: #094c6c;
-
-            svg {
-                color: #094c6c;
-            }
-        }
-    }
-
-    &.navigation {
-        color: ${(props) => (props.disabled ? '#9ca7b4' : '#57666e')};
-
-        ${focus};
-
-        &:hover {
-            ${(props) => (props.disabled ? '' : 'color: #000;')}
-        }
-
-        &.active {
-            ${(props) => (props.disabled ? '' : 'color: #0080a5;')}
-        }
-    }
+    ${focus};
 `;

--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -786,7 +786,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
       <body>
         <div
           aria-hidden="false"
-          class="emjWqv"
+          class="ewYrHc"
           role="tooltip"
           style="position: absolute; left: 0px; top: 0px; transform: translate(12px, 0px);"
         >
@@ -988,7 +988,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
           <body>
             <div
               aria-hidden="false"
-              class="emjWqv"
+              class="ewYrHc"
               role="tooltip"
               style="position: absolute; left: 0px; top: 0px; transform: translate(12px, 0px);"
             >
@@ -1172,12 +1172,12 @@ exports[`Tooltip Has mobile styles 1`] = `
       <body>
         <div
           aria-hidden="false"
-          class="sc-jGVbCA emjWqv"
+          class="sc-fXoxut ewYrHc"
           role="tooltip"
           style="position: absolute; left: 0px; top: 0px; transform: translate(12px, 0px);"
         >
           <div
-            class="sc-bQdQlF iNCzKN"
+            class="sc-Fyfyc bXFsYG"
             data-placement="right"
             style="position: absolute; top: 0px; transform: translate(0px, 0px);"
           />


### PR DESCRIPTION
## PR Description
Ce PR refactor les links pour qu'ils utilisent le plus possible `styled-components` au lieu de des classNames. J'ai profité de l'occasion pour rename les tests.

Ce PR est en lien avec [ce PR](https://github.com/kronostechnologies/design-elements/pull/189).