### PR TITLE
fix(NavMenuButton, DropdownMenuButton): use abstractButton:hover color for expanded buttons

### DIFF
--- a/packages/react/src/components/application-menu/application-menu.test.tsx.snap
+++ b/packages/react/src/components/application-menu/application-menu.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Application Menu Matches the snapshot (desktop) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 > * {
@@ -136,7 +136,7 @@ exports[`Application Menu Matches the snapshot (mobile) 1`] = `
 .c2:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0 {
@@ -180,7 +180,7 @@ exports[`Application Menu Matches the snapshot (mobile) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 > * {
@@ -273,7 +273,7 @@ exports[`Application Menu mobileDrawerContent prop adds a side drawer and burger
 .c2:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0 {
@@ -317,7 +317,7 @@ exports[`Application Menu mobileDrawerContent prop adds a side drawer and burger
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 > * {

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -115,7 +116,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 .c16:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c16:focus:not(:focus-visible) {
@@ -125,7 +126,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 .c16:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c22 {
@@ -150,7 +151,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 .c22:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c22:focus:not(:focus-visible) {
@@ -160,7 +161,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 .c22:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c21 {
@@ -234,8 +235,13 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 }
 
 .c19:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c19:hover {
@@ -341,8 +347,13 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 }
 
 .c11:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c11:hover {
@@ -377,8 +388,13 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 }
 
 .c15:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c15:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c15:hover {
@@ -451,7 +467,8 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 >
   <button
     aria-expanded="false"
-    class="c2 c3 "
+    class="c2 c3"
+    data-expanded="false"
     data-testid="menu-button"
     type="button"
   >

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
@@ -48,11 +48,13 @@ const StyledDropdownMenuButton = styled(DropdownMenuButton)`
 `;
 
 interface BentoMenuButtonProps {
+    title?: string,
     productLinks: NavItemProps[];
     externalLinks: ExternalItemProps[];
 }
 
 export const BentoMenuButton: FunctionComponent<BentoMenuButtonProps> = ({
+    title,
     productLinks,
     externalLinks,
 }) => {
@@ -102,6 +104,7 @@ export const BentoMenuButton: FunctionComponent<BentoMenuButtonProps> = ({
                     </GroupItem>
                 </>
             )}
+            title={title}
             hasCaret={false}
             icon={<Icon name="bento" size={isMobile ? '24' : '16'} />}
             buttonType="tertiary"

--- a/packages/react/src/components/buttons/abstract-button.tsx
+++ b/packages/react/src/components/buttons/abstract-button.tsx
@@ -76,7 +76,8 @@ const getPrimaryButtonStyles: (props: ButtonTypeStyles) => FlattenInterpolation<
     border-color: ${inverted ? theme.greys.white : theme.main['primary-1.1']};
     color: ${inverted ? theme.main['primary-1.1'] : theme.greys.white};
 
-    &:hover {
+    &:hover,
+    &[data-expanded="true"] {
         background-color: ${inverted ? theme.greys.white : theme.main['primary-1.3']};
         border-color: ${inverted ? theme.greys.white : theme.main['primary-1.3']};
         ${inverted && `color: ${theme.main['primary-1.3']}`}
@@ -97,7 +98,8 @@ const getSecondaryButtonStyles: (props: ButtonTypeStyles) => FlattenInterpolatio
     border-color: ${inverted ? theme.greys.white : theme.main['primary-1.1']};
     color: ${inverted ? theme.greys.white : theme.main['primary-1.1']};
 
-    &:hover {
+    &:hover,
+    &[data-expanded="true"] {
         border-color: ${inverted ? theme.main['primary-1.2'] : theme.main['primary-1.3']};
         color: ${inverted ? theme.main['primary-1.2'] : theme.main['primary-1.3']};
     }
@@ -122,7 +124,8 @@ const getTertiaryButtonStyles: (props: ButtonTypeStyles) => FlattenInterpolation
     border-color: transparent;
     color: ${inverted ? theme.greys.white : theme.greys['dark-grey']};
 
-    &:hover {
+    &:hover,
+    &[data-expanded="true"] {
         background-color: ${inverted ? theme.main['primary-1.3'] : theme.greys.grey};
         color: ${inverted ? theme.greys.white : theme.greys.black};
     }
@@ -147,7 +150,8 @@ const getDestructiveButtonStyles: (props: ButtonTypeStyles) => FlattenInterpolat
     border-color: ${inverted ? theme.greys.white : theme.notifications['alert-2.1']};
     color: ${inverted ? theme.notifications['alert-2.1'] : theme.greys.white};
 
-    &:hover {
+    &:hover,
+    &[data-expanded="true"] {
         /* TODO change colors when updating thematization */
         background-color: ${inverted ? theme.greys.white : '#7B1A15'};
         border-color: ${inverted ? theme.greys.white : '#7B1A15'};

--- a/packages/react/src/components/buttons/add-button.test.tsx.snap
+++ b/packages/react/src/components/buttons/add-button.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`Add Button has disabled styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -180,7 +181,8 @@ exports[`Add Button has mobile styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -284,7 +286,8 @@ exports[`Add Button has primary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -388,7 +391,8 @@ exports[`Add Button has secondary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   border-color: #003A5A;
   color: #003A5A;
 }
@@ -492,7 +496,8 @@ exports[`Add Button has tertiary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }

--- a/packages/react/src/components/buttons/button.test.tsx.snap
+++ b/packages/react/src/components/buttons/button.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`Button has destructive styles (inverted) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
   color: #7B1A15;
@@ -172,7 +173,8 @@ exports[`Button has destructive styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #7B1A15;
   border-color: #7B1A15;
   color: #FFFFFF;
@@ -269,7 +271,8 @@ exports[`Button has disabled styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -363,7 +366,8 @@ exports[`Button has mobile styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -456,7 +460,8 @@ exports[`Button has primary styles (inverted) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #FFFFFF;
   border-color: #FFFFFF;
   color: #003A5A;
@@ -551,7 +556,8 @@ exports[`Button has primary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -644,7 +650,8 @@ exports[`Button has secondary styles (inverted) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -742,7 +749,8 @@ exports[`Button has secondary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   border-color: #003A5A;
   color: #003A5A;
 }
@@ -835,7 +843,8 @@ exports[`Button has tertiary styles (inverted) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -934,7 +943,8 @@ exports[`Button has tertiary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }

--- a/packages/react/src/components/buttons/icon-button.test.tsx.snap
+++ b/packages/react/src/components/buttons/icon-button.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`Icon Button Has disabled styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -180,7 +181,8 @@ exports[`Icon Button Has mobile styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -282,7 +284,8 @@ exports[`Icon Button Has primary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -384,7 +387,8 @@ exports[`Icon Button Has secondary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   border-color: #003A5A;
   color: #003A5A;
 }
@@ -486,7 +490,8 @@ exports[`Icon Button Has tertiary styles 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }

--- a/packages/react/src/components/card-link/card-link.test.tsx.snap
+++ b/packages/react/src/components/card-link/card-link.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`CardLink Matches Snapshot 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <a

--- a/packages/react/src/components/carousel/carousel.test.tsx.snap
+++ b/packages/react/src/components/carousel/carousel.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Carousel should match snapshot 1`] = `
 .c7:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6 + .c6 {
@@ -99,7 +99,7 @@ exports[`Carousel should match snapshot 1`] = `
 .c8:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6 + .c6 {
@@ -121,7 +121,7 @@ exports[`Carousel should match snapshot 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c9 {
@@ -139,7 +139,7 @@ exports[`Carousel should match snapshot 1`] = `
 .c9:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <section

--- a/packages/react/src/components/chooser-card/chooser-card.test.tsx.snap
+++ b/packages/react/src/components/chooser-card/chooser-card.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Chooser Card Matches snapshot (Checked, Desktop) 1`] = `
 .c0:focus-within {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:hover:not([disabled]) {
@@ -184,7 +184,7 @@ exports[`Chooser Card Matches snapshot (Default, Desktop) 1`] = `
 .c0:focus-within {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:hover:not([disabled]) {
@@ -312,7 +312,7 @@ exports[`Chooser Card Matches snapshot (Default, Mobile) 1`] = `
 .c0:focus-within {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:hover:not([disabled]) {
@@ -440,7 +440,7 @@ exports[`Chooser Card Matches snapshot (Disabled, Desktop) 1`] = `
 .c0:focus-within {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:hover:not([disabled]) {

--- a/packages/react/src/components/datepicker/datepicker.test.tsx.snap
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx.snap
@@ -2595,7 +2595,8 @@ exports[`Datepicker matches snapshot (open, hasTodayButton) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c17:hover {
+.c17:hover,
+.c17[data-expanded="true"] {
   border-color: #003A5A;
   color: #003A5A;
 }

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -113,7 +114,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 .c12:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c12:focus:not(:focus-visible) {
@@ -123,7 +124,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 .c12:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c17 {
@@ -148,7 +149,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 .c17:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c17:focus:not(:focus-visible) {
@@ -158,7 +159,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 .c17:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c16 {
@@ -232,8 +233,13 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c14:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c14:hover {
@@ -311,8 +317,13 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c8:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c8:hover {
@@ -347,8 +358,13 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c11:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c11:hover {
@@ -379,8 +395,6 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c3 {
-  background-color: #003A5A;
-  border-color: #003A5A;
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   text-transform: unset;
@@ -404,6 +418,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   <button
     aria-expanded="true"
     class="c1 c2 c3"
+    data-expanded="true"
     data-testid="menu-button"
     type="button"
   >
@@ -682,7 +697,8 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -720,7 +736,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 .c12:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c12:focus:not(:focus-visible) {
@@ -730,7 +746,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 .c12:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c17 {
@@ -755,7 +771,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 .c17:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c17:focus:not(:focus-visible) {
@@ -765,7 +781,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 .c17:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c16 {
@@ -839,8 +855,13 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c14:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c14:hover {
@@ -918,8 +939,13 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c8:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c8:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c8:hover {
@@ -954,8 +980,13 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c11:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c11:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c11:hover {
@@ -1009,6 +1040,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   <button
     aria-expanded="false"
     class="c1 c2 c3"
+    data-expanded="false"
     data-testid="menu-button"
     type="button"
   >

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.tsx
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.tsx
@@ -7,7 +7,7 @@ import React, {
     useRef,
     useState, VoidFunctionComponent,
 } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { eventIsInside } from '../../utils/events';
 import { v4 as uuid } from '../../utils/uuid';
@@ -19,33 +19,15 @@ import { getRootDocument } from '../../utils/dom';
 import { AvatarProps } from '../avatar/avatar';
 import { IconButton } from '../buttons/icon-button';
 import { Button, ButtonType } from '../buttons/button';
-import { Theme } from '../../themes';
 
 const StyledNav = styled.nav`
     position: relative;
 `;
 
-interface ExpandedProps {
-    $expanded: boolean;
-}
-
-const ExpandedStyle = css<{ $expanded: boolean, theme: Theme }>`
-    ${({ $expanded, theme }) => $expanded && `
-        background-color: ${theme.main['primary-1.3']};
-        border-color: ${theme.main['primary-1.3']};
-    `}
-`;
-
-const StyledButton = styled(Button)<ExpandedProps & { isMobile: boolean }>`
-    ${ExpandedStyle}
-
+const StyledButton = styled(Button)<{ isMobile: boolean }>`
     font-size: 0.875rem;
     font-weight: var(--font-normal);
     text-transform: unset;
-`;
-
-const StyledIconButton = styled(IconButton)<ExpandedProps>`
-    ${ExpandedStyle}
 `;
 
 const StyledRightIcon = styled(Icon)`
@@ -170,8 +152,8 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
             {!isIconOnly && (
                 <StyledButton
                     aria-expanded={isOpen}
+                    data-expanded={isOpen}
                     data-testid="menu-button"
-                    $expanded={isOpen}
                     isMobile={isMobile}
                     onClick={() => setOpen(!isOpen)}
                     onKeyDown={handleButtonKeyDown}
@@ -193,11 +175,11 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
                 </StyledButton>
             )}
             {isIconOnly && (
-                <StyledIconButton
+                <IconButton
                     iconName="moreHorizontal"
                     aria-expanded={isOpen}
+                    data-expanded={isOpen}
                     data-testid="menu-button"
-                    $expanded={isOpen}
                     onClick={() => setOpen(!isOpen)}
                     onKeyDown={handleButtonKeyDown}
                     ref={buttonRef}
@@ -207,7 +189,7 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
                     inverted={inverted}
                 >
                     {icon}
-                </StyledIconButton>
+                </IconButton>
             )}
             <StyledDropdownMenu
                 ref={navMenuRef}

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`DropdownMenu Is hidden 1`] = `
 .c5:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c5:focus:not(:focus-visible) {
@@ -33,7 +33,7 @@ exports[`DropdownMenu Is hidden 1`] = `
 .c5:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c9 {
@@ -90,8 +90,13 @@ exports[`DropdownMenu Is hidden 1`] = `
 }
 
 .c7:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c7:hover {
@@ -169,8 +174,13 @@ exports[`DropdownMenu Is hidden 1`] = `
 }
 
 .c2:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c2:hover {
@@ -366,7 +376,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 .c5:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c5:focus:not(:focus-visible) {
@@ -376,7 +386,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 .c5:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c9 {
@@ -433,8 +443,13 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 }
 
 .c7:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c7:hover {
@@ -512,8 +527,13 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 }
 
 .c2:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c2:hover {

--- a/packages/react/src/components/dropdown-menu/list-items/external-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/external-item.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 import { DeviceContextProps, useDeviceContext } from '../../device-context-provider/device-context-provider';
 import { ExternalLink, ExternalLinkProps } from '../../external-link/external-link';
+import { focus } from '../../../utils/css-state';
 
 export interface ExternalItemProps extends ExternalLinkProps {
     label: string;
@@ -25,10 +26,7 @@ export const StyledExternalLink = styled(ExternalLink)<ExternalItemsStyledProps>
     text-overflow: ellipsis;
     white-space: nowrap;
 
-    &:focus {
-        box-shadow: ${({ theme }) => theme.tokens['focus-border-box-shadow-inset']};
-        outline: none;
-    }
+    ${(props) => focus(props, undefined, undefined, true)}
 
     &:hover {
         background-color: ${({ theme }) => theme.greys.grey};

--- a/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
@@ -4,6 +4,7 @@ import { NavLink, NavLinkProps } from 'react-router-dom';
 import { DeviceContextProps, useDeviceContext } from '../../device-context-provider/device-context-provider';
 import { IconName } from '../../icon/icon';
 import { ItemContent } from './item-content';
+import { focus } from '../../../utils/css-state';
 
 export interface NavItemProps {
     value: string;
@@ -37,10 +38,7 @@ const NavItemStyle = css<LinkProps>`
     text-decoration: none;
     white-space: nowrap;
 
-    &:focus {
-        box-shadow: ${({ theme }) => theme.tokens['focus-border-box-shadow-inset']};
-        outline: none;
-    }
+    ${(props) => focus(props, undefined, undefined, true)}
 
     &:hover {
         background-color: ${({ disabled, theme }) => (disabled ? 'transparent' : theme.greys.grey)};

--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`External Link matches snapshot (disabled) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -33,7 +33,7 @@ exports[`External Link matches snapshot (disabled) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c3 {
@@ -117,7 +117,7 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -127,7 +127,7 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c2 {
@@ -227,7 +227,7 @@ exports[`External Link matches snapshot (only icon) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -237,7 +237,7 @@ exports[`External Link matches snapshot (only icon) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c2 {
@@ -335,7 +335,7 @@ exports[`External Link matches snapshot (without href) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -345,7 +345,7 @@ exports[`External Link matches snapshot (without href) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c2 {
@@ -445,7 +445,7 @@ exports[`External Link matches snapshot 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -455,7 +455,7 @@ exports[`External Link matches snapshot 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c3 {

--- a/packages/react/src/components/global-banner/global-banner.test.tsx.snap
+++ b/packages/react/src/components/global-banner/global-banner.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -316,7 +317,8 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -347,7 +349,8 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -604,7 +607,8 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -635,7 +639,8 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -892,7 +897,8 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -923,7 +929,8 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -1192,7 +1199,8 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -1436,7 +1444,8 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -1467,7 +1476,8 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -1727,7 +1737,8 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -1758,7 +1769,8 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -2018,7 +2030,8 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -2049,7 +2062,8 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }

--- a/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
+++ b/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`Global Navigation Matches snapshot 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -145,7 +146,7 @@ exports[`Global Navigation Matches snapshot 1`] = `
 .c6:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6:hover {

--- a/packages/react/src/components/listbox/listbox.test.tsx.snap
+++ b/packages/react/src/components/listbox/listbox.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Listbox Matches the snapshot (dropdown) 1`] = `
 }
 
 .c1:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 
@@ -217,7 +217,7 @@ exports[`Listbox Matches the snapshot (multiselect + checkIndicator) 1`] = `
 }
 
 .c1:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 
@@ -416,7 +416,7 @@ exports[`Listbox Matches the snapshot 1`] = `
 }
 
 .c1:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 

--- a/packages/react/src/components/modal/modal-dialog.test.tsx.snap
+++ b/packages/react/src/components/modal/modal-dialog.test.tsx.snap
@@ -128,7 +128,8 @@ exports[`Modal-Dialog Matches snapshot (custom button labels) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c12:hover {
+.c12:hover,
+.c12[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -160,7 +161,8 @@ exports[`Modal-Dialog Matches snapshot (custom button labels) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c9:hover {
+.c9:hover,
+.c9[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -186,7 +188,8 @@ exports[`Modal-Dialog Matches snapshot (custom button labels) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c11:hover {
+.c11:hover,
+.c11[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -473,7 +476,8 @@ exports[`Modal-Dialog Matches snapshot (custom footer content) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:hover {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -692,7 +696,8 @@ exports[`Modal-Dialog Matches snapshot (not titles) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -724,7 +729,8 @@ exports[`Modal-Dialog Matches snapshot (not titles) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c5:hover {
+.c5:hover,
+.c5[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -750,7 +756,8 @@ exports[`Modal-Dialog Matches snapshot (not titles) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c7:hover {
+.c7:hover,
+.c7[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1000,7 +1007,8 @@ exports[`Modal-Dialog Matches snapshot (only subtitle) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c11:hover {
+.c11:hover,
+.c11[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1032,7 +1040,8 @@ exports[`Modal-Dialog Matches snapshot (only subtitle) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -1058,7 +1067,8 @@ exports[`Modal-Dialog Matches snapshot (only subtitle) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1334,7 +1344,8 @@ exports[`Modal-Dialog Matches snapshot (only title) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c11:hover {
+.c11:hover,
+.c11[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1366,7 +1377,8 @@ exports[`Modal-Dialog Matches snapshot (only title) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c8:hover {
+.c8:hover,
+.c8[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -1392,7 +1404,8 @@ exports[`Modal-Dialog Matches snapshot (only title) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1639,7 +1652,8 @@ exports[`Modal-Dialog Matches snapshot (opened, desktop) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c13:hover {
+.c13:hover,
+.c13[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1679,7 +1693,8 @@ exports[`Modal-Dialog Matches snapshot (opened, desktop) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c10:hover {
+.c10:hover,
+.c10[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -1705,7 +1720,8 @@ exports[`Modal-Dialog Matches snapshot (opened, desktop) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c12:hover {
+.c12:hover,
+.c12[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -2011,7 +2027,8 @@ exports[`Modal-Dialog Matches snapshot (opened, mobile) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c12:hover {
+.c12:hover,
+.c12[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -2043,7 +2060,8 @@ exports[`Modal-Dialog Matches snapshot (opened, mobile) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c9:hover {
+.c9:hover,
+.c9[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -2069,7 +2087,8 @@ exports[`Modal-Dialog Matches snapshot (opened, mobile) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c11:hover {
+.c11:hover,
+.c11[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }

--- a/packages/react/src/components/modal/modal.test.tsx.snap
+++ b/packages/react/src/components/modal/modal.test.tsx.snap
@@ -320,7 +320,8 @@ exports[`Modal Matches snapshot (noPadding) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -501,7 +502,8 @@ exports[`Modal Matches snapshot (opened, desktop) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:hover {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -736,7 +738,8 @@ exports[`Modal Matches snapshot (opened, mobile) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx
@@ -122,7 +122,7 @@ describe('NavMenuButton', () => {
             </NavMenuButton>,
         );
 
-        expect(wrapper.find(IconButton).exists()).toBe(false);
+        expect(wrapper.find(IconButton).exists()).toBe(true);
     });
 
     test('nav-menu is open when defaultOpen prop is set to true', () => {

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx.snap
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`NavMenuButton Matches Snapshot (defaultOpen) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -129,8 +130,13 @@ exports[`NavMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c7:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c7:hover {
@@ -147,8 +153,6 @@ exports[`NavMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c3 {
-  background-color: #003A5A;
-  border-color: #003A5A;
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   text-transform: unset;
@@ -172,6 +176,7 @@ exports[`NavMenuButton Matches Snapshot (defaultOpen) 1`] = `
   <button
     aria-expanded="true"
     class="c1 c2 c3"
+    data-expanded="true"
     data-testid="menu-button"
     type="button"
   >
@@ -324,7 +329,8 @@ exports[`NavMenuButton Matches Snapshot 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -378,8 +384,13 @@ exports[`NavMenuButton Matches Snapshot 1`] = `
 }
 
 .c7:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c7:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c7:hover {
@@ -419,6 +430,7 @@ exports[`NavMenuButton Matches Snapshot 1`] = `
   <button
     aria-expanded="false"
     class="c1 c2 c3"
+    data-expanded="false"
     data-testid="menu-button"
     type="button"
   >

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
@@ -8,7 +8,7 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { eventIsInside } from '../../utils/events';
 import { v4 as uuid } from '../../utils/uuid';
@@ -18,33 +18,15 @@ import { NavMenu, NavMenuOption } from '../nav-menu/nav-menu';
 import { getRootDocument } from '../../utils/dom';
 import { IconButton } from '../buttons/icon-button';
 import { Button, ButtonType } from '../buttons/button';
-import { Theme } from '../../themes';
-
-interface ExpandedProps {
-    $expanded: boolean;
-}
 
 const StyledNav = styled.nav`
     position: relative;
 `;
 
-const ExpandedStyle = css<{ $expanded: boolean, theme: Theme }>`
-    ${({ $expanded, theme }) => $expanded && `
-        background-color: ${theme.main['primary-1.3']};
-        border-color: ${theme.main['primary-1.3']};
-    `}
-`;
-
-const StyledButton = styled(Button)<ExpandedProps & { isMobile: boolean }>`
-    ${ExpandedStyle}
-
+const StyledButton = styled(Button)<{ isMobile: boolean }>`
     font-size: 0.875rem;
     font-weight: var(--font-normal);
     text-transform: unset;
-`;
-
-const StyledIconButton = styled(IconButton)<ExpandedProps>`
-    ${ExpandedStyle}
 `;
 
 const StyledRightIcon = styled(Icon)`
@@ -178,8 +160,8 @@ export function NavMenuButton({
             {!iconOnly && (
                 <StyledButton
                     aria-expanded={isOpen}
+                    data-expanded={isOpen}
                     data-testid="menu-button"
-                    $expanded={isOpen}
                     isMobile={isMobile}
                     onClick={handleButtonClick}
                     ref={buttonRef}
@@ -200,10 +182,10 @@ export function NavMenuButton({
                 </StyledButton>
             )}
             {iconOnly && iconName && (
-                <StyledIconButton
+                <IconButton
                     aria-expanded={isOpen}
+                    data-expanded={isOpen}
                     data-testid="menu-button"
-                    $expanded={isOpen}
                     iconName={iconName}
                     onClick={handleButtonClick}
                     ref={buttonRef}

--- a/packages/react/src/components/nav-menu/nav-menu.test.tsx.snap
+++ b/packages/react/src/components/nav-menu/nav-menu.test.tsx.snap
@@ -39,8 +39,13 @@ exports[`NavMenu Is hidden 1`] = `
 }
 
 .c1:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c1:hover {
@@ -155,8 +160,13 @@ exports[`NavMenu Matches the snapshot 1`] = `
 }
 
 .c1:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c1:hover {

--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -13,6 +13,7 @@ import styled, { css } from 'styled-components';
 import { Icon, IconName } from '../icon/icon';
 import { v4 as uuid } from '../../utils/uuid';
 import { DeviceContextProps, useDeviceContext } from '../device-context-provider/device-context-provider';
+import { focus } from '../../utils/css-state';
 
 const List = styled.ul`
     background-color: ${({ theme }) => theme.greys.white};
@@ -61,11 +62,7 @@ const linkStyles = css<LinkProps>`
     padding: 0 var(--spacing-2x);
     text-decoration: none;
 
-    &:focus {
-        box-shadow: ${({ theme }) => theme.tokens['focus-border-box-shadow-inset']};
-        outline: none;
-    }
-
+    ${(props) => focus(props, undefined, undefined, true)}
     :hover {
         background-color: ${({ theme }) => theme.greys.grey};
 

--- a/packages/react/src/components/pagination/pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/pagination.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -136,7 +137,7 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
 .c5:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c5:hover {
@@ -178,7 +179,7 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
 .c6:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6:hover {
@@ -399,7 +400,8 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -458,7 +460,7 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
 .c5:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c5:hover {
@@ -500,7 +502,7 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
 .c6:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6:hover {
@@ -721,7 +723,8 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -780,7 +783,7 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
 .c5:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c5:hover {
@@ -822,7 +825,7 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
 .c6:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6:hover {
@@ -1043,7 +1046,8 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -1102,7 +1106,7 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
 .c5:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c5:hover {
@@ -1144,7 +1148,7 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
 .c6:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c6:hover {

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -33,7 +33,7 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -84,7 +84,7 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -94,7 +94,7 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -162,7 +162,7 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -172,7 +172,7 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -239,7 +239,7 @@ exports[`Route Link matches snapshot (Link) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -249,7 +249,7 @@ exports[`Route Link matches snapshot (Link) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -310,7 +310,7 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -320,7 +320,7 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -371,7 +371,7 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -381,7 +381,7 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -449,7 +449,7 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -459,7 +459,7 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -526,7 +526,7 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c0:focus:not(:focus-visible) {
@@ -536,7 +536,7 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
 .c0:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {

--- a/packages/react/src/components/search/search-input.test.tsx.snap
+++ b/packages/react/src/components/search/search-input.test.tsx.snap
@@ -270,7 +270,7 @@ label + .c6 {
 .c9:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 input:valid + .c8 {

--- a/packages/react/src/components/select/select.test.tsx.snap
+++ b/packages/react/src/components/select/select.test.tsx.snap
@@ -64,7 +64,7 @@ input + .c2 {
 }
 
 .c8:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 
@@ -467,7 +467,7 @@ input + .c2 {
 }
 
 .c11:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 
@@ -954,7 +954,7 @@ input + .c2 {
 }
 
 .c8:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 
@@ -1398,7 +1398,7 @@ exports[`Select mobile select has a different style 1`] = `
 }
 
 .c6:focus {
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296,0 10px 20px 0 rgba(0,0,0,0.19);
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA,0 10px 20px 0 rgba(0,0,0,0.19);
   outline: none;
 }
 

--- a/packages/react/src/components/table/table-row.tsx
+++ b/packages/react/src/components/table/table-row.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, ReactElement } from 'react';
 import { Row } from 'react-table';
 import styled, { css } from 'styled-components';
 import { Theme } from '../../themes';
+import { focus } from '../../utils/css-state';
 
 interface StyledTableRowProps {
     clickable: boolean;
@@ -18,13 +19,9 @@ const StyledTableRow = styled.tr<StyledTableRowProps & { theme: Theme }>`
         }
     `}
 
-    ${({ clickable, theme }) => clickable && css`
-        :focus {
-            border-color: ${theme.tokens['focus-border']};
-            box-shadow: ${theme.tokens['focus-border-box-shadow-inset']};
-            outline: none;
-        }
+    ${(props) => focus(props, undefined, undefined, true)}
 
+    ${({ clickable, theme }) => clickable && css`
         :hover {
             background-color: ${theme.greys.grey};
             cursor: pointer;

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -6,9 +6,13 @@ exports[`Table has clickable rows styles 1`] = `
 }
 
 .c1:focus {
-  border-color: #006296;
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c1:hover {
@@ -140,6 +144,16 @@ exports[`Table has custom text alignment 1`] = `
   border-top: 1px solid #DBDEE1;
 }
 
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
 .c0 {
   border-collapse: collapse;
   border-spacing: 0;
@@ -269,6 +283,16 @@ exports[`Table has desktop styles 1`] = `
   border-top: 1px solid #DBDEE1;
 }
 
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
 .c0 {
   border-collapse: collapse;
   border-spacing: 0;
@@ -392,8 +416,28 @@ exports[`Table has error rows styles 1`] = `
   border: 1px solid #CD2C23;
 }
 
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
 .c2 {
   border-top: 1px solid #DBDEE1;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c0 {
@@ -517,6 +561,16 @@ exports[`Table has mobile styles 1`] = `
   border-top: 1px solid #DBDEE1;
 }
 
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
 .c0 {
   border-collapse: collapse;
   border-spacing: 0;
@@ -636,6 +690,16 @@ exports[`Table has mobile styles 1`] = `
 exports[`Table has rowNumbers styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c0 {
@@ -867,6 +931,16 @@ exports[`Table has selectable rows styles 1`] = `
 
 .c9 {
   border-top: 1px solid #DBDEE1;
+}
+
+.c9:focus {
+  outline: none;
+}
+
+.c9:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c0 {
@@ -1116,6 +1190,16 @@ exports[`Table has small rowSize styles 1`] = `
   border-top: 1px solid #DBDEE1;
 }
 
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
 .c0 {
   border-collapse: collapse;
   border-spacing: 0;
@@ -1255,6 +1339,16 @@ exports[`Table has sorting styles 1`] = `
 
 .c3 {
   border-top: 1px solid #DBDEE1;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c0 {
@@ -1416,6 +1510,16 @@ exports[`Table has striped styles 1`] = `
   background-color: #FAFAFA;
 }
 
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
 .c0 {
   border-collapse: collapse;
   border-spacing: 0;
@@ -1535,6 +1639,16 @@ exports[`Table has striped styles 1`] = `
 exports[`Table has tablet styles 1`] = `
 .c1 {
   border-top: 1px solid #DBDEE1;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c0 {

--- a/packages/react/src/components/tag/tag.test.tsx.snap
+++ b/packages/react/src/components/tag/tag.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Tag Tag medium matches snapshot (desktop clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1:focus {
@@ -47,7 +47,7 @@ exports[`Tag Tag medium matches snapshot (desktop clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button
@@ -85,7 +85,7 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
 .c3:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -122,7 +122,7 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -186,7 +186,7 @@ exports[`Tag Tag medium matches snapshot (desktop with icons) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -237,7 +237,7 @@ exports[`Tag Tag medium matches snapshot (desktop) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -278,7 +278,7 @@ exports[`Tag Tag medium matches snapshot (desktop) 2`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -325,7 +325,7 @@ exports[`Tag Tag medium matches snapshot (mobile clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1:focus {
@@ -335,7 +335,7 @@ exports[`Tag Tag medium matches snapshot (mobile clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button
@@ -373,7 +373,7 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
 .c3:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -410,7 +410,7 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -474,7 +474,7 @@ exports[`Tag Tag medium matches snapshot (mobile with icons) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -525,7 +525,7 @@ exports[`Tag Tag medium matches snapshot (mobile) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -566,7 +566,7 @@ exports[`Tag Tag medium matches snapshot (mobile) 2`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -613,7 +613,7 @@ exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1:focus {
@@ -623,7 +623,7 @@ exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button
@@ -661,7 +661,7 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
 .c3:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -698,7 +698,7 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -762,7 +762,7 @@ exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -813,7 +813,7 @@ exports[`Tag Tag small matches snapshot (desktop) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -854,7 +854,7 @@ exports[`Tag Tag small matches snapshot (desktop) 2`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -901,7 +901,7 @@ exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1:focus {
@@ -911,7 +911,7 @@ exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button
@@ -949,7 +949,7 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
 .c3:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c1 {
@@ -986,7 +986,7 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -1050,7 +1050,7 @@ exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -1101,7 +1101,7 @@ exports[`Tag Tag small matches snapshot (mobile) 1`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span
@@ -1142,7 +1142,7 @@ exports[`Tag Tag small matches snapshot (mobile) 2`] = `
 .c1:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <span

--- a/packages/react/src/components/theme-wrapper/theme-wrapper.test.tsx.snap
+++ b/packages/react/src/components/theme-wrapper/theme-wrapper.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`Theme Wrapper Returns component with default theme 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
@@ -167,7 +168,8 @@ exports[`Theme Wrapper Returns component with test theme 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:hover {
+.c1:hover,
+.c1[data-expanded="true"] {
   background-color: #8984E8;
   border-color: #8984E8;
 }

--- a/packages/react/src/components/toast/toast-container.test.tsx.snap
+++ b/packages/react/src/components/toast/toast-container.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:hover {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -364,7 +365,8 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:hover {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -651,7 +653,8 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:hover {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
@@ -938,7 +941,8 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:hover {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }

--- a/packages/react/src/components/toggle-switch/toggle-switch.test.tsx.snap
+++ b/packages/react/src/components/toggle-switch/toggle-switch.test.tsx.snap
@@ -63,7 +63,7 @@ Array [
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button
@@ -161,7 +161,7 @@ Array [
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button
@@ -259,7 +259,7 @@ Array [
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <button

--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <Tooltip
@@ -389,7 +389,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <Tooltip>
@@ -627,7 +627,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <Tooltip
@@ -864,7 +864,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 .c0:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 3px #84C6EA,0 0 0 1px #006296;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 <Tooltip>

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -75,7 +75,8 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -191,8 +192,13 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c13:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c13:hover {
@@ -227,8 +233,13 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c15:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c15:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c15:hover {
@@ -259,8 +270,6 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c3 {
-  background-color: #003A5A;
-  border-color: #003A5A;
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   text-transform: unset;
@@ -315,6 +324,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   <button
     aria-expanded="true"
     class="c1 c2 c3"
+    data-expanded="true"
     data-testid="menu-button"
     type="button"
   >
@@ -522,7 +532,8 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover {
+.c2:hover,
+.c2[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -638,8 +649,13 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
 }
 
 .c13:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c13:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c13:hover {
@@ -674,8 +690,13 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
 }
 
 .c15:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c15:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c15:hover {
@@ -760,6 +781,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   <button
     aria-expanded="false"
     class="c1 c2 c3"
+    data-expanded="false"
     data-testid="menu-button"
     type="button"
   >
@@ -970,7 +992,8 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c3:hover {
+.c3:hover,
+.c3[data-expanded="true"] {
   background-color: #003A5A;
   color: #FFFFFF;
 }
@@ -1086,8 +1109,13 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 }
 
 .c12:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c12:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c12:hover {
@@ -1122,8 +1150,13 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 }
 
 .c14:focus {
-  box-shadow: inset 0 0 0 3px #84C6EA,inset 0 0 0 1px #006296;
   outline: none;
+}
+
+.c14:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
 }
 
 .c14:hover {
@@ -1204,7 +1237,8 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 >
   <button
     aria-expanded="false"
-    class="c2 c3 "
+    class="c2 c3"
+    data-expanded="false"
     data-testid="menu-button"
     type="button"
   >

--- a/packages/react/src/themes/tokens.ts
+++ b/packages/react/src/themes/tokens.ts
@@ -3,8 +3,8 @@ import { Theme } from './theme';
 
 export const tokens: Theme['tokens'] = {
     'focus-box-shadow': `0 0 0 2px ${main['primary-1.2']}`,
-    'focus-border-box-shadow': `0 0 0 3px ${main['primary-1.2']}, 0 0 0 1px ${main['primary-1.1']}`,
-    'focus-border-box-shadow-inset': `inset 0 0 0 3px ${main['primary-1.2']}, inset 0 0 0 1px ${main['primary-1.1']}`,
+    'focus-border-box-shadow': ` 0 0 0 1px ${main['primary-1.1']}, 0 0 0 3px ${main['primary-1.2']}`,
+    'focus-border-box-shadow-inset': `inset 0 0 0 2px ${main['primary-1.2']}, inset 0 0 0 3px ${main['primary-1.1']}`,
     'focus-border': `${main['primary-1.1']}`,
     'overlay-box-shadow': '0 10px 20px 0 rgba(0, 0, 0, 0.19)',
 };

--- a/packages/react/src/utils/css-state.ts
+++ b/packages/react/src/utils/css-state.ts
@@ -1,11 +1,11 @@
 import { Theme } from '../themes';
 
-export const focus = ({ theme }: { theme: Theme }, hasBorder = false, selector?: string): string => `
+export const focus = ({ theme }: { theme: Theme }, hasBorder = false, selector?: string, inset = false): string => `
     ${selector === undefined ? '&:focus { outline: none; }' : ''}
     ${selector === undefined ? '&:focus' : `${selector}`} {
         outline: none;
         ${hasBorder ? `border-color: ${theme.tokens['focus-border']};` : ''}
         box-shadow: ${theme.tokens['focus-box-shadow']};
-        ${!hasBorder ? `box-shadow: ${theme.tokens['focus-border-box-shadow']};` : ''}
+        ${!hasBorder ? `box-shadow: ${inset ? theme.tokens['focus-border-box-shadow-inset'] : theme.tokens['focus-border-box-shadow']};` : ''}
     }
 `;


### PR DESCRIPTION
Il y avait un problème où le `expanded` n'était pas bien bindé sur la couleur du type du bouton. J'ai bindé le style sur `aria-expanded`, ca ma éviter quelques casse-tête au niveau des props et je trouve ca clean.

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] All GitHub checks are successful.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] All GitHub checks are successful.
