### PR TITLE
DS-216: feat: sticky column/row

### DIFF
--- a/packages/react/src/components/table/table.test.tsx
+++ b/packages/react/src/components/table/table.test.tsx
@@ -10,6 +10,12 @@ interface TestData {
     error?: boolean;
 }
 
+interface TestData3Columns {
+    column1: string;
+    column2: string;
+    column3: string;
+}
+
 type TablePropsLite = Omit<TableProps<TestData>, 'columns' | 'data'>;
 
 const data: TestData[] = [
@@ -76,6 +82,23 @@ const columnsSorted: TableColumn<TestData> = [
     },
 ];
 
+const columnsSticky: TableColumn<TestData3Columns> = [
+    {
+        Header: 'Column 1',
+        accessor: 'column1',
+        sticky: true,
+    },
+    {
+        Header: 'Column 2',
+        accessor: 'column2',
+        sticky: true,
+    },
+    {
+        Header: 'Column 3',
+        accessor: 'column3',
+    },
+];
+
 const errorData: TestData[] = [
     {
         column1: 'Hello',
@@ -90,6 +113,24 @@ const errorData: TestData[] = [
         column1: 'Hello',
         column2: 'World',
         error: true,
+    },
+];
+
+const stickyColumnsData: TestData3Columns[] = [
+    {
+        column1: 'Hello',
+        column2: 'Big',
+        column3: 'World',
+    },
+    {
+        column1: 'Hello',
+        column2: 'Big',
+        column3: 'World',
+    },
+    {
+        column1: 'Hello',
+        column2: 'Big',
+        column3: 'World',
     },
 ];
 
@@ -226,6 +267,18 @@ describe('Table', () => {
 
     test('has selectable rows styles', () => {
         const tree = renderWithProviders(<Table<TestData> selectableRows columns={columns} data={data} />);
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('has sticky header styles', () => {
+        const tree = renderWithProviders(<Table<TestData> stickyHeader columns={columns} data={data} />);
+
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('has sticky column styles', () => {
+        const tree = renderWithProviders(<Table<TestData3Columns> columns={columnsSticky} data={stickyColumnsData} />);
 
         expect(tree).toMatchSnapshot();
     });

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -3,26 +3,39 @@
 exports[`Table has clickable rows styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
 .c1:focus {
-  outline: none;
+  position: relative;
 }
 
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
+.c1:focus::after {
   box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+  content: "";
+  height: calc(100% + 3px);
+  left: 0;
+  outline: none;
+  position: absolute;
+  top: -2px;
+  width: 100%;
+  z-index: 3;
 }
 
 .c1:hover {
-  background-color: #DBDEE1;
   cursor: pointer;
+}
+
+.c1:hover td {
+  background-color: #DBDEE1;
+}
+
+.c1:not(:hover) td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -66,6 +79,7 @@ exports[`Table has clickable rows styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -73,6 +87,7 @@ exports[`Table has clickable rows styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -91,11 +106,13 @@ exports[`Table has clickable rows styles 1`] = `
       tabindex="0"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -108,11 +125,13 @@ exports[`Table has clickable rows styles 1`] = `
       tabindex="0"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -125,11 +144,13 @@ exports[`Table has clickable rows styles 1`] = `
       tabindex="0"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -142,21 +163,15 @@ exports[`Table has clickable rows styles 1`] = `
 exports[`Table has custom text alignment 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -200,6 +215,7 @@ exports[`Table has custom text alignment 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -208,6 +224,7 @@ exports[`Table has custom text alignment 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -226,12 +243,14 @@ exports[`Table has custom text alignment 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
         style="text-align:right"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
         style="text-align:center"
       >
@@ -244,12 +263,14 @@ exports[`Table has custom text alignment 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
         style="text-align:right"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
         style="text-align:center"
       >
@@ -262,12 +283,14 @@ exports[`Table has custom text alignment 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
         style="text-align:right"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
         style="text-align:center"
       >
@@ -281,21 +304,15 @@ exports[`Table has custom text alignment 1`] = `
 exports[`Table has desktop styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -339,6 +356,7 @@ exports[`Table has desktop styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -346,6 +364,7 @@ exports[`Table has desktop styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -363,11 +382,13 @@ exports[`Table has desktop styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -379,11 +400,13 @@ exports[`Table has desktop styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -395,11 +418,13 @@ exports[`Table has desktop styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -412,37 +437,46 @@ exports[`Table has desktop styles 1`] = `
 exports[`Table has error rows styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  position: relative;
   background-color: #fcf8f9;
-  border: 1px solid #CD2C23;
 }
 
-.c1:focus {
+.c1::after {
+  box-shadow: inset 0 0 0 1px #CD2C23;
+  content: "";
+  height: calc(100% + 1px);
+  left: 0;
   outline: none;
+  position: absolute;
+  width: 100%;
+  z-index: 3;
 }
 
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td:first-child::after {
+  border-left: 1px solid #CD2C23;
+  content: "";
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  z-index: 3;
+}
+
+.c1 td {
+  background-color: inherit;
 }
 
 .c2 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c2:focus {
-  outline: none;
-}
-
-.c2:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c2 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -486,6 +520,7 @@ exports[`Table has error rows styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -493,6 +528,7 @@ exports[`Table has error rows styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -510,11 +546,13 @@ exports[`Table has error rows styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -526,11 +564,13 @@ exports[`Table has error rows styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -542,11 +582,13 @@ exports[`Table has error rows styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -559,21 +601,15 @@ exports[`Table has error rows styles 1`] = `
 exports[`Table has mobile styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -617,6 +653,7 @@ exports[`Table has mobile styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -624,6 +661,7 @@ exports[`Table has mobile styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -641,11 +679,13 @@ exports[`Table has mobile styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -657,11 +697,13 @@ exports[`Table has mobile styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -673,11 +715,13 @@ exports[`Table has mobile styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -690,21 +734,15 @@ exports[`Table has mobile styles 1`] = `
 exports[`Table has rowNumbers styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -754,6 +792,7 @@ exports[`Table has rowNumbers styles 1`] = `
         scope="col"
       />
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -761,6 +800,7 @@ exports[`Table has rowNumbers styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -784,11 +824,13 @@ exports[`Table has rowNumbers styles 1`] = `
         1
       </td>
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -806,11 +848,13 @@ exports[`Table has rowNumbers styles 1`] = `
         2
       </td>
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -828,11 +872,13 @@ exports[`Table has rowNumbers styles 1`] = `
         3
       </td>
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -931,21 +977,15 @@ exports[`Table has selectable rows styles 1`] = `
 
 .c9 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c9:focus {
-  outline: none;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c9 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -1022,6 +1062,7 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1029,6 +1070,7 @@ exports[`Table has selectable rows styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1077,11 +1119,13 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </td>
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -1124,11 +1168,13 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </td>
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -1171,11 +1217,13 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </td>
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -1188,21 +1236,15 @@ exports[`Table has selectable rows styles 1`] = `
 exports[`Table has small rowSize styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -1246,6 +1288,7 @@ exports[`Table has small rowSize styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1253,6 +1296,7 @@ exports[`Table has small rowSize styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1270,11 +1314,13 @@ exports[`Table has small rowSize styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -1286,11 +1332,13 @@ exports[`Table has small rowSize styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -1302,11 +1350,13 @@ exports[`Table has small rowSize styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -1339,21 +1389,15 @@ exports[`Table has sorting styles 1`] = `
 
 .c3 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c3:focus {
-  outline: none;
-}
-
-.c3:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c3 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -1455,11 +1499,13 @@ exports[`Table has sorting styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -1471,11 +1517,13 @@ exports[`Table has sorting styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -1487,11 +1535,13 @@ exports[`Table has sorting styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -1501,28 +1551,23 @@ exports[`Table has sorting styles 1`] = `
 </table>
 `;
 
-exports[`Table has striped styles 1`] = `
+exports[`Table has sticky column styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:nth-child(odd) {
-  background-color: #FAFAFA;
+.c1 td {
+  background-color: inherit;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c2 {
+  position: -webkit-sticky;
+  position: sticky;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -1566,6 +1611,7 @@ exports[`Table has striped styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1573,6 +1619,309 @@ exports[`Table has striped styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
+        colspan="1"
+        role="columnheader"
+        scope="col"
+      >
+        Column 2
+      </th>
+      <th
+        class=""
+        colspan="1"
+        role="columnheader"
+        scope="col"
+      >
+        Column 3
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    role="rowgroup"
+  >
+    <tr
+      class="c1"
+      data-testid="table-row-0"
+      role="row"
+    >
+      <td
+        class="c2"
+        role="cell"
+      >
+        Hello
+      </td>
+      <td
+        class="c2"
+        role="cell"
+      >
+        Big
+      </td>
+      <td
+        class=""
+        role="cell"
+      >
+        World
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      data-testid="table-row-1"
+      role="row"
+    >
+      <td
+        class="c2"
+        role="cell"
+      >
+        Hello
+      </td>
+      <td
+        class="c2"
+        role="cell"
+      >
+        Big
+      </td>
+      <td
+        class=""
+        role="cell"
+      >
+        World
+      </td>
+    </tr>
+    <tr
+      class="c1"
+      data-testid="table-row-2"
+      role="row"
+    >
+      <td
+        class="c2"
+        role="cell"
+      >
+        Hello
+      </td>
+      <td
+        class="c2"
+        role="cell"
+      >
+        Big
+      </td>
+      <td
+        class=""
+        role="cell"
+      >
+        World
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Table has sticky header styles 1`] = `
+.c2 {
+  border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
+}
+
+.c2 td {
+  background-color: inherit;
+}
+
+.c1 {
+  background-color: #FFFFFF;
+  position: -webkit-sticky;
+  position: sticky;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 th {
+  font-weight: var(--font-semi-bold);
+  padding: var(--spacing-1x) var(--spacing-2x);
+}
+
+.c0 td {
+  padding: var(--spacing-2x);
+}
+
+.c0 th,
+.c0 td {
+  font-size: 0.875rem;
+  line-height: 24px;
+  margin: 0;
+  text-align: left;
+}
+
+.c0 th:last-child,
+.c0 td:last-child {
+  border-right: 0;
+}
+
+.c0 .eq-table__util-column {
+  box-sizing: border-box;
+  color: #60666E;
+  font-size: 0.75rem;
+  min-width: 40px;
+  text-align: center;
+  width: 40px;
+}
+
+<table
+  class="c0"
+  role="table"
+>
+  <thead>
+    <tr
+      role="row"
+    >
+      <th
+        class="c1"
+        colspan="1"
+        role="columnheader"
+        scope="col"
+      >
+        Column 1
+      </th>
+      <th
+        class="c1"
+        colspan="1"
+        role="columnheader"
+        scope="col"
+      >
+        Column 2
+      </th>
+    </tr>
+  </thead>
+  <tbody
+    role="rowgroup"
+  >
+    <tr
+      class="c2"
+      data-testid="table-row-0"
+      role="row"
+    >
+      <td
+        class=""
+        role="cell"
+      >
+        Hello
+      </td>
+      <td
+        class=""
+        role="cell"
+      >
+        World
+      </td>
+    </tr>
+    <tr
+      class="c2"
+      data-testid="table-row-1"
+      role="row"
+    >
+      <td
+        class=""
+        role="cell"
+      >
+        Hello
+      </td>
+      <td
+        class=""
+        role="cell"
+      >
+        Planet
+      </td>
+    </tr>
+    <tr
+      class="c2"
+      data-testid="table-row-2"
+      role="row"
+    >
+      <td
+        class=""
+        role="cell"
+      >
+        Hello
+      </td>
+      <td
+        class=""
+        role="cell"
+      >
+        Galaxy
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;
+
+exports[`Table has striped styles 1`] = `
+.c1 {
+  border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
+}
+
+.c1:nth-child(odd) {
+  background-color: #FAFAFA;
+}
+
+.c1 td {
+  background-color: inherit;
+}
+
+.c0 {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 th {
+  font-weight: var(--font-semi-bold);
+  padding: var(--spacing-1x) var(--spacing-2x);
+}
+
+.c0 td {
+  padding: var(--spacing-2x);
+}
+
+.c0 th,
+.c0 td {
+  font-size: 0.875rem;
+  line-height: 24px;
+  margin: 0;
+  text-align: left;
+}
+
+.c0 th:last-child,
+.c0 td:last-child {
+  border-right: 0;
+}
+
+.c0 .eq-table__util-column {
+  box-sizing: border-box;
+  color: #60666E;
+  font-size: 0.75rem;
+  min-width: 40px;
+  text-align: center;
+  width: 40px;
+}
+
+<table
+  class="c0"
+  role="table"
+>
+  <thead>
+    <tr
+      role="row"
+    >
+      <th
+        class=""
+        colspan="1"
+        role="columnheader"
+        scope="col"
+      >
+        Column 1
+      </th>
+      <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1590,11 +1939,13 @@ exports[`Table has striped styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -1606,11 +1957,13 @@ exports[`Table has striped styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -1622,11 +1975,13 @@ exports[`Table has striped styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy
@@ -1639,21 +1994,15 @@ exports[`Table has striped styles 1`] = `
 exports[`Table has tablet styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+  background-color: #FFFFFF;
 }
 
-.c1:focus {
-  outline: none;
-}
-
-.c1:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+.c1 td {
+  background-color: inherit;
 }
 
 .c0 {
   border-collapse: collapse;
-  border-spacing: 0;
   width: 100%;
 }
 
@@ -1697,6 +2046,7 @@ exports[`Table has tablet styles 1`] = `
       role="row"
     >
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1704,6 +2054,7 @@ exports[`Table has tablet styles 1`] = `
         Column 1
       </th>
       <th
+        class=""
         colspan="1"
         role="columnheader"
         scope="col"
@@ -1721,11 +2072,13 @@ exports[`Table has tablet styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         World
@@ -1737,11 +2090,13 @@ exports[`Table has tablet styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Planet
@@ -1753,11 +2108,13 @@ exports[`Table has tablet styles 1`] = `
       role="row"
     >
       <td
+        class=""
         role="cell"
       >
         Hello
       </td>
       <td
+        class=""
         role="cell"
       >
         Galaxy

--- a/packages/react/src/components/table/utils/table-utils.test.ts
+++ b/packages/react/src/components/table/utils/table-utils.test.ts
@@ -1,0 +1,123 @@
+import {
+    calculateStickyColumns, calculateStickyHeader,
+} from './table-utils';
+
+function getTable(): HTMLTableElement {
+    const table: HTMLTableElement = document.createElement('table');
+    const header: HTMLTableRowElement = document.createElement('tr');
+    header.appendChild(document.createElement('th'));
+    header.appendChild(document.createElement('th'));
+    header.appendChild(document.createElement('th'));
+    table.appendChild(header);
+    const row1: HTMLTableRowElement = document.createElement('tr');
+    row1.appendChild(document.createElement('td'));
+    row1.appendChild(document.createElement('td'));
+    row1.appendChild(document.createElement('td'));
+    table.appendChild(row1);
+    const row2: HTMLTableRowElement = document.createElement('tr');
+    row2.appendChild(document.createElement('td'));
+    row2.appendChild(document.createElement('td'));
+    row2.appendChild(document.createElement('td'));
+    table.appendChild(row2);
+    const row3: HTMLTableRowElement = document.createElement('tr');
+    row3.appendChild(document.createElement('td'));
+    row3.appendChild(document.createElement('td'));
+    row3.appendChild(document.createElement('td'));
+    table.appendChild(row3);
+    return table;
+}
+
+function getTableValues() : {
+    headerCells: HTMLCollectionOf<HTMLTableHeaderCellElement>,
+    rows: HTMLCollectionOf<HTMLTableRowElement>,
+    } {
+    const table = getTable();
+
+    return {
+        headerCells: table.getElementsByTagName('th'),
+        rows: table.getElementsByTagName('tr'),
+    };
+}
+
+describe('Table utils', () => {
+    describe('calculateStickyColumns', () => {
+        test('should set header cell z-index when column is sticky', () => {
+            const { headerCells, rows } = getTableValues();
+
+            calculateStickyColumns([true, true, false], headerCells, rows);
+
+            expect(headerCells[0].style.getPropertyValue('z-index')).toEqual('2');
+            expect(headerCells[1].style.getPropertyValue('z-index')).toEqual('2');
+            expect(headerCells[2].style.getPropertyValue('z-index')).toEqual('');
+        });
+
+        test('should set all rows column z-index when column is sticky', () => {
+            const { headerCells, rows } = getTableValues();
+
+            calculateStickyColumns([true, true, false], headerCells, rows);
+
+            Array.from(rows).forEach((row) => {
+                expect(row.cells[0].style.getPropertyValue('z-index')).toEqual('2');
+                expect(row.cells[1].style.getPropertyValue('z-index')).toEqual('2');
+                expect(row.cells[2].style.getPropertyValue('z-index')).toEqual('');
+            });
+        });
+
+        test('should set header cell left when column is sticky', () => {
+            const { headerCells, rows } = getTableValues();
+
+            calculateStickyColumns([true, true, false], headerCells, rows);
+
+            expect(headerCells[0].style.getPropertyValue('left')).toEqual('0px');
+            const left = headerCells[0].clientWidth;
+            expect(headerCells[1].style.getPropertyValue('left')).toEqual(`${left}px`);
+            expect(headerCells[2].style.getPropertyValue('left')).toEqual('');
+        });
+
+        test('should set all rows column left when column is sticky', () => {
+            const { headerCells, rows } = getTableValues();
+
+            calculateStickyColumns([true, true, false], headerCells, rows);
+
+            const left = headerCells[0].clientWidth;
+            Array.from(rows).forEach((row) => {
+                expect(row.cells[0].style.getPropertyValue('left')).toEqual('0px');
+                expect(row.cells[1].style.getPropertyValue('left')).toEqual(`${left}px`);
+                expect(row.cells[2].style.getPropertyValue('left')).toEqual('');
+            });
+        });
+    });
+
+    describe('calculateStickyRows', () => {
+        test('should set header cell z-index when header is sticky', () => {
+            const { headerCells } = getTableValues();
+
+            calculateStickyHeader([false, false, false], headerCells);
+
+            expect(headerCells[0].style.getPropertyValue('z-index')).toEqual('4');
+            expect(headerCells[1].style.getPropertyValue('z-index')).toEqual('4');
+            expect(headerCells[2].style.getPropertyValue('z-index')).toEqual('4');
+        });
+
+        test('should set header cell z-index higher when both header and column are sticky', () => {
+            const { headerCells } = getTableValues();
+
+            // first column is sticky
+            calculateStickyHeader([true, false, false], headerCells);
+
+            expect(headerCells[0].style.getPropertyValue('z-index')).toEqual('5');
+            expect(headerCells[1].style.getPropertyValue('z-index')).toEqual('4');
+            expect(headerCells[2].style.getPropertyValue('z-index')).toEqual('4');
+        });
+
+        test('should set header cell top when header is sticky', () => {
+            const { headerCells } = getTableValues();
+
+            calculateStickyHeader([true, false, false], headerCells);
+
+            expect(headerCells[0].style.getPropertyValue('top')).toEqual('0px');
+            expect(headerCells[1].style.getPropertyValue('top')).toEqual('0px');
+            expect(headerCells[2].style.getPropertyValue('top')).toEqual('0px');
+        });
+    });
+});

--- a/packages/react/src/components/table/utils/table-utils.ts
+++ b/packages/react/src/components/table/utils/table-utils.ts
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export function calculateStickyColumns(
+    stickyColumns: boolean[],
+    headerCells: HTMLCollectionOf<HTMLTableHeaderCellElement>,
+    rows: HTMLCollectionOf<HTMLTableRowElement>,
+): void {
+    let left = 0;
+    stickyColumns.forEach((sticky, index) => {
+        if (sticky) {
+            const headerCell = headerCells[index];
+            headerCell.style.setProperty('left', `${left}px`);
+            headerCell.style.setProperty('z-index', '2');
+
+            Array.from(rows).forEach((row) => {
+                row.cells[index].style.setProperty('left', `${left}px`);
+                row.cells[index].style.setProperty('z-index', '2');
+            });
+
+            left += headerCell.getBoundingClientRect().width;
+        }
+    });
+}
+
+export function calculateStickyHeader(
+    stickyColumns: boolean[],
+    headerCells: HTMLCollectionOf<HTMLTableHeaderCellElement>,
+): void {
+    Array.from(headerCells).forEach((headerCell, index) => {
+        headerCell.style.setProperty('top', '0px');
+        headerCell.style.setProperty('z-index', stickyColumns[index] ? '5' : '4');
+    });
+}
+
+export function calculateStickyPosition(
+    stickyColumns: boolean[],
+    stickyHeader: boolean,
+    tableRef: React.RefObject<HTMLTableElement>,
+): void {
+    if (tableRef.current === null) {
+        return;
+    }
+    const headerCells = tableRef.current.getElementsByTagName('th');
+    const rows = tableRef.current.getElementsByTagName('tr');
+
+    calculateStickyColumns(stickyColumns, headerCells, rows);
+    if (stickyHeader) {
+        calculateStickyHeader(stickyColumns, headerCells);
+    }
+}

--- a/packages/storybook/stories/table.stories.tsx
+++ b/packages/storybook/stories/table.stories.tsx
@@ -476,3 +476,256 @@ export const SelectableRows: Story = () => {
         <Table<SelectableData> selectableRows columns={columns} data={data} onSelectedRowsChange={console.info} />
     );
 };
+
+interface StickyData {
+    column1: string;
+    column2: string;
+    column3: string;
+    column4: string;
+    column5: string;
+    column6: string;
+    column7: string;
+    column8: string;
+    column9: string;
+    column10: string;
+    column11: string;
+    column12: string;
+    column13: string;
+    column14: string;
+    column15: string,
+}
+
+export const Sticky: Story = () => {
+    const columns: TableColumn<StickyData> = [
+        {
+            Header: 'Column 1',
+            accessor: 'column1',
+            sticky: true,
+        },
+        {
+            Header: 'Column 2',
+            accessor: 'column2',
+            sticky: true,
+        },
+        {
+            Header: 'Column 3',
+            accessor: 'column3',
+        },
+        {
+            Header: 'Column 4',
+            accessor: 'column4',
+        },
+        {
+            Header: 'Column 5',
+            accessor: 'column5',
+        },
+        {
+            Header: 'Column 6',
+            accessor: 'column6',
+        },
+        {
+            Header: 'Column 7',
+            accessor: 'column7',
+        },
+        {
+            Header: 'Column 8',
+            accessor: 'column8',
+        },
+        {
+            Header: 'Column 9',
+            accessor: 'column9',
+        },
+        {
+            Header: 'Column 10',
+            accessor: 'column10',
+        },
+        {
+            Header: 'Column 11',
+            accessor: 'column11',
+        },
+        {
+            Header: 'Column 12',
+            accessor: 'column12',
+        },
+        {
+            Header: 'Column 13',
+            accessor: 'column13',
+        },
+        {
+            Header: 'Column 14',
+            accessor: 'column14',
+        },
+        {
+            Header: 'Column 15',
+            accessor: 'column15',
+        },
+    ];
+
+    const data: TableRow<StickyData>[] = [
+        {
+            column1: 'a',
+            column2: 'a',
+            column3: 'a',
+            column4: 'a',
+            column5: 'a',
+            column6: 'a',
+            column7: 'a',
+            column8: 'a',
+            column9: 'a',
+            column10: 'a',
+            column11: 'a',
+            column12: 'a',
+            column13: 'a',
+            column14: 'a',
+            column15: 'a',
+        },
+        {
+            column1: 'b',
+            column2: 'b',
+            column3: 'b',
+            column4: 'b',
+            column5: 'b',
+            column6: 'b',
+            column7: 'b',
+            column8: 'b',
+            column9: 'b',
+            column10: 'b',
+            column11: 'b',
+            column12: 'b',
+            column13: 'b',
+            column14: 'b',
+            column15: 'b',
+        },
+        {
+            column1: 'c',
+            column2: 'c',
+            column3: 'c',
+            column4: 'c',
+            column5: 'c',
+            column6: 'c',
+            column7: 'c',
+            column8: 'c',
+            column9: 'c',
+            column10: 'c',
+            column11: 'c',
+            column12: 'c',
+            column13: 'c',
+            column14: 'c',
+            column15: 'c',
+            error: true,
+        },
+        {
+            column1: 'd',
+            column2: 'd',
+            column3: 'd',
+            column4: 'd',
+            column5: 'd',
+            column6: 'd',
+            column7: 'd',
+            column8: 'd',
+            column9: 'd',
+            column10: 'd',
+            column11: 'd',
+            column12: 'd',
+            column13: 'd',
+            column14: 'd',
+            column15: 'd',
+        },
+        {
+            column1: 'e',
+            column2: 'e',
+            column3: 'e',
+            column4: 'e',
+            column5: 'e',
+            column6: 'e',
+            column7: 'e',
+            column8: 'e',
+            column9: 'e',
+            column10: 'e',
+            column11: 'e',
+            column12: 'e',
+            column13: 'e',
+            column14: 'e',
+            column15: 'e',
+        },
+        {
+            column1: 'f',
+            column2: 'f',
+            column3: 'f',
+            column4: 'f',
+            column5: 'f',
+            column6: 'f',
+            column7: 'f',
+            column8: 'f',
+            column9: 'f',
+            column10: 'f',
+            column11: 'f',
+            column12: 'f',
+            column13: 'f',
+            column14: 'f',
+            column15: 'f',
+        },
+        {
+            column1: 'g',
+            column2: 'g',
+            column3: 'g',
+            column4: 'g',
+            column5: 'g',
+            column6: 'g',
+            column7: 'g',
+            column8: 'g',
+            column9: 'g',
+            column10: 'g',
+            column11: 'g',
+            column12: 'g',
+            column13: 'g',
+            column14: 'g',
+            column15: 'g',
+        },
+        {
+            column1: 'h',
+            column2: 'h',
+            column3: 'h',
+            column4: 'h',
+            column5: 'h',
+            column6: 'h',
+            column7: 'h',
+            column8: 'h',
+            column9: 'h',
+            column10: 'h',
+            column11: 'h',
+            column12: 'h',
+            column13: 'h',
+            column14: 'h',
+            column15: 'h',
+        },
+        {
+            column1: 'i',
+            column2: 'i',
+            column3: 'i',
+            column4: 'i',
+            column5: 'i',
+            column6: 'i',
+            column7: 'i',
+            column8: 'i',
+            column9: 'i',
+            column10: 'i',
+            column11: 'i',
+            column12: 'i',
+            column13: 'i',
+            column14: 'i',
+            column15: 'i',
+        },
+    ];
+
+    const Wrap = styled.div`
+        height: 200px;
+        overflow: scroll;
+`;
+
+    return (
+        <Wrap>
+            <Table columns={columns} data={data} stickyHeader onRowClick={(row) => console.info('row: ', row)} />
+        </Wrap>
+    );
+};


### PR DESCRIPTION
## PR Description
Permet d'avoir des colonnes ou le header sticky.
- Seulement le header peut être sticky, et non pas les rows. Ca répond quand même au besoin de centralize;
- Autant de colonnes que désirées peuvent être sticky à gauche;

## GitHub issues resolved by PR
https://jira.equisoft.com/browse/DS-216

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] All GitHub checks are successful.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] All GitHub checks are successful.
