### PR TITLE
feat(Table) Put background-color of striped table higher so :hover co…

### DIFF
--- a/packages/react/src/components/table/table-row.tsx
+++ b/packages/react/src/components/table/table-row.tsx
@@ -15,7 +15,11 @@ interface StyledTableRowProps {
 
 const StyledTableRow = styled.tr<StyledTableRowProps & { theme: Theme }>`
     border-top: 1px solid ${({ theme }) => theme.greys.grey};
-    ${({ clickable, theme }) => clickable && css`
+    ${({ error, striped, theme }) => striped && !error && css`
+        :nth-child(odd) {
+            background-color: ${theme.greys['colored-white']};
+        }
+    `} ${({ clickable, theme }) => clickable && css`
         :focus {
             border-color: ${theme.tokens['focus-border']};
             box-shadow: ${theme.tokens['focus-border-box-shadow-inset']};
@@ -26,11 +30,7 @@ const StyledTableRow = styled.tr<StyledTableRowProps & { theme: Theme }>`
             background-color: ${theme.greys.grey};
             cursor: pointer;
         }
-    `} ${({ error, striped, theme }) => striped && !error && css`
-        :nth-child(odd) {
-            background-color: ${theme.greys['colored-white']};
-        }
-    `} ${({ error, theme }) => error && css`
+    `}  ${({ error, theme }) => error && css`
         /* TODO fix with next thematization theme.notifications.error4 */
         background-color: #fcf8f9;
         border: 1px solid ${theme.notifications['error-2.1']};


### PR DESCRIPTION
Ce PR ajuste le component Table en mode "striped" pour que le background-color du :hover soit en priorité sur les rows plus foncées.
Les rows plus foncées ne changeait pas de couleur lors du :hover.

https://jira.equisoft.com/secure/RapidBoard.jspa?rapidView=786&projectKey=DS&view=detail&selectedIssue=DS-172&quickFilter=4537