### PR TITLE
feat(GlobalBanner): set container position to relative to work with ApplicationMenu

### DIFF
--- a/packages/react/src/components/global-banner/global-banner.test.tsx.snap
+++ b/packages/react/src/components/global-banner/global-banner.test.tsx.snap
@@ -121,6 +121,7 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
   padding: var(--spacing-1x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -377,6 +378,7 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
   padding: var(--spacing-1x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -648,6 +650,7 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
   padding: var(--spacing-1x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -919,6 +922,7 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
   padding: var(--spacing-1x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -1170,6 +1174,7 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
   padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -1432,6 +1437,7 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
   padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -1709,6 +1715,7 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
   padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {
@@ -1986,6 +1993,7 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
   padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  position: relative;
 }
 
 .c1 {

--- a/packages/react/src/components/global-banner/global-banner.tsx
+++ b/packages/react/src/components/global-banner/global-banner.tsx
@@ -64,6 +64,7 @@ const Container = styled.section<ContainerProps>`
     letter-spacing: ${({ isMobile }) => (isMobile ? 0.02875 : 0.0125)}rem;
     line-height: 1.5rem;
     padding: ${getContainerPadding};
+    position: relative;
 `;
 
 const Content = styled.div<{ isMobile: boolean }>`


### PR DESCRIPTION
## Description
Ce PR met `position: relative` par défaut sur le container de GlobalBanner, car il sera pratiquement toujours utilisé avec le component ApplicationMenu qui est aussi en `position: relative`. Cela permet de définir le z-index facilement entre les deux components et d'éviter que le skip-link passe par-dessus GlobalBanner.
