### PR TITLE
feat(NavItem, ExternalItem): added target props

### DIFF
--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -489,6 +489,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
           data-testid="listitem-optionA"
           href="/testa"
           tabindex="0"
+          target="_blank"
         >
           <svg
             aria-hidden="true"
@@ -517,6 +518,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
           disabled=""
           href="/testb"
           tabindex="-1"
+          target="_blank"
         >
           <svg
             aria-hidden="true"
@@ -544,6 +546,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
           data-testid="listitem-optionC"
           href="/testc"
           tabindex="0"
+          target="_blank"
         >
           <svg
             aria-hidden="true"
@@ -571,6 +574,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
           data-testid="listitem-optionD"
           href="/testd"
           tabindex="0"
+          target="_blank"
         >
           <svg
             aria-hidden="true"

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
@@ -67,6 +67,7 @@ export const BentoMenuButton: FunctionComponent<BentoMenuButtonProps> = ({
                         {productLinks.map((product, idx) => (
                             <NavItem
                                 ref={idx === 0 ? firstItemRef : undefined}
+                                target="_blank"
                                 data-testid={`product-${product.value}`}
                                 key={`product-${product.value}`}
                                 value={product.value}

--- a/packages/react/src/components/dropdown-menu/list-items/external-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/external-item.tsx
@@ -7,6 +7,7 @@ export interface ExternalItemProps extends ExternalLinkProps {
     label: string;
     href: string;
     disabled?: boolean;
+    target?: string;
     onClick?(): void;
 }
 
@@ -44,6 +45,7 @@ export const ExternalItem = ({
     href,
     label,
     disabled,
+    target,
     onClick,
 }: ExternalItemProps): ReactElement => {
     const device = useDeviceContext();
@@ -55,6 +57,7 @@ export const ExternalItem = ({
                 href={href}
                 label={label}
                 disabled={disabled}
+                target={target}
             />
         </li>
     );

--- a/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
@@ -15,6 +15,7 @@ export interface NavItemProps {
     exact?: boolean;
     isHtmlLink?: boolean;
     disabled?: boolean;
+    target?: string;
     onClick?(event: MouseEvent): void;
 }
 
@@ -73,6 +74,7 @@ export const NavItem = forwardRef(({
     onClick,
     isHtmlLink = false,
     lozenge,
+    target,
 }: NavItemProps, ref: Ref<HTMLAnchorElement>): ReactElement => {
     const device = useDeviceContext();
     return (
@@ -85,6 +87,7 @@ export const NavItem = forwardRef(({
                     $device={device}
                     disabled={disabled}
                     href={href}
+                    target={target}
                     onClick={disabled ? undefined : onClick}
                 >
                     <ItemContent
@@ -107,6 +110,7 @@ export const NavItem = forwardRef(({
                     data-testid={`listitem-${value}`}
                     disabled={disabled}
                     exact={exact}
+                    target={target}
                     onClick={disabled ? undefined : onClick}
                 >
                     <ItemContent


### PR DESCRIPTION
## PR Description
Enables default target to be _blank

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] All GitHub checks are successful.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] All GitHub checks are successful.
