### PR TITLE
fix(Icon: organization): enable custom colors

### DIFF
--- a/packages/react/src/icons/organization.svg
+++ b/packages/react/src/icons/organization.svg
@@ -7,11 +7,11 @@
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Avatar" transform="translate(-20.000000, -19.000000)">
             <g id="Icon/Organisation" transform="translate(16.000000, 16.000000)">
-                <mask id="mask-2" fill="white">
+                <mask id="mask-2" fill="transparent">
                     <use xlink:href="#path-1"></use>
                 </mask>
-                <use id="Icon" fill="#000000" fill-rule="nonzero" xlink:href="#path-1"></use>
-                <g id="Group" mask="url(#mask-2)" fill="#003A5A">
+                <use id="Icon" fill="currentColor" fill-rule="nonzero" xlink:href="#path-1"></use>
+                <g id="Group" mask="url(#mask-2)" fill="currentColor">
                     <g id="Fill">
                         <rect id="Primary-70" x="0" y="0" width="48" height="48"></rect>
                     </g>


### PR DESCRIPTION
## PR Description
Quick PR pour permettre la coloration de l'icône `organization`.
