### PR TITLE
feat(Tabs): add :focus-visible selector to TabPanels

### DIFF
--- a/packages/react/src/components/tabs/tab-panel.tsx
+++ b/packages/react/src/components/tabs/tab-panel.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import styled from 'styled-components';
-import { focus } from '../../utils/css-state';
+import { focus, focusVisibleReset } from '../../utils/css-state';
 
 interface TabPanelProps {
     id: string,
@@ -11,6 +11,8 @@ interface TabPanelProps {
 
 const StyledDiv = styled.div`
     ${focus}
+    ${({ theme }) => focus({ theme }, false, ':focus-visible')}
+    ${focusVisibleReset}
 `;
 
 export function TabPanel({

--- a/packages/react/src/utils/css-state.ts
+++ b/packages/react/src/utils/css-state.ts
@@ -1,3 +1,4 @@
+import { css, FlattenInterpolation, ThemeProps } from 'styled-components';
 import { Theme } from '../themes';
 
 export const focus = ({ theme }: { theme: Theme }, hasBorder = false, selector?: string, inset = false): string => `
@@ -7,5 +8,13 @@ export const focus = ({ theme }: { theme: Theme }, hasBorder = false, selector?:
         ${hasBorder ? `border-color: ${theme.tokens['focus-border']};` : ''}
         box-shadow: ${theme.tokens['focus-box-shadow']};
         ${!hasBorder ? `box-shadow: ${inset ? theme.tokens['focus-border-box-shadow-inset'] : theme.tokens['focus-border-box-shadow']};` : ''}
+    }
+`;
+
+export const focusVisibleReset = (_props: { theme: Theme }, hasBorder = false): FlattenInterpolation<ThemeProps<Theme>> => css`
+    &:focus:not(:focus-visible) {
+        ${hasBorder && 'border-color: inherit;'}
+
+        box-shadow: none;
     }
 `;


### PR DESCRIPTION
## PR Description
Cette PR ajuste le focus sur le component TabPanel pour que les styles focus s'activent seulement au focus clavier. Cet ajustement est fonctionnel sur Chrome et Firefox, mais sur Safari c'est comme avant car le sélecteur css `:focus-visible` n'y est pas encore géré.

Ce changement a été apporté pour fix le bug [ACC-961](https://jira.equisoft.com/browse/ACC-961?workflowName=CRM+Dev+Workflow+-+3.0&stepId=22) dans CPanel2.
