### PR TITLE
feat(NavMenu): add target prop to NavMenuOption

### DIFF
--- a/packages/react/src/components/nav-menu/nav-menu.tsx
+++ b/packages/react/src/components/nav-menu/nav-menu.tsx
@@ -95,6 +95,7 @@ export interface NavMenuOption {
     // Option label, if not provided will be set with value
     label?: string;
     startIcon?: IconName;
+    target?: string;
     value: string;
     onClick?(event: MouseEvent<HTMLAnchorElement>): void;
 }
@@ -198,6 +199,7 @@ export const NavMenu = forwardRef(({
                                 disabled={option.disabled}
                                 onClick={option.disabled ? undefined : handleOnClick}
                                 onKeyDown={(event) => handleKeyDown(event, option)}
+                                target={option.target}
                             >
                                 {label}
                             </HtmlLink>
@@ -212,6 +214,7 @@ export const NavMenu = forwardRef(({
                                 disabled={option.disabled}
                                 onClick={option.disabled ? undefined : handleOnClick}
                                 onKeyDown={(event) => handleKeyDown(event, option)}
+                                target={option.target}
                             >
                                 {label}
                             </ReactRouterNavLink>


### PR DESCRIPTION
## PR Description
Ce PR ajoute la prop target à NavMenuOption afin de permettre de passer `target="_blank"` et ainsi permettre d'ouvrir des liens dans un nouvel onglet.
