### PR TITLE
DS-498 [Breaking Change] feat(ApplicationMenu): child container takes all available width

### DIFF
--- a/packages/react/src/components/application-menu/application-menu-content.tsx
+++ b/packages/react/src/components/application-menu/application-menu-content.tsx
@@ -20,6 +20,8 @@ const Container = styled.div`
     align-items: center;
     color: ${(props) => props.theme.greys.white};
     display: flex;
+    justify-content: flex-end;
+    width: 100%;
 
     > * + * {
         margin-left: var(--spacing-1x);

--- a/packages/react/src/components/application-menu/application-menu.test.tsx.snap
+++ b/packages/react/src/components/application-menu/application-menu.test.tsx.snap
@@ -11,6 +11,11 @@ exports[`Application Menu Matches the snapshot (desktop) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  width: 100%;
 }
 
 .c2 > * + * {


### PR DESCRIPTION
## PR Description
Ce PR permet au contenu dans `ApplicationMenu` de prendre toute la largeur disponible. C'est un breaking change car ça peut impacter l'affichage du contenu.
DS-498
