### PR TITLE
DS-508 feat(NavMenu): allow usage without react-router

### DIFF
--- a/packages/react/src/components/nav-menu/nav-menu.test.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { mountWithProviders, renderWithTheme } from '../../test-utils/renderer';
-import { NavMenu, NavMenuOption } from './nav-menu';
+import { NavMenu, NavMenuOption, HtmlLink, ReactRouterNavLink } from './nav-menu';
 
 jest.mock('../../utils/uuid');
 
@@ -45,6 +45,21 @@ const optionWithEndIcon: NavMenuOption[] = [
         value: 'optionA',
         href: '/testA',
         endIcon: 'home',
+    },
+];
+
+const optionsWithHtmlLinks: NavMenuOption[] = [
+    {
+        label: 'Option A',
+        value: 'optionA',
+        href: '/testA',
+        isHtmlLink: true,
+    },
+    {
+        label: 'Option B',
+        value: 'optionB',
+        href: '/testB',
+        isHtmlLink: true,
     },
 ];
 
@@ -90,6 +105,18 @@ describe('NavMenu', () => {
         const wrapper = shallow(<NavMenu options={optionWithEndIcon} />);
 
         expect(getByTestId(wrapper, 'end-icon').exists()).toBe(true);
+    });
+
+    test('Should use react-router links by default', () => {
+        const wrapper = shallow(<NavMenu options={options} />);
+
+        expect(wrapper.find(ReactRouterNavLink).length).toBe(options.length);
+    });
+
+    test('Should use html links when isHtmlLink is set to true', () => {
+        const wrapper = shallow(<NavMenu options={optionsWithHtmlLinks} />);
+
+        expect(wrapper.find(HtmlLink).length).toBe(optionsWithHtmlLinks.length);
     });
 
     test('Should update focused value when focusedValue prop changes', () => {

--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, KeyboardEvent, ReactElement, Ref, RefObject, useEffect, useMemo } from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Icon, IconName } from '../icon/icon';
 import { v4 as uuid } from '../../utils/uuid';
 import { DeviceContextProps, useDeviceContext } from '../device-context-provider/device-context-provider';
@@ -18,7 +18,7 @@ const List = styled.ul`
     width: 100%;
 `;
 
-interface ListItemLinkProps extends NavLinkProps {
+interface LinkProps {
     $device: DeviceContextProps;
 }
 
@@ -41,7 +41,7 @@ const EndIcon = styled(Icon).attrs({ size: iconSize })`
     min-width: ${iconSize}px;
 `;
 
-const ListItemLink = styled(NavLink)<ListItemLinkProps>`
+const linkStyles = css<LinkProps>`
     align-items: center;
     color: ${({ theme }) => theme.greys.black};
     display: flex;
@@ -66,10 +66,19 @@ const ListItemLink = styled(NavLink)<ListItemLinkProps>`
     }
 `;
 
+export const ReactRouterNavLink = styled(NavLink)<LinkProps & NavLinkProps>`
+    ${linkStyles};
+`;
+
+export const HtmlLink = styled.a<LinkProps>`
+    ${linkStyles};
+`;
+
 export interface NavMenuOption {
     endIcon?: IconName;
     exact?: boolean;
     href: string;
+    isHtmlLink?: boolean;
     // Option label, if not provided will be set with value
     label?: string;
     startIcon?: IconName;
@@ -149,23 +158,45 @@ export const NavMenu = forwardRef(({
             ref={ref}
             hidden={hidden}
         >
-            {list.map((option) => (
-                <li key={option.id}>
-                    <ListItemLink
-                        data-testid={`listitem-${option.value}`}
-                        exact={option.exact}
-                        innerRef={option.ref}
-                        $device={device}
-                        to={option.href}
-                        onClick={() => onChange?.(option)}
-                        onKeyDown={(event) => handleKeyDown(event, option)}
-                    >
+            {list.map((option) => {
+                const testId = `listitem-${option.value}`;
+                const label = (
+                    <>
                         {option.startIcon && <StartIcon data-testid="start-icon" name={option.startIcon} />}
                         <Label>{option.label || option.value}</Label>
                         {option.endIcon && <EndIcon data-testid="end-icon" name={option.endIcon} />}
-                    </ListItemLink>
-                </li>
-            ))}
+                    </>
+                );
+
+                return (
+                    <li key={option.id}>
+                        {option.isHtmlLink ? (
+                            <HtmlLink
+                                data-testid={testId}
+                                ref={option.ref}
+                                $device={device}
+                                href={option.href}
+                                onClick={() => onChange?.(option)}
+                                onKeyDown={(event) => handleKeyDown(event, option)}
+                            >
+                                {label}
+                            </HtmlLink>
+                        ) : (
+                            <ReactRouterNavLink
+                                data-testid={testId}
+                                exact={option.exact}
+                                innerRef={option.ref}
+                                $device={device}
+                                to={option.href}
+                                onClick={() => onChange?.(option)}
+                                onKeyDown={(event) => handleKeyDown(event, option)}
+                            >
+                                {label}
+                            </ReactRouterNavLink>
+                        )}
+                    </li>
+                );
+            })}
         </List>
     );
 });

--- a/packages/storybook/stories/nav-menu-button.stories.tsx
+++ b/packages/storybook/stories/nav-menu-button.stories.tsx
@@ -61,6 +61,21 @@ const optionsWithIcons: NavMenuOption[] = [
     },
 ];
 
+const optionsWithHtmlLinks: NavMenuOption[] = [
+    {
+        label: 'Option A',
+        value: 'optionA',
+        href: '/testa',
+        isHtmlLink: true,
+    },
+    {
+        label: 'Option B',
+        value: 'optionB',
+        href: '/testb',
+        isHtmlLink: true,
+    },
+];
+
 export const Desktop: Story = () => (
     <ApplicationMenu>
         <NavMenuButton options={options}>Menu</NavMenuButton>
@@ -109,5 +124,11 @@ export const DefaultOpen: Story = () => (
 export const WithOptionIcons: Story = () => (
     <ApplicationMenu>
         <NavMenuButton options={optionsWithIcons}>Menu</NavMenuButton>
+    </ApplicationMenu>
+);
+
+export const WithHtmlLinks: Story = () => (
+    <ApplicationMenu>
+        <NavMenuButton options={optionsWithHtmlLinks}>Menu</NavMenuButton>
     </ApplicationMenu>
 );


### PR DESCRIPTION
## PR Description
Cette PR permet d'utiliser le NavMenu sans avoir besoin de `react-router`. La solution est de changer entre des liens `react-router` et des liens HTML standards via une prop `isHtmlLink`.

DS-508