### PR TITLE
fix(SearchInput): only show reset button when input value is not empty

### DIFF
--- a/packages/react/src/components/search/search-input.test.tsx
+++ b/packages/react/src/components/search/search-input.test.tsx
@@ -62,10 +62,16 @@ describe('SearchInput', () => {
     });
 
     describe('reset', () => {
+        it('should display reset when onReset and value are provided', () => {
+            const wrapper = shallow(<SearchInput onReset={jest.fn()} value="test" />);
+
+            expect(getByTestId(wrapper, 'search-reset').length).toBe(1);
+        });
+
         it('should call onReset when reset is clicked', () => {
             const onReset = jest.fn();
             const wrapper = shallow(
-                <SearchInput onReset={onReset} />,
+                <SearchInput onReset={onReset} value="test" />,
             );
 
             getByTestId(wrapper, 'search-reset').invoke('onClick')();
@@ -74,13 +80,15 @@ describe('SearchInput', () => {
         });
 
         it('should not display reset when onReset is not provided', () => {
-            const wrapper = shallow(
-                <SearchInput />,
-            );
+            const wrapper = shallow(<SearchInput />);
 
-            const searchButton = getByTestId(wrapper, 'search-reset');
+            expect(getByTestId(wrapper, 'search-reset').length).toBe(0);
+        });
 
-            expect(searchButton.length).toBe(0);
+        it('should not display reset when onReset is provided but not value', () => {
+            const wrapper = shallow(<SearchInput onReset={jest.fn()} />);
+
+            expect(getByTestId(wrapper, 'search-reset').length).toBe(0);
         });
     });
 

--- a/packages/react/src/components/search/search-input.tsx
+++ b/packages/react/src/components/search/search-input.tsx
@@ -211,7 +211,7 @@ export const SearchInput: VoidFunctionComponent<SearchInputProps> = ({
                     data-testid="search-input"
                 />
 
-                {onReset && (
+                {(onReset && value) && (
                     <Reset onClick={handleReset} data-testid="search-reset">
                         <IcoReset />
                         <VisuallyHidden>Reset</VisuallyHidden>

--- a/packages/storybook/stories/search-contextual.stories.tsx
+++ b/packages/storybook/stories/search-contextual.stories.tsx
@@ -1,6 +1,6 @@
 import { SearchContextual } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
-import * as React from 'react';
+import React, { useState } from 'react';
 import { rawCodeParameters } from './utils/parameters';
 
 export default {
@@ -16,10 +16,24 @@ export const Disabled: Story = () => (
     <SearchContextual disabled />
 );
 
-export const EventCallback: Story = () => (
+export const EventCallbacks: Story = () => (
     <SearchContextual
         onChange={(value) => console.info(`New value is : ${value}`)}
-        onReset={() => console.info('Reset clicked')}
+        onSearch={(value) => console.info(`Searching for: ${value}`)}
+        onInputFocus={() => console.info('Input focused')}
     />
 );
-EventCallback.parameters = rawCodeParameters;
+EventCallbacks.parameters = rawCodeParameters;
+
+export const WithReset: Story = () => {
+    const [value, setValue] = useState('');
+
+    return (
+        <SearchContextual
+            value={value}
+            onChange={setValue}
+            onReset={() => setValue('')}
+        />
+    );
+};
+WithReset.parameters = rawCodeParameters;

--- a/packages/storybook/stories/search-global.stories.tsx
+++ b/packages/storybook/stories/search-global.stories.tsx
@@ -1,6 +1,6 @@
 import { SearchGlobal } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
-import React from 'react';
+import React, { useState } from 'react';
 import { rawCodeParameters } from './utils/parameters';
 
 export default {
@@ -14,9 +14,24 @@ export const Global: Story = () => (
 export const Disabled: Story = () => (
     <SearchGlobal disabled />
 );
-export const EventCallback: Story = () => (
+export const EventCallbacks: Story = () => (
     <SearchGlobal
+        onChange={(value) => console.info(`New value is : ${value}`)}
         onSearch={(value) => console.info(`Searching for: ${value}`)}
+        onInputFocus={() => console.info('Input focused')}
     />
 );
-EventCallback.parameters = rawCodeParameters;
+EventCallbacks.parameters = rawCodeParameters;
+
+export const WithReset: Story = () => {
+    const [value, setValue] = useState('');
+
+    return (
+        <SearchGlobal
+            value={value}
+            onChange={setValue}
+            onReset={() => setValue('')}
+        />
+    );
+};
+WithReset.parameters = rawCodeParameters;


### PR DESCRIPTION
## PR Description
Cette PR change la condition d'affichage du reset-button dans le component SearchInput afin qu'il s'affiche seulement lorsqu'il y a du texte dans l'input.

J'ajoute ce changement pour répondre au besoin de [ACC-958](https://jira.equisoft.com/browse/ACC-958?workflowName=CRM+Dev+Workflow+-+3.0&stepId=22)

![image](https://user-images.githubusercontent.com/53787300/140778477-1fe86668-b367-42f8-86fa-f0dd83617628.png)
![image](https://user-images.githubusercontent.com/53787300/140778562-b1fa46c8-9b43-4e16-ac14-c514b3a8864d.png)
