### PR TITLE
DS-559 feat(NavMenuButton): add buttonAriaLabel prop

### DIFF
--- a/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx
@@ -39,6 +39,18 @@ describe('NavMenuButton', () => {
     buttonTypes.forEach((type) => {
         const isIconOnly = type === 'iconOnly';
 
+        test(`Adds aria-label to menu-button when buttonAriaLabel is defined (${type})`, () => {
+            const ariaLabel = 'test-aria-label';
+
+            const wrapper = shallow(
+                <NavMenuButton buttonAriaLabel={ariaLabel} options={options} iconOnly={isIconOnly} iconName="home">
+                    Test Button
+                </NavMenuButton>,
+            );
+
+            expect(getByTestId(wrapper, 'menu-button').prop('aria-label')).toBe(ariaLabel);
+        });
+
         test(`Opens nav-menu when menu-button is clicked (${type})`, () => {
             const wrapper = mountWithProviders(
                 <NavMenuButton options={options} iconOnly={isIconOnly} iconName="home">

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
@@ -56,6 +56,7 @@ interface MenuButtonProps {
      * @default 'Menu'
      * */
     ariaLabel?: string;
+    buttonAriaLabel?: string;
     children?: ReactNode;
     className?: string;
     /**
@@ -81,6 +82,7 @@ interface MenuButtonProps {
 
 export function NavMenuButton({
     ariaLabel,
+    buttonAriaLabel,
     children,
     className,
     defaultOpen = false,
@@ -169,6 +171,7 @@ export function NavMenuButton({
         <StyledNav ref={navRef} className={className} id={id} aria-label={ariaLabel || t('ariaLabel')}>
             {!iconOnly && (
                 <StyledButton
+                    aria-label={buttonAriaLabel}
                     aria-expanded={isOpen}
                     data-expanded={isOpen}
                     data-testid="menu-button"
@@ -193,6 +196,7 @@ export function NavMenuButton({
             )}
             {iconOnly && iconName && (
                 <IconButton
+                    aria-label={buttonAriaLabel}
                     aria-expanded={isOpen}
                     data-expanded={isOpen}
                     data-testid="menu-button"


### PR DESCRIPTION
## PR Description
Cette PR ajoute la prop `buttonAriaLabel` sur NavMenuButton afin de permettre de passer un aria-label au bouton.

DS-559