### PR TITLE
fix(Search): Fix border right to appear in SearchContextual

### DIFF
--- a/packages/react/src/components/search/search-input.tsx
+++ b/packages/react/src/components/search/search-input.tsx
@@ -66,7 +66,7 @@ const Input = styled.input<InputProps>`
     ${({ theme }) => inputsStyle(theme)}
 
     border-radius: ${({ hasButton }) => (hasButton ? 'var(--border-radius) 0 0 var(--border-radius)' : '')};
-    border-right: 0;
+    border-right: ${({ hasButton }) => (hasButton ? '0' : '')};
     height: 2rem;
     padding-bottom: var(--spacing-half);
     padding-left: ${({ hasIcon }) => (hasIcon ? '1.75rem' : 'var(--spacing-1x)')};


### PR DESCRIPTION
Cette PR est pour fixer le border-right du SearchContextual qui n'apparaissait pas dans le UI. Le border-right devrais seulement disparaitre s'il y a un bouton comme dans le SearchGlobal.

https://jira.equisoft.com/secure/RapidBoard.jspa?rapidView=786&projectKey=DS&view=detail&selectedIssue=DS-171&quickFilter=4537