### PR TITLE
fix(Stories): changed configs to land on introduction page

### DIFF
--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -13,7 +13,10 @@ module.exports = {
             shouldRemoveUndefinedFromOptional: true,
         },
     },
-    stories: ['../stories/**/*.stories.@(tsx|mdx)'],
+    stories: [
+        '../stories/0-intro.stories.mdx',
+        '../stories/**/*.stories.@(tsx|mdx)',
+    ],
     addons: [
         '@storybook/preset-scss',
         '@storybook/addon-docs',


### PR DESCRIPTION
## PR Description
La landing page devrait être la page d'introduction du DS.
Have no fear, le retrait de l'option `alphabetical` garde tout de même l'ordre pour les stories.
