### PR TITLE
refactor(Table): expose SortByColumnOptions through TableColumn inter…

### DIFF
--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useCallback, useEffect, useState } from 'react';
-import { CellProps, Column, Row, TableState, useSortBy, useTable } from 'react-table';
+import { CellProps, Column, Row, TableState, useSortBy, useTable, UseSortByColumnOptions } from 'react-table';
 import styled from 'styled-components';
 import { Theme } from '../../themes';
 import { DeviceType, useDeviceContext } from '../device-context-provider/device-context-provider';
@@ -18,7 +18,7 @@ interface StyledTableProps {
     rowSize?: RowSize;
 }
 
-type CustomColumn<T extends object> = Column<T> & {
+type CustomColumn<T extends object> = Column<T> & UseSortByColumnOptions<T> & {
     defaultSort?: ColumnSort;
     sortable?: boolean,
     textAlign?: string,

--- a/packages/storybook/stories/table.stories.tsx
+++ b/packages/storybook/stories/table.stories.tsx
@@ -260,7 +260,14 @@ export const SmallRows: Story = () => {
 };
 
 export const RowClickCallback: Story = () => {
-    const columns: TableColumn<Data> = [
+    interface DataWithHref {
+        column1: string;
+        column2: string;
+        column3: string;
+        href: string;
+    }
+
+    const columns: TableColumn<DataWithHref> = [
         {
             Header: 'Column 1',
             accessor: 'column1',
@@ -274,13 +281,6 @@ export const RowClickCallback: Story = () => {
             accessor: 'column3',
         },
     ];
-
-    interface DataWithHref {
-        column1: string;
-        column2: string;
-        column3: string;
-        href: string;
-    }
 
     const data: TableRow<DataWithHref>[] = [
         {


### PR DESCRIPTION
Ce PR expose les props de `UseSortByColumnOptions` via l'interface `TableColumn`. Cela va permettre d'utiliser les options suivantes dans les colonnes de tableau:
```ts
type UseSortByColumnOptions<D extends object> = Partial<{
    defaultCanSort: boolean;
    disableSortBy: boolean;
    sortDescFirst: boolean;
    sortInverted: boolean;
    sortType: SortByFn<D> | DefaultSortTypes | string;
}>;
```

Ce changements a été apporté car nous voulons utiliser `sortType` dans CPanel2.