### PR TITLE
feat(NavMenu): add option.onClick callback 

### DIFF
--- a/packages/react/src/components/nav-menu/nav-menu.test.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.test.tsx
@@ -130,6 +130,46 @@ describe('NavMenu', () => {
         expect(document.activeElement).toBe(getByTestId(wrapper, 'listitem-optionB').getDOMNode());
     });
 
+    test('calls option.onClick when an htmlLink is clicked', () => {
+        const onClick = jest.fn();
+        const wrapper = mountWithProviders(
+            <NavMenu options={[
+                {
+                    label: 'Option A',
+                    value: 'optionA',
+                    href: '/testA',
+                    onClick,
+                    isHtmlLink: true,
+                },
+            ]}
+            />,
+        );
+
+        getByTestId(wrapper, 'listitem-optionA').simulate('click');
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    test('calls option.onClick when an ReactRouterNavLink is clicked', () => {
+        const onClick = jest.fn();
+        const wrapper = mountWithProviders(
+            <NavMenu options={[
+                {
+                    label: 'Option A',
+                    value: 'optionA',
+                    href: '/testA',
+                    onClick,
+                    isHtmlLink: false,
+                },
+            ]}
+            />,
+        );
+
+        getByTestId(wrapper, 'listitem-optionA').simulate('click');
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
     test('Matches the snapshot', () => {
         const tree = renderWithTheme(
             <Router>

--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -1,4 +1,13 @@
-import React, { forwardRef, KeyboardEvent, ReactElement, Ref, RefObject, useEffect, useMemo } from 'react';
+import React, {
+    forwardRef,
+    KeyboardEvent,
+    MouseEvent,
+    ReactElement,
+    Ref,
+    RefObject,
+    useEffect,
+    useMemo,
+} from 'react';
 import { NavLink, NavLinkProps } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { Icon, IconName } from '../icon/icon';
@@ -83,6 +92,7 @@ export interface NavMenuOption {
     label?: string;
     startIcon?: IconName;
     value: string;
+    onClick?(event: MouseEvent<HTMLAnchorElement>): void;
 }
 
 interface ListOption extends NavMenuOption {
@@ -168,6 +178,11 @@ export const NavMenu = forwardRef(({
                     </>
                 );
 
+                function handleOnClick(e: MouseEvent<HTMLAnchorElement>): void {
+                    onChange?.(option);
+                    option.onClick?.(e);
+                }
+
                 return (
                     <li key={option.id}>
                         {option.isHtmlLink ? (
@@ -176,7 +191,7 @@ export const NavMenu = forwardRef(({
                                 ref={option.ref}
                                 $device={device}
                                 href={option.href}
-                                onClick={() => onChange?.(option)}
+                                onClick={handleOnClick}
                                 onKeyDown={(event) => handleKeyDown(event, option)}
                             >
                                 {label}
@@ -188,7 +203,7 @@ export const NavMenu = forwardRef(({
                                 innerRef={option.ref}
                                 $device={device}
                                 to={option.href}
-                                onClick={() => onChange?.(option)}
+                                onClick={handleOnClick}
                                 onKeyDown={(event) => handleKeyDown(event, option)}
                             >
                                 {label}

--- a/packages/react/src/components/user-profile/user-profile.tsx
+++ b/packages/react/src/components/user-profile/user-profile.tsx
@@ -41,6 +41,8 @@ interface UserProfileProps {
     username: string;
     usernamePrefix?: string;
     options: NavMenuOption[];
+    onMenuVisibilityChanged?(isOpen: boolean): void;
+    onMenuOptionSelected?(option: NavMenuOption): void;
 }
 
 export function UserProfile({
@@ -51,6 +53,8 @@ export function UserProfile({
     options,
     username,
     usernamePrefix,
+    onMenuOptionSelected,
+    onMenuVisibilityChanged,
 }: UserProfileProps): ReactElement {
     const { t } = useTranslation('user-profile');
     const { isMobile } = useDeviceContext();
@@ -64,6 +68,8 @@ export function UserProfile({
             id={id}
             isMobile={isMobile}
             options={options}
+            onMenuOptionSelected={onMenuOptionSelected}
+            onMenuVisibilityChanged={onMenuVisibilityChanged}
         >
             <StyledAvatar isMobile={isMobile} username={username} />
             {usernamePrefix && <Prefix data-testid="username-prefix">{usernamePrefix}</Prefix>}


### PR DESCRIPTION
[CRM-13041](https://jira.equisoft.com/browse/CRM-13041)
(Sera utile pour crm-13041 et aussi crm-13007)

Le crm a besoin de pouvoir overrider le comportement par défaut lorsqu'on clique sur des liens parce qu'il y a des side effects legacy louche à exécuter sur le on click des liens de navigation. 