### PR TITLE
feat(NavMenu): Add exact prop to links

### DIFF
--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -43,6 +43,7 @@ const ListItemLink = styled(NavLink)<ListItemLinkProps>`
 `;
 
 export interface NavMenuOption {
+    exact?: boolean;
     href: string;
     // Option label, if not provided will be set with value
     label?: string;
@@ -123,6 +124,7 @@ export const NavMenu = forwardRef(({
                 <li key={option.id}>
                     <ListItemLink
                         data-testid={`listitem-${option.value}`}
+                        exact={option.exact}
                         innerRef={option.ref}
                         $device={device}
                         to={option.href}


### PR DESCRIPTION
## PR Description
Ajoute la prop `exact` aux `NavMenuOptions` afin de permettre d'utiliser la fonctionnalité `exact` des liens de `react-router-dom`.