### PR TITLE
docs: improve components doc and samples' code

### DIFF
--- a/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Dropdown open with long text) 1`
       />
     </styled.li>
     <styled.li>
-      <Styled(Component)
+      <Styled(IconButton)
         aria-expanded={true}
         buttonType="tertiary"
         data-testid="ellipse-button"
@@ -35,7 +35,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Dropdown open with long text) 1`
         onClick={[Function]}
         type="button"
       />
-      <Styled(Component)
+      <Styled(NavMenu)
         data-testid="nav-menu"
         focusedValue=""
         hidden={false}
@@ -91,7 +91,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
       />
     </styled.li>
     <styled.li>
-      <Styled(Component)
+      <Styled(IconButton)
         aria-expanded={false}
         buttonType="tertiary"
         data-testid="ellipse-button"
@@ -100,7 +100,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
         onClick={[Function]}
         type="button"
       />
-      <Styled(Component)
+      <Styled(NavMenu)
         data-testid="nav-menu"
         focusedValue=""
         hidden={true}

--- a/packages/react/src/components/buttons/icon-button.tsx
+++ b/packages/react/src/components/buttons/icon-button.tsx
@@ -70,3 +70,5 @@ export const IconButton = forwardRef(({
         </StyledButton>
     );
 });
+
+IconButton.displayName = 'IconButton';

--- a/packages/react/src/components/carousel/carousel.tsx
+++ b/packages/react/src/components/carousel/carousel.tsx
@@ -94,6 +94,9 @@ function RightArrowIcon(): ReactElement {
 
 export interface CarouselProps extends Pick<AriaAttributes, 'aria-label'> {
     autoTransitionDelay?: number;
+    /**
+     * Anything React can render. Each root element will be rendered as a slide.
+     */
     children: ReactNode;
     className?: string;
     header: ReactNode;

--- a/packages/react/src/components/checkbox/checkbox.test.tsx.snap
+++ b/packages/react/src/components/checkbox/checkbox.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`Checkbox matches snapshot 1`] = `
   margin-top: var(--spacing-1x);
 }
 
-<ForwardRef
+<Checkbox
   label="Boat"
   name="vehicule"
   value="boat"
@@ -152,5 +152,5 @@ exports[`Checkbox matches snapshot 1`] = `
       </styled.span>
     </label>
   </styled.label>
-</ForwardRef>
+</Checkbox>
 `;

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -149,3 +149,5 @@ export const Checkbox: FunctionComponent<Props> = forwardRef(({
         </StyledLabel>
     );
 });
+
+Checkbox.displayName = 'Checkbox';

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -564,3 +564,5 @@ export const Datepicker = forwardRef(({
         </>
     );
 });
+
+Datepicker.displayName = 'Datepicker';

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -498,3 +498,5 @@ export const Listbox = forwardRef(({
         </Box>
     );
 });
+
+Listbox.displayName = 'Listbox';

--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -141,3 +141,5 @@ export const NavMenu = forwardRef(({
         </List>
     );
 });
+
+NavMenu.displayName = 'NavMenu';

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -138,3 +138,5 @@ export const TextInput = forwardRef(({
         </FieldContainer>
     );
 });
+
+TextInput.displayName = 'TextInput';

--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -17,11 +17,15 @@ export const decorators = [
 export const parameters = {
     options: {
         storySort: {
-            method: 'alphabetical'
-        }
+            method: 'alphabetical',
+        },
     },
     docs: {
         container: DocsContainer,
         page: DocsPage,
+        source: {
+            type: 'dynamic',
+            excludeDecorators: true,
+        },
     },
 };

--- a/packages/storybook/stories/add-button.stories.tsx
+++ b/packages/storybook/stories/add-button.stories.tsx
@@ -2,6 +2,7 @@ import { AddButton } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
 import { InvertedBackground } from './utils/inverted-background';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Add Button',
@@ -39,3 +40,4 @@ export const EventCallback: Story = () => (
         onClick={() => console.info('The button has been clicked!')}
     />
 );
+EventCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/buttons.stories.tsx
+++ b/packages/storybook/stories/buttons.stories.tsx
@@ -2,6 +2,7 @@ import { Button } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
 import { InvertedBackground } from './utils/inverted-background';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Button',
@@ -39,3 +40,4 @@ export const EventCallback: Story = () => (
         buttonType="primary"
     />
 );
+EventCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/checkbox-group.stories.tsx
+++ b/packages/storybook/stories/checkbox-group.stories.tsx
@@ -2,6 +2,7 @@ import { CheckboxGroup } from '@equisoft/design-elements-react';
 
 import { forceReRender, Story } from '@storybook/react';
 import React, { ChangeEvent } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Checkbox Group',
@@ -86,3 +87,4 @@ export const Callback: Story = () => {
         />
     );
 };
+Callback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/chooser-button-group.stories.tsx
+++ b/packages/storybook/stories/chooser-button-group.stories.tsx
@@ -1,6 +1,7 @@
 import { ChooserButtonGroup } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { useState } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 const maritalStatus = [
     { value: 'single', label: 'Single, living alone or with a roommate' },
@@ -68,3 +69,4 @@ export const WithCallback: Story = () => (
         options={ageRange}
     />
 );
+WithCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/chooser-card.stories.tsx
+++ b/packages/storybook/stories/chooser-card.stories.tsx
@@ -1,6 +1,7 @@
 import { ChooserCard } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { useState } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Chooser Card',
@@ -61,6 +62,7 @@ export const Controlled: Story = () => {
         </>
     );
 };
+Controlled.parameters = rawCodeParameters;
 
 export const Disabled: Story = () => (
     <ChooserCard name="story4" label="Card" value="card" disabled>
@@ -91,3 +93,4 @@ export const onChangeCallback: Story = () => (
         </ChooserCard>
     </>
 );
+onChangeCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/datepicker.stories.tsx
+++ b/packages/storybook/stories/datepicker.stories.tsx
@@ -2,6 +2,7 @@ import { Button, Datepicker, DatepickerHandles } from '@equisoft/design-elements
 import { Story } from '@storybook/react';
 import React, { FormEvent, useRef } from 'react';
 import styled from 'styled-components';
+import { rawCodeParameters } from './utils/parameters';
 import { decorateWith } from './utils/decorator';
 import { ShadowDomDecorator } from './utils/shadow-dom-decorator';
 
@@ -17,6 +18,7 @@ export default {
     title: 'Controls/Datepicker',
     component: Datepicker,
     decorators: [decorateWith(Container)],
+    parameters: rawCodeParameters,
 };
 
 export const Normal: Story = () => (

--- a/packages/storybook/stories/external-link.stories.tsx
+++ b/packages/storybook/stories/external-link.stories.tsx
@@ -1,6 +1,7 @@
 import { ExternalLink } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Navigation/External Link',
@@ -28,3 +29,4 @@ export const Disabled: Story = () => (
 export const WithCallback: Story = () => (
     <ExternalLink label="External Link" onClick={() => console.info('Link clicked')} />
 );
+WithCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/icon-button.stories.tsx
+++ b/packages/storybook/stories/icon-button.stories.tsx
@@ -2,6 +2,7 @@ import { IconButton } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
 import { InvertedBackground } from './utils/inverted-background';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Icon Button',
@@ -40,3 +41,4 @@ export const EventCallback: Story = () => (
         buttonType="primary"
     />
 );
+EventCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/inputs.stories.tsx
+++ b/packages/storybook/stories/inputs.stories.tsx
@@ -1,6 +1,7 @@
 import { TextInput } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Text Input',
@@ -43,6 +44,7 @@ export const Inputs: Story = () => (
         />
     </div>
 );
+
 export const DefaultValue: Story = () => (
     <TextInput
         disabled={false}
@@ -54,6 +56,7 @@ export const DefaultValue: Story = () => (
         validationErrorMessage="Error message"
     />
 );
+
 export const Required: Story = () => (
     <TextInput
         disabled={false}
@@ -65,6 +68,7 @@ export const Required: Story = () => (
         validationErrorMessage="This field is required"
     />
 );
+
 export const EventCallbacks: Story = () => (
     <TextInput
         disabled={false}
@@ -85,6 +89,8 @@ export const EventCallbacks: Story = () => (
         }}
     />
 );
+EventCallbacks.parameters = rawCodeParameters;
+
 export const PatternValidation: Story = () => (
     <TextInput
         disabled={false}
@@ -97,6 +103,7 @@ export const PatternValidation: Story = () => (
         validationErrorMessage="Please enter a valid phone number"
     />
 );
+
 export const Disabled: Story = () => (
     <TextInput
         disabled

--- a/packages/storybook/stories/money-input.stories.tsx
+++ b/packages/storybook/stories/money-input.stories.tsx
@@ -1,6 +1,7 @@
 import { Button, MoneyInput } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { useState } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Money Input',
@@ -17,18 +18,23 @@ export const Normal: Story = () => (
 export const EnglishLocale: Story = () => (
     <MoneyInput label="Choose a number" locale="en-CA" />
 );
+
 export const NoLabel: Story = () => (
     <MoneyInput />
 );
+
 export const Disabled: Story = () => (
     <MoneyInput disabled label="Entrez un montant" />
 );
+
 export const WithCurrency: Story = () => (
     <MoneyInput label="Entrez un montant" currency="USD" />
 );
+
 export const WithPrecision: Story = () => (
     <MoneyInput label="Entrez un montant" precision={0} />
 );
+
 export const ControlledWithValue: Story = () => {
     const [value, setValue] = useState<number | null>(350);
 
@@ -36,17 +42,21 @@ export const ControlledWithValue: Story = () => {
         <MoneyInput label="Entrez un montant" value={value} onChange={setValue} />
     );
 };
+ControlledWithValue.parameters = rawCodeParameters;
+
 export const Required: Story = () => (
     <form onSubmit={(event) => event.preventDefault()}>
         <MoneyInput required label="Entrez un montant" />
         <Button buttonType="primary" type="submit">Soumettre</Button>
     </form>
 );
+
 export const CustomErrorMessage: Story = () => (
     <form onSubmit={(event) => event.preventDefault()}>
         <MoneyInput required label="Entrez un montant" validationErrorMessage="Custom error message." />
     </form>
 );
+
 export const OnChangeCallback: Story = () => (
     <MoneyInput
         label="Entrez un montant"
@@ -56,3 +66,4 @@ export const OnChangeCallback: Story = () => (
         }}
     />
 );
+OnChangeCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/nav-menu-button.stories.tsx
+++ b/packages/storybook/stories/nav-menu-button.stories.tsx
@@ -2,14 +2,19 @@ import { ApplicationMenu, NavMenuButton } from '@equisoft/design-elements-react'
 import { Story } from '@storybook/react';
 import React from 'react';
 import styled from 'styled-components';
+import { decorateWith } from './utils/decorator';
 import { DesktopDecorator, MobileDecorator } from './utils/device-context-decorator';
 import { RouterDecorator } from './utils/router-decorator';
 import { ShadowDomDecorator } from './utils/shadow-dom-decorator';
 
+const StyledDiv = styled.div`
+    height: 180px;
+`;
+
 export default {
     title: 'Navigation/Nav Menu Button',
     component: NavMenuButton,
-    decorators: [RouterDecorator],
+    decorators: [RouterDecorator, decorateWith(StyledDiv)],
 };
 
 const options = [
@@ -35,41 +40,29 @@ const options = [
     },
 ];
 
-const StyledDiv = styled.div`
-    height: 180px;
-`;
-
 export const Desktop: Story = () => (
-    <StyledDiv>
-        <ApplicationMenu>
-            <NavMenuButton options={options}>Menu</NavMenuButton>
-        </ApplicationMenu>
-    </StyledDiv>
+    <ApplicationMenu>
+        <NavMenuButton options={options}>Menu</NavMenuButton>
+    </ApplicationMenu>
 );
 Desktop.decorators = [DesktopDecorator];
 
 export const DesktopInsideShadowDom: Story = () => (
-    <StyledDiv>
-        <ApplicationMenu>
-            <NavMenuButton options={options}>Menu</NavMenuButton>
-        </ApplicationMenu>
-    </StyledDiv>
+    <ApplicationMenu>
+        <NavMenuButton options={options}>Menu</NavMenuButton>
+    </ApplicationMenu>
 );
 DesktopInsideShadowDom.decorators = [DesktopDecorator, ShadowDomDecorator];
 
 export const Mobile: Story = () => (
-    <StyledDiv>
-        <ApplicationMenu>
-            <NavMenuButton options={options}>Menu</NavMenuButton>
-        </ApplicationMenu>
-    </StyledDiv>
+    <ApplicationMenu>
+        <NavMenuButton options={options}>Menu</NavMenuButton>
+    </ApplicationMenu>
 );
 Mobile.decorators = [MobileDecorator];
 
 export const DefaultOpen: Story = () => (
-    <StyledDiv>
-        <ApplicationMenu>
-            <NavMenuButton defaultOpen options={options}>Menu</NavMenuButton>
-        </ApplicationMenu>
-    </StyledDiv>
+    <ApplicationMenu>
+        <NavMenuButton defaultOpen options={options}>Menu</NavMenuButton>
+    </ApplicationMenu>
 );

--- a/packages/storybook/stories/pagination.stories.tsx
+++ b/packages/storybook/stories/pagination.stories.tsx
@@ -2,6 +2,7 @@ import { Pagination } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { useState } from 'react';
 import { DeviceContextDecorator } from './utils/device-context-decorator';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Navigation/Pagination',
@@ -29,15 +30,12 @@ export const ControlledPagination: Story = () => {
         />
     );
 };
+ControlledPagination.parameters = rawCodeParameters;
 
 export const WithoutResults: Story = () => (
-    <>
-        <Pagination totalPages={11} />
-    </>
+    <Pagination totalPages={11} />
 );
 
 export const With4DigitsNumberOfPages: Story = () => (
-    <>
-        <Pagination totalPages={1000} />
-    </>
+    <Pagination totalPages={1000} />
 );

--- a/packages/storybook/stories/phone-input.stories.tsx
+++ b/packages/storybook/stories/phone-input.stories.tsx
@@ -5,7 +5,7 @@ import { PhoneInput } from '@equisoft/design-elements-react';
 import { DesktopDecorator, MobileDecorator } from './utils/device-context-decorator';
 
 export default {
-    title: 'Phone Input',
+    title: 'Controls/Phone Input',
     component: PhoneInput,
 };
 

--- a/packages/storybook/stories/radio-button-group.stories.tsx
+++ b/packages/storybook/stories/radio-button-group.stories.tsx
@@ -1,6 +1,7 @@
 import { RadioButtonGroup } from '@equisoft/design-elements-react';
-import { forceReRender, Story } from '@storybook/react';
-import React, { ChangeEvent } from 'react';
+import { Story } from '@storybook/react';
+import React, { ChangeEvent, useState } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Radio Button Group',
@@ -14,22 +15,6 @@ const buttons = [
     { label: 'Saturn', value: 'saturn' },
 ];
 
-const buttonsControlled = [
-    { label: 'Blue', value: 'blue' },
-    { label: 'Red', value: 'red' },
-    { label: 'Green', value: 'green', disabled: true },
-    { label: 'Yellow', value: 'yellow' },
-];
-
-let checkedValue = 'red';
-
-function handleChange(event: ChangeEvent<HTMLInputElement>): void {
-    if (checkedValue !== event.target.value) {
-        checkedValue = event.target.value;
-    }
-    forceReRender();
-}
-
 export const Normal: Story = () => (
     <RadioButtonGroup label="Planets" groupName="planets" buttons={buttons} />
 );
@@ -42,15 +27,31 @@ export const DefaultChecked: Story = () => (
     <RadioButtonGroup groupName="cars" buttons={[{ label: 'Toyota', value: 'toyota', defaultChecked: true }]} />
 );
 
-export const Controlled: Story = () => (
-    <RadioButtonGroup
-        label="Colors"
-        groupName="colors"
-        checkedValue={checkedValue}
-        buttons={buttonsControlled}
-        onChange={handleChange}
-    />
-);
+export const Controlled: Story = () => {
+    const [value, setValue] = useState('red');
+
+    function handleChange(event: ChangeEvent<HTMLInputElement>): void {
+        if (value !== event.target.value) {
+            setValue(event.target.value);
+        }
+    }
+
+    return (
+        <RadioButtonGroup
+            label="Colors"
+            groupName="colors"
+            checkedValue={value}
+            buttons={[
+                { label: 'Blue', value: 'blue' },
+                { label: 'Red', value: 'red' },
+                { label: 'Green', value: 'green', disabled: true },
+                { label: 'Yellow', value: 'yellow' },
+            ]}
+            onChange={handleChange}
+        />
+    );
+};
+Controlled.parameters = rawCodeParameters;
 
 export const Callback: Story = () => {
     function onChange(event: React.ChangeEvent<HTMLInputElement>): void {
@@ -69,3 +70,4 @@ export const Callback: Story = () => {
         />
     );
 };
+Callback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/search-contextual.stories.tsx
+++ b/packages/storybook/stories/search-contextual.stories.tsx
@@ -1,6 +1,7 @@
 import { SearchContextual } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import * as React from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Search Contextual',
@@ -21,3 +22,4 @@ export const EventCallback: Story = () => (
         onReset={() => console.info('Reset clicked')}
     />
 );
+EventCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/search-global.stories.tsx
+++ b/packages/storybook/stories/search-global.stories.tsx
@@ -1,6 +1,7 @@
 import { SearchGlobal } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Search Global',
@@ -18,3 +19,4 @@ export const EventCallback: Story = () => (
         onSearch={(value) => console.info(`Searching for: ${value}`)}
     />
 );
+EventCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/select.stories.tsx
+++ b/packages/storybook/stories/select.stories.tsx
@@ -3,6 +3,7 @@ import { Story } from '@storybook/react';
 import React from 'react';
 import styled from 'styled-components';
 import { decorateWith } from './utils/decorator';
+import { rawCodeParameters } from './utils/parameters';
 import { ShadowDomDecorator } from './utils/shadow-dom-decorator';
 
 const Container = styled.div`
@@ -48,21 +49,26 @@ InsideShadowDom.decorators = [ShadowDomDecorator];
 export const CustomPlaceholder: Story = () => (
     <Select label="Select an option" options={provinces} placeholder="Custom placeholder" />
 );
+
 export const Disabled: Story = () => (
     <Select label="Select an option" options={provinces} disabled />
 );
+
 export const Invalid: Story = () => (
     <Select label="Select an option" options={provinces} valid={false} />
 );
+
 export const Required: Story = () => (
     <form onSubmit={(event) => event.preventDefault()}>
         <Select required label="Select an option" options={provinces} />
         <button type="submit">Submit</button>
     </form>
 );
+
 export const Searchable: Story = () => (
     <Select label="Select an option" options={provinces} searchable />
 );
+
 export const WithCallback: Story = () => (
     <Select
         label="Select an option"
@@ -70,15 +76,20 @@ export const WithCallback: Story = () => (
         onChange={(option) => console.info(`Label: ${option.label} | Value: ${option.value}`)}
     />
 );
+WithCallback.parameters = rawCodeParameters;
+
 export const WithDefaultValue: Story = () => (
     <Select label="Select an option" options={provinces} defaultValue="qc" />
 );
+
 export const WithoutLabel: Story = () => (
     <Select options={provinces} />
 );
+
 export const WithSkip: Story = () => (
     <Select label="Select an option" options={provinces} skipOption={skipOption} />
 );
+
 export const WithTwoItemsVisible: Story = () => (
     <Select label="Select an option" options={provinces} numberOfItemsVisible={2} />
 );

--- a/packages/storybook/stories/side-drawer.stories.tsx
+++ b/packages/storybook/stories/side-drawer.stories.tsx
@@ -2,6 +2,7 @@ import { Button, SideDrawer } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import { rawCodeParameters } from './utils/parameters';
 
 const Box = styled.div`
     background-color: #094c6c;
@@ -17,6 +18,7 @@ const Box = styled.div`
 export default {
     title: 'Structure/Side Drawer',
     component: SideDrawer,
+    parameters: rawCodeParameters,
 };
 
 export const Normal: Story = () => {

--- a/packages/storybook/stories/stepper-input.stories.tsx
+++ b/packages/storybook/stories/stepper-input.stories.tsx
@@ -1,6 +1,7 @@
 import { StepperInput } from '@equisoft/design-elements-react';
 import React, { useState } from 'react';
 import { Story } from '@storybook/react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Stepper input',
@@ -20,6 +21,7 @@ export const Controlled: Story = () => {
         <StepperInput label="Stepper input" onChange={setInputValue} value={inputValue} />
     );
 };
+Controlled.parameters = rawCodeParameters;
 
 export const WithDefaultValue: Story = () => (
     <StepperInput label="Stepper input" defaultValue={0} />
@@ -48,3 +50,4 @@ export const Disabled: Story = () => (
 export const WithOnChangeCallback: Story = () => (
     <StepperInput label="Stepper input" onChange={(value) => console.info(value)} />
 );
+WithOnChangeCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/table.stories.tsx
+++ b/packages/storybook/stories/table.stories.tsx
@@ -2,10 +2,12 @@ import { Table, TableColumn, TableRow, Tooltip } from '@equisoft/design-elements
 import { Story } from '@storybook/react';
 import React from 'react';
 import styled from 'styled-components';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Structure/Table',
     component: Table,
+    parameters: rawCodeParameters,
 };
 
 interface Data {
@@ -53,7 +55,9 @@ export const Normal: Story = () => {
 };
 
 export const WithColumnClassnames: Story = () => {
-    const StyledTable = styled(({ className, columns, data }) => <Table<Data> className={className} columns={columns} data={data} />)`
+    const StyledTable = styled(({ className, columns, data }) => (
+        <Table<Data> className={className} columns={columns} data={data} />
+    ))`
         .column-1 {
             box-sizing: border-box;
             width: 150px;
@@ -62,8 +66,7 @@ export const WithColumnClassnames: Story = () => {
         .column-2 {
             box-sizing: border-box;
             width: 300px;
-        }
-`;
+        }`;
 
     const columns: TableColumn<Data> = [
         {

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -1,10 +1,12 @@
 import { Card, Tab, Table, TableColumn, Tabs, TextArea } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Disclosure/Tabs',
     component: Tabs,
+    parameters: rawCodeParameters,
 };
 
 interface Data {

--- a/packages/storybook/stories/textarea.stories.tsx
+++ b/packages/storybook/stories/textarea.stories.tsx
@@ -1,6 +1,7 @@
 import { TextArea } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { SyntheticEvent } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Text Area',
@@ -40,6 +41,7 @@ export const EventCallbacks: Story = () => {
         />
     );
 };
+EventCallbacks.parameters = rawCodeParameters;
 
 export const Required: Story = () => (
     <TextArea

--- a/packages/storybook/stories/toggle-button-group.stories.tsx
+++ b/packages/storybook/stories/toggle-button-group.stories.tsx
@@ -1,6 +1,7 @@
 import { ToggleButtonGroup } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
 import React, { MouseEvent } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 const buttonGroup = [
     { label: 'Option 1', value: 'option1' },
@@ -44,3 +45,4 @@ export const WithCallback: Story = () => (
         onClick={(event: MouseEvent<HTMLButtonElement>) => console.info(`Toggled button value: ${event.currentTarget.value}`)}
     />
 );
+WithCallback.parameters = rawCodeParameters;

--- a/packages/storybook/stories/toggle-switch.stories.tsx
+++ b/packages/storybook/stories/toggle-switch.stories.tsx
@@ -1,10 +1,12 @@
 import { ToggleSwitch } from '@equisoft/design-elements-react';
-import React, { useState } from 'react';
 import { Story } from '@storybook/react';
+import React, { useState } from 'react';
+import { rawCodeParameters } from './utils/parameters';
 
 export default {
     title: 'Controls/Toggle Switch',
     component: ToggleSwitch,
+    parameters: rawCodeParameters,
 };
 
 export const Normal: Story = () => {

--- a/packages/storybook/stories/tooltip.stories.tsx
+++ b/packages/storybook/stories/tooltip.stories.tsx
@@ -3,6 +3,7 @@ import { Story } from '@storybook/react';
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { DesktopDecorator } from './utils/device-context-decorator';
+import { rawCodeParameters } from './utils/parameters';
 
 const StyledDiv = styled.div`
     height: 240px;
@@ -55,3 +56,4 @@ export const DesktopPlacement: Story = () => {
     );
 };
 DesktopPlacement.decorators = [DesktopDecorator];
+DesktopPlacement.parameters = rawCodeParameters;

--- a/packages/storybook/stories/utils/parameters.tsx
+++ b/packages/storybook/stories/utils/parameters.tsx
@@ -1,0 +1,7 @@
+export const rawCodeParameters = {
+    docs: {
+        source: {
+            type: 'code',
+        },
+    },
+};


### PR DESCRIPTION
L'ajout des displayNames est nécessaire pour les components qui utilisent `forwardRef`, sinon ça fait `[object Object]` dans les samples. Pour les autres, le plugin webpack suffit.