### PR TITLE
feat(GlobalBanner): add forwardRef to GlobalBanner

### DIFF
--- a/packages/react/src/components/global-banner/global-banner.tsx
+++ b/packages/react/src/components/global-banner/global-banner.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, MouseEvent, useState } from 'react';
+import React, { forwardRef, FunctionComponent, MouseEvent, Ref, useState } from 'react';
 import styled, { css, StyledProps } from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
@@ -208,7 +208,7 @@ interface Props {
 
 }
 
-export const GlobalBanner: FunctionComponent<Props> = ({
+export const GlobalBanner: FunctionComponent<Props> = forwardRef(({
     actionButton,
     children,
     className,
@@ -217,7 +217,7 @@ export const GlobalBanner: FunctionComponent<Props> = ({
     label,
     secondaryActionButton,
     type = 'default',
-}) => {
+}, ref: Ref<HTMLElement>) => {
     const { isMobile } = useDeviceContext();
     const [visible, setVisible] = useState(!hidden);
     const { t } = useTranslation('global-banner');
@@ -226,6 +226,7 @@ export const GlobalBanner: FunctionComponent<Props> = ({
 
     return visible ? (
         <Container
+            ref={ref}
             aria-atomic="true"
             aria-live="polite"
             className={className}
@@ -284,4 +285,4 @@ export const GlobalBanner: FunctionComponent<Props> = ({
             )}
         </Container>
     ) : null;
-};
+});


### PR DESCRIPTION
Nécessaire pour pouvoir merger cette pr là dans le crm : https://github.com/kronostechnologies/kronos-crm/pull/7378

Nécessaire pour avoir accès à la height du component dynamiquement. Dans le crm, ça fait ça quand le bento prends plus d'une ligne. Je prévois ajuster le margin top du header selon cette height dynamique là

<img width="917" alt="Capture d’écran, le 2021-10-26 à 16 08 09" src="https://user-images.githubusercontent.com/19400226/138953158-3d90bfc2-9e44-4891-ac78-d5a40ad75ec8.png">
