### PR TITLE
refactor(DeviceContextProvider): revert to innerWidth

### DIFF
--- a/packages/react/src/components/device-context-provider/device-context-provider.test.tsx
+++ b/packages/react/src/components/device-context-provider/device-context-provider.test.tsx
@@ -32,7 +32,7 @@ function getContextObject(
 }
 
 function setScreenWidth(width: number): void {
-    Object.defineProperty(window, 'outerWidth', { writable: true, configurable: true, value: width });
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: width });
 }
 
 describe('Device Context Provider', () => {

--- a/packages/react/src/components/device-context-provider/device-context-provider.tsx
+++ b/packages/react/src/components/device-context-provider/device-context-provider.tsx
@@ -69,7 +69,7 @@ export const DeviceContextProvider: FunctionComponent<DeviceContextProviderProps
     const [device, setDevice] = useState<DeviceContextProps>(getDeviceContext(staticDevice));
 
     function handleScreenResize(): void {
-        const screenWidth = (window.outerWidth || document.documentElement.clientWidth);
+        const screenWidth = (window.innerWidth || document.documentElement.clientWidth);
         const currentDevice = getDevice(screenWidth);
 
         setDevice(getDeviceContext(currentDevice));


### PR DESCRIPTION
## PR Description
Ce PR revert les changes qui avaient été fait dans #302 . Le changement avait été fait pour répondre au besoin de Connect, mais ça ne résout pas le problème. Le problème est directement dans Connect et y sera fixé. La bonne pratique est d'utilisé `innerWidth` donc on revert ce changement.
