### PR TITLE
refactor(AbstractButton): bring back default onClick stopPropagation

### DIFF
--- a/packages/react/src/components/buttons/abstract-button.tsx
+++ b/packages/react/src/components/buttons/abstract-button.tsx
@@ -1,3 +1,4 @@
+import React, { ButtonHTMLAttributes, EventHandler, forwardRef, MouseEvent, Ref, useCallback } from 'react';
 import styled, { css, FlattenInterpolation, ThemeProps } from 'styled-components';
 import { Theme } from '../../themes';
 import { focus } from '../../utils/css-state';
@@ -35,9 +36,29 @@ export const defaultButtonStyles = css<{ isMobile: boolean }>`
     }
 `;
 
-export const AbstractButton = styled.button<{ isMobile: boolean }>`
+interface AbstractButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+    isMobile: boolean;
+}
+
+const StyledButton = styled.button<AbstractButtonProps>`
     ${defaultButtonStyles}
 `;
+
+export const AbstractButton = forwardRef((
+    { children, onClick, ...props }: AbstractButtonProps,
+    ref: Ref<HTMLButtonElement>,
+) => {
+    const handleClick: EventHandler<MouseEvent<HTMLButtonElement>> = useCallback((event) => {
+        event.stopPropagation();
+        onClick?.(event);
+    }, [onClick]);
+
+    return (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <StyledButton onClick={handleClick} ref={ref} {...props}>{children}</StyledButton>
+    );
+});
+AbstractButton.displayName = 'AbstractButton';
 
 type ButtonType = 'primary' | 'secondary' | 'tertiary' | 'destructive';
 

--- a/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
+++ b/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
@@ -218,6 +218,7 @@ exports[`Global Navigation Matches snapshot 1`] = `
         aria-label="add"
         className="c1 c2 c3"
         data-testid="coreActionButton"
+        onClick={[Function]}
         type="button"
       >
         <svg

--- a/packages/react/src/components/search/search-input.test.tsx.snap
+++ b/packages/react/src/components/search/search-input.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchInput should match the snapshot 1`] = `
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -41,21 +41,21 @@ exports[`SearchInput should match the snapshot 1`] = `
   user-select: none;
 }
 
-.c12:focus {
+.c13:focus {
   outline: none;
 }
 
-.c12:focus {
+.c13:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c12:not(:disabled) {
+.c13:not(:disabled) {
   cursor: pointer;
 }
 
-.c12 > svg {
+.c13 > svg {
   color: inherit;
 }
 
@@ -79,7 +79,7 @@ input + .c2 {
   margin-left: var(--spacing-half);
 }
 
-.c13 {
+.c12 {
   background: #FFFFFF;
   border-color: #60666E;
   color: #60666E;
@@ -88,14 +88,14 @@ input + .c2 {
   width: 2rem;
 }
 
-.c13:hover {
+.c12:hover {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c13:disabled,
-.c13:disabled:focus,
-.c13:disabled:hover {
+.c12:disabled,
+.c12:disabled:focus,
+.c12:disabled:hover {
   background-color: #F1F2F2;
   border-color: #DBDEE1;
   color: #B7BBC2;
@@ -410,35 +410,49 @@ input:valid + .c8 {
           disabled={true}
           onClick={[Function]}
         >
-          <Styled(styled.button)
+          <Styled(AbstractButton)
             className="c11 primary"
             disabled={true}
             isMobile={false}
             onClick={[Function]}
           >
-            <button
-              className="c12 c13 c11 primary"
+            <AbstractButton
+              className="c12 c11 primary"
               disabled={true}
+              isMobile={false}
               onClick={[Function]}
             >
-              <Styled(Icon)>
-                <Icon
-                  className="c14"
-                  color="currentColor"
-                  name="search"
-                  size="24"
+              <styled.button
+                className="c12 c11 primary"
+                disabled={true}
+                isMobile={false}
+                onClick={[Function]}
+              >
+                <button
+                  className="c13 c12 c11 primary"
+                  disabled={true}
+                  onClick={[Function]}
                 >
-                  <svg
-                    className="c14"
-                    color="currentColor"
-                    focusable={false}
-                    height="24"
-                    width="24"
-                  />
-                </Icon>
-              </Styled(Icon)>
-            </button>
-          </Styled(styled.button)>
+                  <Styled(Icon)>
+                    <Icon
+                      className="c14"
+                      color="currentColor"
+                      name="search"
+                      size="24"
+                    >
+                      <svg
+                        className="c14"
+                        color="currentColor"
+                        focusable={false}
+                        height="24"
+                        width="24"
+                      />
+                    </Icon>
+                  </Styled(Icon)>
+                </button>
+              </styled.button>
+            </AbstractButton>
+          </Styled(AbstractButton)>
         </SearchButton>
       </Styled(SearchButton)>
     </div>

--- a/packages/react/src/components/theme-wrapper/theme-wrapper.test.tsx.snap
+++ b/packages/react/src/components/theme-wrapper/theme-wrapper.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`Theme Wrapper Returns component with default theme 1`] = `
 
 <button
   className="c0 c1"
+  onClick={[Function]}
   type="submit"
 />
 `;
@@ -180,6 +181,7 @@ exports[`Theme Wrapper Returns component with test theme 1`] = `
 
 <button
   className="c0 c1"
+  onClick={[Function]}
   type="submit"
 />
 `;

--- a/packages/react/src/components/toast/toast-container.test.tsx.snap
+++ b/packages/react/src/components/toast/toast-container.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ToastContainer should match snapshot (error) 1`] = `
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -41,25 +41,25 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   user-select: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:not(:disabled) {
+.c5:not(:disabled) {
   cursor: pointer;
 }
 
-.c4 > svg {
+.c5 > svg {
   color: inherit;
 }
 
-.c5 {
+.c4 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
@@ -67,28 +67,28 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   width: 32px;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c5:hover,
-.c5[data-expanded="true"] {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c5:disabled {
+.c4:disabled {
   background-color: transparent;
   color: #B7BBC2;
 }
 
-.c5:focus {
+.c4:focus {
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
@@ -227,7 +227,7 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
               label="Dismiss notification"
               onClick={[Function]}
             >
-              <Styled(styled.button)
+              <Styled(AbstractButton)
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
                 className="c3"
@@ -236,29 +236,49 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
                 onClick={[Function]}
                 type="submit"
               >
-                <button
+                <AbstractButton
                   aria-label="Dismiss notification"
-                  className="c4 c5 c3"
+                  buttonType="tertiary"
+                  className="c4 c3"
                   data-testid="dismiss"
+                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <Icon
-                    aria-hidden="true"
-                    color="currentColor"
-                    name="x"
-                    size="16"
+                  <styled.button
+                    aria-label="Dismiss notification"
+                    buttonType="tertiary"
+                    className="c4 c3"
+                    data-testid="dismiss"
+                    isMobile={false}
+                    onClick={[Function]}
+                    type="submit"
                   >
-                    <svg
-                      aria-hidden="true"
-                      color="currentColor"
-                      focusable={false}
-                      height="16"
-                      width="16"
-                    />
-                  </Icon>
-                </button>
-              </Styled(styled.button)>
+                    <button
+                      aria-label="Dismiss notification"
+                      className="c5 c4 c3"
+                      data-testid="dismiss"
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        color="currentColor"
+                        name="x"
+                        size="16"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          color="currentColor"
+                          focusable={false}
+                          height="16"
+                          width="16"
+                        />
+                      </Icon>
+                    </button>
+                  </styled.button>
+                </AbstractButton>
+              </Styled(AbstractButton)>
             </IconButton>
           </Styled(IconButton)>
         </p>
@@ -269,7 +289,7 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
 `;
 
 exports[`ToastContainer should match snapshot (information) 1`] = `
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -309,25 +329,25 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   user-select: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:not(:disabled) {
+.c5:not(:disabled) {
   cursor: pointer;
 }
 
-.c4 > svg {
+.c5 > svg {
   color: inherit;
 }
 
-.c5 {
+.c4 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
@@ -335,28 +355,28 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   width: 32px;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c5:hover,
-.c5[data-expanded="true"] {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c5:disabled {
+.c4:disabled {
   background-color: transparent;
   color: #B7BBC2;
 }
 
-.c5:focus {
+.c4:focus {
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
@@ -495,7 +515,7 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
               label="Dismiss notification"
               onClick={[Function]}
             >
-              <Styled(styled.button)
+              <Styled(AbstractButton)
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
                 className="c3"
@@ -504,29 +524,49 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
                 onClick={[Function]}
                 type="submit"
               >
-                <button
+                <AbstractButton
                   aria-label="Dismiss notification"
-                  className="c4 c5 c3"
+                  buttonType="tertiary"
+                  className="c4 c3"
                   data-testid="dismiss"
+                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <Icon
-                    aria-hidden="true"
-                    color="currentColor"
-                    name="x"
-                    size="16"
+                  <styled.button
+                    aria-label="Dismiss notification"
+                    buttonType="tertiary"
+                    className="c4 c3"
+                    data-testid="dismiss"
+                    isMobile={false}
+                    onClick={[Function]}
+                    type="submit"
                   >
-                    <svg
-                      aria-hidden="true"
-                      color="currentColor"
-                      focusable={false}
-                      height="16"
-                      width="16"
-                    />
-                  </Icon>
-                </button>
-              </Styled(styled.button)>
+                    <button
+                      aria-label="Dismiss notification"
+                      className="c5 c4 c3"
+                      data-testid="dismiss"
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        color="currentColor"
+                        name="x"
+                        size="16"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          color="currentColor"
+                          focusable={false}
+                          height="16"
+                          width="16"
+                        />
+                      </Icon>
+                    </button>
+                  </styled.button>
+                </AbstractButton>
+              </Styled(AbstractButton)>
             </IconButton>
           </Styled(IconButton)>
         </p>
@@ -537,7 +577,7 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
 `;
 
 exports[`ToastContainer should match snapshot (success) 1`] = `
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -577,25 +617,25 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   user-select: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:not(:disabled) {
+.c5:not(:disabled) {
   cursor: pointer;
 }
 
-.c4 > svg {
+.c5 > svg {
   color: inherit;
 }
 
-.c5 {
+.c4 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
@@ -603,28 +643,28 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   width: 32px;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c5:hover,
-.c5[data-expanded="true"] {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c5:disabled {
+.c4:disabled {
   background-color: transparent;
   color: #B7BBC2;
 }
 
-.c5:focus {
+.c4:focus {
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
@@ -763,7 +803,7 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
               label="Dismiss notification"
               onClick={[Function]}
             >
-              <Styled(styled.button)
+              <Styled(AbstractButton)
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
                 className="c3"
@@ -772,29 +812,49 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
                 onClick={[Function]}
                 type="submit"
               >
-                <button
+                <AbstractButton
                   aria-label="Dismiss notification"
-                  className="c4 c5 c3"
+                  buttonType="tertiary"
+                  className="c4 c3"
                   data-testid="dismiss"
+                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <Icon
-                    aria-hidden="true"
-                    color="currentColor"
-                    name="x"
-                    size="16"
+                  <styled.button
+                    aria-label="Dismiss notification"
+                    buttonType="tertiary"
+                    className="c4 c3"
+                    data-testid="dismiss"
+                    isMobile={false}
+                    onClick={[Function]}
+                    type="submit"
                   >
-                    <svg
-                      aria-hidden="true"
-                      color="currentColor"
-                      focusable={false}
-                      height="16"
-                      width="16"
-                    />
-                  </Icon>
-                </button>
-              </Styled(styled.button)>
+                    <button
+                      aria-label="Dismiss notification"
+                      className="c5 c4 c3"
+                      data-testid="dismiss"
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        color="currentColor"
+                        name="x"
+                        size="16"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          color="currentColor"
+                          focusable={false}
+                          height="16"
+                          width="16"
+                        />
+                      </Icon>
+                    </button>
+                  </styled.button>
+                </AbstractButton>
+              </Styled(AbstractButton)>
             </IconButton>
           </Styled(IconButton)>
         </p>
@@ -805,7 +865,7 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
 `;
 
 exports[`ToastContainer should match snapshot (warning) 1`] = `
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -845,25 +905,25 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   user-select: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
 }
 
-.c4:focus {
+.c5:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c4:not(:disabled) {
+.c5:not(:disabled) {
   cursor: pointer;
 }
 
-.c4 > svg {
+.c5 > svg {
   color: inherit;
 }
 
-.c5 {
+.c4 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
@@ -871,28 +931,28 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   width: 32px;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
 }
 
-.c5:focus {
+.c4:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c5:hover,
-.c5[data-expanded="true"] {
+.c4:hover,
+.c4[data-expanded="true"] {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c5:disabled {
+.c4:disabled {
   background-color: transparent;
   color: #B7BBC2;
 }
 
-.c5:focus {
+.c4:focus {
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
@@ -1031,7 +1091,7 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
               label="Dismiss notification"
               onClick={[Function]}
             >
-              <Styled(styled.button)
+              <Styled(AbstractButton)
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
                 className="c3"
@@ -1040,29 +1100,49 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
                 onClick={[Function]}
                 type="submit"
               >
-                <button
+                <AbstractButton
                   aria-label="Dismiss notification"
-                  className="c4 c5 c3"
+                  buttonType="tertiary"
+                  className="c4 c3"
                   data-testid="dismiss"
+                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <Icon
-                    aria-hidden="true"
-                    color="currentColor"
-                    name="x"
-                    size="16"
+                  <styled.button
+                    aria-label="Dismiss notification"
+                    buttonType="tertiary"
+                    className="c4 c3"
+                    data-testid="dismiss"
+                    isMobile={false}
+                    onClick={[Function]}
+                    type="submit"
                   >
-                    <svg
-                      aria-hidden="true"
-                      color="currentColor"
-                      focusable={false}
-                      height="16"
-                      width="16"
-                    />
-                  </Icon>
-                </button>
-              </Styled(styled.button)>
+                    <button
+                      aria-label="Dismiss notification"
+                      className="c5 c4 c3"
+                      data-testid="dismiss"
+                      onClick={[Function]}
+                      type="submit"
+                    >
+                      <Icon
+                        aria-hidden="true"
+                        color="currentColor"
+                        name="x"
+                        size="16"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          color="currentColor"
+                          focusable={false}
+                          height="16"
+                          width="16"
+                        />
+                      </Icon>
+                    </button>
+                  </styled.button>
+                </AbstractButton>
+              </Styled(AbstractButton)>
             </IconButton>
           </Styled(IconButton)>
         </p>


### PR DESCRIPTION
## PR Description
J'ai retiré le `event.stopPropagation()` dans [cette PR](https://github.com/kronostechnologies/design-elements/pull/304#discussion_r733828836), mais finalement ce n'était pas nécessaire. J'ai donc revert le changement dans cette PR.
