### PR TITLE
refactor(Tooltip): replace help icon to info icon

### DIFF
--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -186,7 +186,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
     >
       <Icon
         color="#60666E"
-        name="helpCircle"
+        name="info"
         size="16"
       >
         <svg
@@ -433,7 +433,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
     >
       <Icon
         color="#60666E"
-        name="helpCircle"
+        name="info"
         size="16"
       >
         <svg
@@ -684,7 +684,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
     >
       <Icon
         color="#60666E"
-        name="helpCircle"
+        name="info"
         size="24"
       >
         <svg
@@ -931,7 +931,7 @@ exports[`Tooltip Has mobile styles 1`] = `
     >
       <Icon
         color="#60666E"
-        name="helpCircle"
+        name="info"
         size="24"
       >
         <svg

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -299,7 +299,7 @@ export const Tooltip: FunctionComponent<TooltipProps> = ({
             >
                 {children || (
                     <Icon
-                        name="helpCircle"
+                        name="info"
                         size={isMobile ? '24' : '16'}
                         color={Theme.greys['dark-grey']}
                     />


### PR DESCRIPTION
## PR Description
Ce PR remplace l'icône `help` par défaut du component Tooltip pour l'icône `info` qui est le bon icône selon les nouvelles maquettes.

[Doc Notion](https://www.notion.so/equisoft/Toggle-Tip-1ba74138a2634b5694aa039df165a296)
