### PR TITLE
feat(DeviceContextProvider): use window.outerWidth instead of window

### DIFF
--- a/packages/react/src/components/device-context-provider/device-context-provider.test.tsx
+++ b/packages/react/src/components/device-context-provider/device-context-provider.test.tsx
@@ -32,7 +32,7 @@ function getContextObject(
 }
 
 function setScreenWidth(width: number): void {
-    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
+    Object.defineProperty(window, 'outerWidth', { writable: true, configurable: true, value: width });
 }
 
 describe('Device Context Provider', () => {

--- a/packages/react/src/components/device-context-provider/device-context-provider.tsx
+++ b/packages/react/src/components/device-context-provider/device-context-provider.tsx
@@ -69,7 +69,7 @@ export const DeviceContextProvider: FunctionComponent<DeviceContextProviderProps
     const [device, setDevice] = useState<DeviceContextProps>(getDeviceContext(staticDevice));
 
     function handleScreenResize(): void {
-        const screenWidth = (window.innerWidth || document.documentElement.clientWidth);
+        const screenWidth = (window.outerWidth || document.documentElement.clientWidth);
         const currentDevice = getDevice(screenWidth);
 
         setDevice(getDeviceContext(currentDevice));


### PR DESCRIPTION
Dans le crm, le device context provider fonctionne pas bien étant donné qu'il y a des min-width à certains endroits. Dans tout les cas, utiliser le outerWidth est plus robuste pour le design system. 