### PR TITLE
refactor(Links): update focus styles

### DIFF
--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -26,6 +26,16 @@ exports[`External Link matches snapshot (disabled) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c2 {
   margin-left: var(--spacing-half);
   margin-right: 0;
@@ -85,6 +95,16 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
 }
 
 .c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #00629666;
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
@@ -170,6 +190,16 @@ exports[`External Link matches snapshot (only icon) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c2 {
   margin-right: var(--spacing-1x);
 }
@@ -244,6 +274,16 @@ exports[`External Link matches snapshot (without href) 1`] = `
 }
 
 .c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #00629666;
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
@@ -324,6 +364,16 @@ exports[`External Link matches snapshot 1`] = `
 }
 
 .c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #00629666;
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -26,6 +26,16 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c1 {
   color: #84C6EA;
   font-size: 0.875rem;
@@ -72,6 +82,16 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
 }
 
 .c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #00629666;
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
@@ -145,6 +165,16 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c1 {
   color: #006296;
   font-size: 0.875rem;
@@ -212,6 +242,16 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c1 {
   color: #006296;
   font-size: 0.875rem;
@@ -273,6 +313,16 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c1 {
   color: #84C6EA;
   font-size: 0.875rem;
@@ -319,6 +369,16 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
 }
 
 .c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #00629666;
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
@@ -392,6 +452,16 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
 }
 
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
 .c1 {
   color: #006296;
   font-size: 0.875rem;
@@ -454,6 +524,16 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
 }
 
 .c0:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #00629666;
+  box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;
+}
+
+.c0:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #00629666;
   box-shadow: 0 0 0 3px #00629666,0 0 0 1px #006296;

--- a/packages/react/src/components/route-link/styles/styled-link.tsx
+++ b/packages/react/src/components/route-link/styles/styled-link.tsx
@@ -20,4 +20,10 @@ export const StyledLink = styled.a<ContainerProps>`
     text-decoration: underline;
 
     ${focus};
+
+    &:focus:not(:focus-visible) {
+        box-shadow: none;
+    }
+
+    ${({ theme }) => focus({ theme }, false, '&:focus-visible')}
 `;


### PR DESCRIPTION
## PR Description
Le comportement pas défaut du focus d'un lien chrome est d'avoir seulement un style ajouté au focus clavier. En ce moment le focus sur les lien apparaît au clavier mais aussi lorsqu'on clique, ce qui est weird. J'ai fait quelques recherches et j'ai vu qu'il était possible d'utiliser `:focus-visible` pour cibler seulement le focus clavier.

Comme le selector n'est pas supporté par tous les browsers, j'ai ajouté un fallback au focus normal comme suggéré dans cet article: https://css-tricks.com/keyboard-only-focus-styles/

### Le support du selector actuel

![image](https://user-images.githubusercontent.com/53787300/120652633-f234bb00-c44d-11eb-80bc-91b074ec91c2.png)

