### PR TITLE
DS-558 feat(DropdownMenuButton): add buttonAriaLabel prop

### DIFF
--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -486,7 +486,7 @@ exports[`BentoMenuButton Matches Snapshot (isDiv) 1`] = `
 <div
   aria-label="Menu"
   class="c0 c1"
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="false"
@@ -1198,7 +1198,7 @@ exports[`BentoMenuButton Matches Snapshot 1`] = `
 <nav
   aria-label="Menu"
   class="c0 c1"
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="false"

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
@@ -48,19 +48,23 @@ const StyledDropdownMenuButton = styled(DropdownMenuButton)`
 `;
 
 interface BentoMenuButtonProps {
+    ariaLabel?: string;
+    buttonAriaLabel?: string;
+    title?: string,
+    productLinks: NavItemProps[];
     externalLinks: ExternalItemProps[];
     isDiv?: boolean;
     onMenuVisibilityChanged?(isOpen: boolean): void;
-    productLinks: NavItemProps[];
-    title?: string,
 }
 
 export const BentoMenuButton: FunctionComponent<BentoMenuButtonProps> = ({
+    ariaLabel,
+    buttonAriaLabel,
+    title,
+    productLinks,
     externalLinks,
     isDiv = false,
     onMenuVisibilityChanged,
-    productLinks,
-    title,
 }) => {
     const { isMobile } = useDeviceContext();
     const { t } = useTranslation('bento');
@@ -113,6 +117,8 @@ export const BentoMenuButton: FunctionComponent<BentoMenuButtonProps> = ({
                 </>
             )}
             isDiv={isDiv}
+            ariaLabel={ariaLabel}
+            buttonAriaLabel={buttonAriaLabel}
             title={title}
             hasCaret={false}
             icon={<Icon name="bento" size={isMobile ? '24' : '16'} />}

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx
@@ -25,6 +25,22 @@ const TestGroups = (): ReactElement<GroupItemProps>[] | ReactElement<GroupItemPr
 );
 
 describe('DropdownMenuButton', () => {
+    test('adds aria-label to menu-button-wrapper when ariaLabel is defined', () => {
+        const ariaLabel = 'test-aria-label';
+
+        const wrapper = shallow(<DropdownMenuButton ariaLabel={ariaLabel} render={TestGroups} />);
+
+        expect(getByTestId(wrapper, 'menu-button-wrapper').prop('aria-label')).toBe(ariaLabel);
+    });
+
+    test('adds aria-label to menu-button when buttonAriaLabel is defined', () => {
+        const ariaLabel = 'test-aria-label';
+
+        const wrapper = shallow(<DropdownMenuButton buttonAriaLabel={ariaLabel} render={TestGroups} />);
+
+        expect(getByTestId(wrapper, 'menu-button').prop('aria-label')).toBe(ariaLabel);
+    });
+
     test('dropdown-menu is open when defaultOpen prop is set to true', () => {
         const wrapper = shallow(
             <DropdownMenuButton defaultOpen render={TestGroups} />,
@@ -69,7 +85,7 @@ describe('DropdownMenuButton', () => {
             <DropdownMenuButton isDiv render={TestGroups} />,
         );
 
-        const dropDownContainer = getByTestId(wrapper, 'dropdown-container');
+        const dropDownContainer = getByTestId(wrapper, 'menu-button-wrapper');
         expect(dropDownContainer.prop('as')).toEqual('div');
     });
 

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -436,7 +436,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 <nav
   aria-label="Menu"
   class="c0"
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="true"
@@ -1097,7 +1097,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 <nav
   aria-label="Menu"
   class="c0"
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="false"

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.tsx
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.tsx
@@ -51,7 +51,7 @@ interface MenuButtonProps {
      * @default 'Menu'
      * */
     ariaLabel?: string;
-    render?(close: () => void): ReactElement<GroupItemProps> | ReactElement<GroupItemProps>[];
+    buttonAriaLabel?: string;
     className?: string;
     /**
      * Sets menu open by default
@@ -69,6 +69,7 @@ interface MenuButtonProps {
     id?: string;
     isDiv?: boolean;
     firstItemRef?: RefObject<HTMLAnchorElement>;
+    render?(close: () => void): ReactElement<GroupItemProps> | ReactElement<GroupItemProps>[];
     onMenuVisibilityChanged?(isOpen: boolean): void;
 }
 
@@ -77,6 +78,7 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
     title,
     ariaLabel,
     isDiv = false,
+    buttonAriaLabel,
     className,
     defaultOpen = false,
     hasCaret = true,
@@ -163,15 +165,16 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
 
     return (
         <StyledNav
-            data-testid="dropdown-container"
-            as={containerTag}
-            ref={navRef}
-            className={className}
-            id={id}
             aria-label={ariaLabel || t('ariaLabel')}
+            as={containerTag}
+            className={className}
+            data-testid="menu-button-wrapper"
+            id={id}
+            ref={navRef}
         >
             {!isIconOnly && (
                 <StyledButton
+                    aria-label={buttonAriaLabel}
                     aria-expanded={isOpen}
                     data-expanded={isOpen}
                     data-testid="menu-button"
@@ -198,6 +201,7 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
             {isIconOnly && (
                 <IconButton
                     iconName="moreHorizontal"
+                    aria-label={buttonAriaLabel}
                     aria-expanded={isOpen}
                     data-expanded={isOpen}
                     data-testid="menu-button"

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -332,7 +332,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 <nav
   aria-label="User menu"
   class="c0 "
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="true"
@@ -822,7 +822,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
 <nav
   aria-label="User menu"
   class="c0 "
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="false"
@@ -1313,7 +1313,7 @@ exports[`UserProfile Matches Snapshot (isDiv) 1`] = `
 <div
   aria-label="User menu"
   class="c0 "
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="false"
@@ -1803,7 +1803,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 <nav
   aria-label="User menu"
   class="c0 c1"
-  data-testid="dropdown-container"
+  data-testid="menu-button-wrapper"
 >
   <button
     aria-expanded="false"

--- a/packages/react/src/components/user-profile/user-profile.tsx
+++ b/packages/react/src/components/user-profile/user-profile.tsx
@@ -30,6 +30,7 @@ interface UserProfileProps {
      * @default 'User menu'
      * */
     ariaLabel?: string;
+    buttonAriaLabel?: string;
     className?: string;
     /**
      * Sets menu open by default
@@ -46,6 +47,7 @@ interface UserProfileProps {
 
 export function UserProfile({
     ariaLabel,
+    buttonAriaLabel,
     className,
     defaultOpen = false,
     id,
@@ -63,6 +65,7 @@ export function UserProfile({
     return (
         <StyledDropdownMenuButton
             ariaLabel={ariaLabel || t('ariaLabel')}
+            buttonAriaLabel={buttonAriaLabel}
             className={className}
             data-testid="user-profile"
             defaultOpen={defaultOpen}


### PR DESCRIPTION
## PR Description
Cette PR ajoute la prop `buttonAriaLabel` sur DropdownMenuButton afin de permettre de passer une aria-label au bouton. La prop est forwardée aux components BentoMenuButton et UserProfile.

DS-558