### PR TITLE
refactor(Tooltip): Rename prop placement to desktopPlacement

### DIFF
--- a/packages/react/src/components/tooltip/tooltip.test.tsx
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx
@@ -1,48 +1,49 @@
-import { renderWithProviders } from '@design-elements/test-utils/renderer';
+import { mountWithProviders } from '@design-elements/test-utils/renderer';
 import React from 'react';
-import { Tooltip, TooltipArrow, TooltipContainer } from './tooltip';
+import { Tooltip } from './tooltip';
 
 jest.mock('@design-elements/utils/uuid');
 
 describe('Tooltip', () => {
     test('Has default desktop styles', () => {
-        const tree = renderWithProviders(
+        const tree = mountWithProviders(
             <Tooltip>
                 Test Content
             </Tooltip>,
+            { wrappingComponentProps: { device: 'desktop' } },
+        );
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('Has default desktop styles (defaultOpen)', () => {
+        const tree = mountWithProviders(
+            <Tooltip defaultOpen>
+                Test Content
+            </Tooltip>,
+            { wrappingComponentProps: { device: 'desktop' } },
         );
 
         expect(tree).toMatchSnapshot();
     });
 
     test('Has mobile styles', () => {
-        const tree = renderWithProviders(
+        const tree = mountWithProviders(
             <Tooltip>
                 Test Content
             </Tooltip>,
-            'mobile',
+            { wrappingComponentProps: { device: 'mobile' } },
         );
 
         expect(tree).toMatchSnapshot();
     });
 
-    test('TooltipContainer has desktop styles', () => {
-        const tree = renderWithProviders(
-            <TooltipContainer>
-                <TooltipArrow />
+    test('Has mobile styles (defaultOpen)', () => {
+        const tree = mountWithProviders(
+            <Tooltip defaultOpen>
                 Test Content
-            </TooltipContainer>,
-        );
-
-        expect(tree).toMatchSnapshot();
-    });
-
-    test('TooltipContainer has mobile styles', () => {
-        const tree = renderWithProviders(
-            <TooltipContainer isMobile>
-                <TooltipArrow />
-                Test Content
-            </TooltipContainer>,
+            </Tooltip>,
+            { wrappingComponentProps: { device: 'mobile' } },
         );
 
         expect(tree).toMatchSnapshot();

--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -1,6 +1,136 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tooltip Has default desktop styles 1`] = `
+exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
+.c1 {
+  background-color: #FFFFFF;
+  border: 1px solid #57666E;
+  border-radius: var(--border-radius);
+  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 0.875rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.25rem;
+  max-width: 327px;
+  min-height: 32px;
+  padding: var(--spacing-1x);
+  -webkit-transition: opacity 300ms;
+  transition: opacity 300ms;
+  z-index: 1000;
+}
+
+.c2 {
+  height: 1rem;
+  position: absolute;
+  width: 1rem;
+}
+
+.c2::before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  width: 0;
+}
+
+.c2::after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c2[data-placement*='bottom'] {
+  height: 1rem;
+  left: 0;
+  margin-top: -0.4rem;
+  top: 0;
+  width: 1rem;
+}
+
+.c2[data-placement*='bottom']::before {
+  border-color: transparent transparent #57666E transparent;
+  border-width: 0 0.5rem 0.4rem 0.5rem;
+  position: absolute;
+  top: -1px;
+}
+
+.c2[data-placement*='bottom']::after {
+  border-color: transparent transparent #FFFFFF transparent;
+  border-width: 0 0.5rem 0.4rem 0.5rem;
+}
+
+.c2[data-placement*='top'] {
+  bottom: 0;
+  height: 1rem;
+  left: 0;
+  margin-bottom: -1rem;
+  width: 1rem;
+}
+
+.c2[data-placement*='top']::before {
+  border-color: #57666E transparent transparent transparent;
+  border-width: 0.4rem 0.5rem 0 0.5rem;
+  position: absolute;
+  top: 1px;
+}
+
+.c2[data-placement*='top']::after {
+  border-color: #FFFFFF transparent transparent transparent;
+  border-width: 0.4rem 0.5rem 0 0.5rem;
+}
+
+.c2[data-placement*='right'] {
+  height: 1rem;
+  left: 0;
+  margin-left: -0.7rem;
+  width: 1rem;
+}
+
+.c2[data-placement*='right']::before {
+  border-color: transparent #57666E transparent transparent;
+  border-width: 0.5rem 0.4rem 0.5rem 0;
+}
+
+.c2[data-placement*='right']::after {
+  border-color: transparent #FFFFFF transparent transparent;
+  border-width: 0.5rem 0.4rem 0.5rem 0;
+  left: 6px;
+  top: 0;
+}
+
+.c2[data-placement*='left'] {
+  height: 1rem;
+  margin-right: -0.7rem;
+  right: 0;
+  width: 1rem;
+}
+
+.c2[data-placement*='left']::before {
+  border-color: transparent transparent transparent #57666E;
+  border-width: 0.5rem 0 0.5rem 0.4em;
+}
+
+.c2[data-placement*='left']::after {
+  border-color: transparent transparent transparent #FFFFFF;
+  border-width: 0.5rem 0 0.5rem 0.4em;
+  left: 3px;
+  top: 0;
+}
+
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -25,61 +155,39 @@ exports[`Tooltip Has default desktop styles 1`] = `
   box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
 }
 
-<span
-  class="c0"
-  id="tooltip-trigger-undefined"
-  tabindex="0"
+<Tooltip
+  defaultOpen={true}
 >
-  <svg
-    color="#57666E"
-    focusable="false"
-    height="16"
-    width="16"
-  />
-</span>
-`;
-
-exports[`Tooltip Has mobile styles 1`] = `
-.c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
-  width: fit-content;
-}
-
-.c0:focus {
-  outline: none;
-}
-
-.c0:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #0080A566;
-  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
-}
-
-<span
-  class="c0"
-  id="tooltip-trigger-undefined"
-  tabindex="0"
->
-  <svg
-    color="#57666E"
-    focusable="false"
-    height="24"
-    width="24"
-  />
-</span>
-`;
-
-exports[`Tooltip TooltipContainer has desktop styles 1`] = `
-.c0 {
+  <TooltipTrigger
+    closeOnReferenceHidden={true}
+    defaultTooltipShown={true}
+    delayHide={0}
+    delayShow={0}
+    followCursor={false}
+    modifiers={
+      Array [
+        Object {
+          "name": "offset",
+          "options": Object {
+            "offset": Array [
+              0,
+              12,
+            ],
+          },
+        },
+      ]
+    }
+    mutationObserverOptions={
+      Object {
+        "childList": true,
+        "subtree": true,
+      }
+    }
+    onVisibilityChange={[Function]}
+    placement="right"
+    portalContainer={
+      <body>
+        .c0 {
   background-color: #FFFFFF;
   border: 1px solid #57666E;
   border-radius: var(--border-radius);
@@ -210,17 +318,486 @@ exports[`Tooltip TooltipContainer has desktop styles 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-  />
-  Test Content
-</div>
+          aria-hidden="false"
+          class="c0"
+          role="tooltip"
+          style="position: absolute; left: 0px; top: 0px;"
+        >
+          <div
+            class="c1"
+            data-placement="right"
+          />
+          Test Content
+        </div>
+      </body>
+    }
+    tooltip={[Function]}
+    trigger="hover"
+    usePortal={true}
+  >
+    <Manager>
+      <Reference>
+        <styled.span
+          id="tooltip-trigger-undefined"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          tabIndex={0}
+        >
+          <span
+            className="c0"
+            id="tooltip-trigger-undefined"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex={0}
+          >
+            <Icon
+              color="#57666E"
+              name="helpCircle"
+              size="16"
+            >
+              <svg
+                color="#57666E"
+                focusable={false}
+                height="16"
+                width="16"
+              />
+            </Icon>
+          </span>
+        </styled.span>
+      </Reference>
+      <Portal
+        containerInfo={
+          <body>
+            <div
+              aria-hidden="false"
+              class="c1"
+              role="tooltip"
+              style="position: absolute; left: 0px; top: 0px;"
+            >
+              <div
+                class="c2"
+                data-placement="right"
+              />
+              Test Content
+            </div>
+          </body>
+        }
+      >
+        <Popper
+          defaultTooltipShown={true}
+          delayHide={0}
+          delayShow={0}
+          modifiers={
+            Array [
+              Object {
+                "enabled": false,
+                "fn": [Function],
+                "name": "followCursor",
+                "phase": "main",
+              },
+              Object {
+                "name": "offset",
+                "options": Object {
+                  "offset": Array [
+                    0,
+                    12,
+                  ],
+                },
+              },
+            ]
+          }
+          onVisibilityChange={[Function]}
+          placement="right"
+        >
+          <Tooltip
+            arrowProps={
+              Object {
+                "ref": [Function],
+                "style": undefined,
+              }
+            }
+            clearScheduled={[Function]}
+            closeOnReferenceHidden={true}
+            hideTooltip={[Function]}
+            innerRef={[Function]}
+            isReferenceHidden={null}
+            mutationObserverOptions={
+              Object {
+                "childList": true,
+                "subtree": true,
+              }
+            }
+            placement="right"
+            style={
+              Object {
+                "left": "0",
+                "position": "absolute",
+                "top": "0",
+              }
+            }
+            tooltip={[Function]}
+            trigger="hover"
+            update={[Function]}
+          >
+            <styled.div
+              aria-hidden={false}
+              isMobile={false}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              role="tooltip"
+              style={
+                Object {
+                  "left": "0",
+                  "position": "absolute",
+                  "top": "0",
+                }
+              }
+            >
+              <div
+                aria-hidden={false}
+                className="c1"
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
+                role="tooltip"
+                style={
+                  Object {
+                    "left": "0",
+                    "position": "absolute",
+                    "top": "0",
+                  }
+                }
+              >
+                <styled.div
+                  data-placement="right"
+                  style={Object {}}
+                >
+                  <div
+                    className="c2"
+                    data-placement="right"
+                    style={Object {}}
+                  />
+                </styled.div>
+                Test Content
+              </div>
+            </styled.div>
+          </Tooltip>
+        </Popper>
+      </Portal>
+    </Manager>
+  </TooltipTrigger>
+</Tooltip>
 `;
 
-exports[`Tooltip TooltipContainer has mobile styles 1`] = `
+exports[`Tooltip Has default desktop styles 1`] = `
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+<Tooltip>
+  <TooltipTrigger
+    closeOnReferenceHidden={true}
+    defaultTooltipShown={false}
+    delayHide={0}
+    delayShow={0}
+    followCursor={false}
+    modifiers={
+      Array [
+        Object {
+          "name": "offset",
+          "options": Object {
+            "offset": Array [
+              0,
+              12,
+            ],
+          },
+        },
+      ]
+    }
+    mutationObserverOptions={
+      Object {
+        "childList": true,
+        "subtree": true,
+      }
+    }
+    onVisibilityChange={[Function]}
+    placement="right"
+    portalContainer={<body />}
+    tooltip={[Function]}
+    trigger="hover"
+    usePortal={true}
+  >
+    <Manager>
+      <Reference>
+        <styled.span
+          id="tooltip-trigger-undefined"
+          onBlur={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          tabIndex={0}
+        >
+          <span
+            className="c0"
+            id="tooltip-trigger-undefined"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex={0}
+          >
+            <Icon
+              color="#57666E"
+              name="helpCircle"
+              size="16"
+            >
+              <svg
+                color="#57666E"
+                focusable={false}
+                height="16"
+                width="16"
+              />
+            </Icon>
+          </span>
+        </styled.span>
+      </Reference>
+    </Manager>
+  </TooltipTrigger>
+</Tooltip>
+`;
+
+exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
+.c1 {
+  background-color: #FFFFFF;
+  border: 1px solid #57666E;
+  border-radius: var(--border-radius);
+  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  font-size: 1rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  max-width: 327px;
+  min-height: 72px;
+  padding: var(--spacing-3x);
+  -webkit-transition: opacity 300ms;
+  transition: opacity 300ms;
+  z-index: 1000;
+}
+
+.c2 {
+  height: 1rem;
+  position: absolute;
+  width: 1rem;
+}
+
+.c2::before {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  width: 0;
+}
+
+.c2::after {
+  border-style: solid;
+  content: '';
+  display: block;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  width: 0;
+}
+
+.c2[data-placement*='bottom'] {
+  height: 1rem;
+  left: 0;
+  margin-top: -0.4rem;
+  top: 0;
+  width: 1rem;
+}
+
+.c2[data-placement*='bottom']::before {
+  border-color: transparent transparent #57666E transparent;
+  border-width: 0 0.5rem 0.4rem 0.5rem;
+  position: absolute;
+  top: -1px;
+}
+
+.c2[data-placement*='bottom']::after {
+  border-color: transparent transparent #FFFFFF transparent;
+  border-width: 0 0.5rem 0.4rem 0.5rem;
+}
+
+.c2[data-placement*='top'] {
+  bottom: 0;
+  height: 1rem;
+  left: 0;
+  margin-bottom: -1rem;
+  width: 1rem;
+}
+
+.c2[data-placement*='top']::before {
+  border-color: #57666E transparent transparent transparent;
+  border-width: 0.4rem 0.5rem 0 0.5rem;
+  position: absolute;
+  top: 1px;
+}
+
+.c2[data-placement*='top']::after {
+  border-color: #FFFFFF transparent transparent transparent;
+  border-width: 0.4rem 0.5rem 0 0.5rem;
+}
+
+.c2[data-placement*='right'] {
+  height: 1rem;
+  left: 0;
+  margin-left: -0.7rem;
+  width: 1rem;
+}
+
+.c2[data-placement*='right']::before {
+  border-color: transparent #57666E transparent transparent;
+  border-width: 0.5rem 0.4rem 0.5rem 0;
+}
+
+.c2[data-placement*='right']::after {
+  border-color: transparent #FFFFFF transparent transparent;
+  border-width: 0.5rem 0.4rem 0.5rem 0;
+  left: 6px;
+  top: 0;
+}
+
+.c2[data-placement*='left'] {
+  height: 1rem;
+  margin-right: -0.7rem;
+  right: 0;
+  width: 1rem;
+}
+
+.c2[data-placement*='left']::before {
+  border-color: transparent transparent transparent #57666E;
+  border-width: 0.5rem 0 0.5rem 0.4em;
+}
+
+.c2[data-placement*='left']::after {
+  border-color: transparent transparent transparent #FFFFFF;
+  border-width: 0.5rem 0 0.5rem 0.4em;
+  left: 3px;
+  top: 0;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+<Tooltip
+  defaultOpen={true}
+>
+  <TooltipTrigger
+    closeOnReferenceHidden={true}
+    defaultTooltipShown={true}
+    delayHide={0}
+    delayShow={0}
+    followCursor={false}
+    modifiers={
+      Array [
+        Object {
+          "name": "offset",
+          "options": Object {
+            "offset": Array [
+              0,
+              12,
+            ],
+          },
+        },
+      ]
+    }
+    mutationObserverOptions={
+      Object {
+        "childList": true,
+        "subtree": true,
+      }
+    }
+    onVisibilityChange={[Function]}
+    placement="top"
+    portalContainer={
+      <body>
+        <div
+          aria-hidden="false"
+          class="cLlhFg"
+          role="tooltip"
+          style="position: absolute; left: 0px; top: 0px; transform: translate(12px, 0px);"
+        >
+          <div
+            class="c2"
+            data-placement="right"
+            style="position: absolute; top: 0px; transform: translate(0px, 0px);"
+          />
+          Test Content
+        </div>
+        .c0 {
   background-color: #FFFFFF;
   border: 1px solid #57666E;
   border-radius: var(--border-radius);
@@ -351,11 +928,306 @@ exports[`Tooltip TooltipContainer has mobile styles 1`] = `
 }
 
 <div
-  class="c0"
->
-  <div
-    class="c1"
-  />
-  Test Content
-</div>
+          aria-hidden="false"
+          class="c0"
+          role="tooltip"
+          style="position: absolute; left: 0px; top: 0px;"
+        >
+          <div
+            class="c1"
+            data-placement="top"
+          />
+          Test Content
+        </div>
+      </body>
+    }
+    tooltip={[Function]}
+    trigger="click"
+    usePortal={true}
+  >
+    <Manager>
+      <Reference>
+        <styled.span
+          id="tooltip-trigger-undefined"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+          tabIndex={0}
+        >
+          <span
+            className="c0"
+            id="tooltip-trigger-undefined"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+            tabIndex={0}
+          >
+            <Icon
+              color="#57666E"
+              name="helpCircle"
+              size="24"
+            >
+              <svg
+                color="#57666E"
+                focusable={false}
+                height="24"
+                width="24"
+              />
+            </Icon>
+          </span>
+        </styled.span>
+      </Reference>
+      <Portal
+        containerInfo={
+          <body>
+            <div
+              aria-hidden="false"
+              class="cLlhFg"
+              role="tooltip"
+              style="position: absolute; left: 0px; top: 0px; transform: translate(12px, 0px);"
+            >
+              <div
+                class="c2"
+                data-placement="right"
+                style="position: absolute; top: 0px; transform: translate(0px, 0px);"
+              />
+              Test Content
+            </div>
+            <div
+              aria-hidden="false"
+              class="c1"
+              role="tooltip"
+              style="position: absolute; left: 0px; top: 0px;"
+            >
+              <div
+                class="c2"
+                data-placement="top"
+              />
+              Test Content
+            </div>
+          </body>
+        }
+      >
+        <Popper
+          defaultTooltipShown={true}
+          delayHide={0}
+          delayShow={0}
+          modifiers={
+            Array [
+              Object {
+                "enabled": false,
+                "fn": [Function],
+                "name": "followCursor",
+                "phase": "main",
+              },
+              Object {
+                "name": "offset",
+                "options": Object {
+                  "offset": Array [
+                    0,
+                    12,
+                  ],
+                },
+              },
+            ]
+          }
+          onVisibilityChange={[Function]}
+          placement="top"
+        >
+          <Tooltip
+            arrowProps={
+              Object {
+                "ref": [Function],
+                "style": undefined,
+              }
+            }
+            clearScheduled={[Function]}
+            closeOnReferenceHidden={true}
+            hideTooltip={[Function]}
+            innerRef={[Function]}
+            isReferenceHidden={null}
+            mutationObserverOptions={
+              Object {
+                "childList": true,
+                "subtree": true,
+              }
+            }
+            placement="top"
+            style={
+              Object {
+                "left": "0",
+                "position": "absolute",
+                "top": "0",
+              }
+            }
+            tooltip={[Function]}
+            trigger="click"
+            update={[Function]}
+          >
+            <styled.div
+              aria-hidden={false}
+              isMobile={true}
+              role="tooltip"
+              style={
+                Object {
+                  "left": "0",
+                  "position": "absolute",
+                  "top": "0",
+                }
+              }
+            >
+              <div
+                aria-hidden={false}
+                className="c1"
+                role="tooltip"
+                style={
+                  Object {
+                    "left": "0",
+                    "position": "absolute",
+                    "top": "0",
+                  }
+                }
+              >
+                <styled.div
+                  data-placement="top"
+                  style={Object {}}
+                >
+                  <div
+                    className="c2"
+                    data-placement="top"
+                    style={Object {}}
+                  />
+                </styled.div>
+                Test Content
+              </div>
+            </styled.div>
+          </Tooltip>
+        </Popper>
+      </Portal>
+    </Manager>
+  </TooltipTrigger>
+</Tooltip>
+`;
+
+exports[`Tooltip Has mobile styles 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+.c0:focus {
+  outline: none;
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #0080A566;
+  box-shadow: 0 0 0 3px #0080A566,0 0 0 1px #0080A5;
+}
+
+<Tooltip>
+  <TooltipTrigger
+    closeOnReferenceHidden={true}
+    defaultTooltipShown={false}
+    delayHide={0}
+    delayShow={0}
+    followCursor={false}
+    modifiers={
+      Array [
+        Object {
+          "name": "offset",
+          "options": Object {
+            "offset": Array [
+              0,
+              12,
+            ],
+          },
+        },
+      ]
+    }
+    mutationObserverOptions={
+      Object {
+        "childList": true,
+        "subtree": true,
+      }
+    }
+    onVisibilityChange={[Function]}
+    placement="top"
+    portalContainer={
+      <body>
+        <div
+          aria-hidden="false"
+          class="sc-bQdQlF cLlhFg"
+          role="tooltip"
+          style="position: absolute; left: 0px; top: 0px; transform: translate(12px, 0px);"
+        >
+          <div
+            class="sc-fXoxut iMOwUl"
+            data-placement="right"
+            style="position: absolute; top: 0px; transform: translate(0px, 0px);"
+          />
+          Test Content
+        </div>
+      </body>
+    }
+    tooltip={[Function]}
+    trigger="click"
+    usePortal={true}
+  >
+    <Manager>
+      <Reference>
+        <styled.span
+          id="tooltip-trigger-undefined"
+          onBlur={[Function]}
+          onClick={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+          tabIndex={0}
+        >
+          <span
+            className="c0"
+            id="tooltip-trigger-undefined"
+            onBlur={[Function]}
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+            tabIndex={0}
+          >
+            <Icon
+              color="#57666E"
+              name="helpCircle"
+              size="24"
+            >
+              <svg
+                color="#57666E"
+                focusable={false}
+                height="24"
+                width="24"
+              />
+            </Icon>
+          </span>
+        </styled.span>
+      </Reference>
+    </Manager>
+  </TooltipTrigger>
+</Tooltip>
 `;

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -145,7 +145,7 @@ const StyledSpan = styled.span`
     ${focus};
 `;
 
-type PlacementType = 'top' | 'right' | 'bottom' | 'left';
+export type TooltipPlacement = 'top' | 'right' | 'bottom' | 'left';
 
 interface TooltipProps {
     /** Tooltip text content */
@@ -156,7 +156,7 @@ interface TooltipProps {
      * Tooltip placement on desktop (always top on mobile)
      * @default right
      */
-    desktopPlacement?: PlacementType;
+    desktopPlacement?: TooltipPlacement;
 }
 
 const modifiers: TooltipTriggerProps['modifiers'] = [
@@ -168,7 +168,7 @@ const modifiers: TooltipTriggerProps['modifiers'] = [
     },
 ];
 
-export function Tooltip({ children, defaultOpen, desktopPlacement }: TooltipProps): ReactElement {
+export function Tooltip({ children, defaultOpen, desktopPlacement = 'right' }: TooltipProps): ReactElement {
     const { isMobile } = useDeviceContext();
     const Theme = useTheme();
     const tooltipId = useMemo(uuid, []);

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -42,7 +42,7 @@ export { RouteLink } from './components/route-link/route-link';
 export * from './components/progress/progress';
 export { SideDrawer } from './components/side-drawer/side-drawer';
 export { Banner } from './components/banner/banner';
-export { Tooltip } from './components/tooltip/tooltip';
+export * from './components/tooltip/tooltip';
 export * from './components/table/table';
 export { Modal } from './components/modal/modal';
 export { ModalDialog } from './components/modal/modal-dialog';

--- a/packages/react/src/test-utils/renderer.tsx
+++ b/packages/react/src/test-utils/renderer.tsx
@@ -19,11 +19,10 @@ export function AllProviders({ children, device }: { children: ReactElement, dev
 export function mountWithProviders<C extends Component, P = C['props'], S = C['state']>(
     component: ReactElement<P>,
     options: MountRendererProps = {},
-    device?: DeviceType,
 ): ReactWrapper<P, S, C> {
     return mount(component, {
-        wrappingComponent: ({ children }) => AllProviders({ children, device }),
         ...options,
+        wrappingComponent: AllProviders,
     });
 }
 

--- a/packages/storybook/stories/tooltip.stories.tsx
+++ b/packages/storybook/stories/tooltip.stories.tsx
@@ -1,6 +1,13 @@
-import { Tooltip } from '@equisoft/design-elements-react';
+import { Select, Tooltip, TooltipPlacement } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
-import React from 'react';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { DesktopDecorator } from './utils/device-context-decorator';
+
+const StyledDiv = styled.div`
+    height: 240px;
+    max-width: 200px;
+`;
 
 export default {
     title: 'Tooltip',
@@ -18,22 +25,33 @@ export const DefaultOpen: Story = () => (
         Tooltip Content
     </Tooltip>
 );
-export const desktopPlacement: Story = () => (
-    <>
-        <Tooltip desktopPlacement="top">
-            Tooltip Content
-        </Tooltip>
-        <br />
-        <Tooltip desktopPlacement="left">
-            Tooltip Content
-        </Tooltip>
-        <br />
-        <Tooltip desktopPlacement="right">
-            Tooltip Content
-        </Tooltip>
-        <br />
-        <Tooltip desktopPlacement="bottom">
-            Tooltip Content
-        </Tooltip>
-    </>
-);
+
+export const DesktopPlacement: Story = () => {
+    const [placement, setPlacement] = useState<TooltipPlacement>('right');
+
+    interface Placements {
+        value: TooltipPlacement;
+        label: TooltipPlacement;
+    }
+    const placements: Placements[] = [
+        { value: 'top', label: 'top' },
+        { value: 'right', label: 'right' },
+        { value: 'bottom', label: 'bottom' },
+        { value: 'left', label: 'left' },
+    ];
+
+    return (
+        <StyledDiv>
+            <Select
+                defaultValue="right"
+                label="Desktop placement"
+                options={placements}
+                onChange={(option) => setPlacement(option.value as TooltipPlacement)}
+            />
+            <Tooltip desktopPlacement={placement}>
+                Tooltip Content
+            </Tooltip>
+        </StyledDiv>
+    );
+};
+DesktopPlacement.decorators = [DesktopDecorator];


### PR DESCRIPTION
## PR Description
Ce PR renomme la prop `placement` du component Tooltip pour `desktopPlacement`. Ce changement vient retirer la confusion par rapport au placement du tooltip en mobile qui est toujours `top`. Aussi, j'ai profité de l'occasion pour refactor les tests de Tooltip.

Comme on renomme une prop, ce changement apporte un breaking change.

[Voir discussion dans cette PR](https://github.com/kronostechnologies/design-elements/pull/183)