### PR TITLE
feat(Lozenge): add icon prop

### DIFF
--- a/packages/react/src/components/lozenge/lozenge.test.tsx
+++ b/packages/react/src/components/lozenge/lozenge.test.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
+import { shallow } from 'enzyme';
 import renderer from 'react-test-renderer';
 import { ThemeWrapped } from '../../test-utils/theme-wrapped';
+import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { Lozenge } from './lozenge';
 
 describe('Lozenge', () => {
-    test('Matches the snapshot', () => {
+    test('has icon when icon prop is specified', () => {
+        const wrapper = shallow(<Lozenge icon="home">Test</Lozenge>);
+
+        expect(getByTestId(wrapper, 'lozenge-icon').exists()).toBe(true);
+    });
+
+    test('matches the snapshot', () => {
         const tree = renderer.create(
             ThemeWrapped(<Lozenge>Hello World</Lozenge>),
         ).toJSON();

--- a/packages/react/src/components/lozenge/lozenge.test.tsx.snap
+++ b/packages/react/src/components/lozenge/lozenge.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Lozenge Matches the snapshot 1`] = `
+exports[`Lozenge matches the snapshot 1`] = `
 .c0 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -11,7 +11,10 @@ exports[`Lozenge Matches the snapshot 1`] = `
   border-radius: var(--border-radius-half);
   box-sizing: border-box;
   color: #60666E;
-  display: inline-block;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
   max-width: 312px;
@@ -20,6 +23,9 @@ exports[`Lozenge Matches the snapshot 1`] = `
   text-overflow: ellipsis;
   text-transform: uppercase;
   white-space: nowrap;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
 }
 
 <span

--- a/packages/react/src/components/lozenge/lozenge.tsx
+++ b/packages/react/src/components/lozenge/lozenge.tsx
@@ -1,6 +1,7 @@
 import React, { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
+import { Icon, IconName } from '../icon/icon';
 
 const MAXIMUM_LENGTH = '312px';
 
@@ -11,7 +12,7 @@ const StyledLozenge = styled.span<{ isMobile: boolean }>`
     border-radius: ${({ isMobile }) => (isMobile ? 'var(--border-radius)' : 'var(--border-radius-half)')};
     box-sizing: border-box;
     color: ${({ theme }) => theme.greys['dark-grey']};
-    display: inline-block;
+    display: inline-flex;
     font-size: ${({ isMobile }) => (isMobile ? '0.875rem' : '0.75rem')};
     line-height: ${({ isMobile }) => (isMobile ? '1.375rem' : '0.875rem')};
     max-width: ${MAXIMUM_LENGTH};
@@ -20,16 +21,35 @@ const StyledLozenge = styled.span<{ isMobile: boolean }>`
     text-overflow: ellipsis;
     text-transform: uppercase;
     white-space: nowrap;
+    width: fit-content;
+`;
+
+const StyledIcon = styled(Icon)<{ isMobile: boolean }>`
+    margin-right: ${({ isMobile }) => (isMobile ? 'var(--spacing-1x)' : 'var(--spacing-half)')};
 `;
 
 interface Props {
     className?: string;
+    icon?: IconName;
 }
 
 export const Lozenge: FunctionComponent<Props> = ({
     children,
     className,
+    icon,
 }) => {
     const { isMobile } = useDeviceContext();
-    return <StyledLozenge className={className} isMobile={isMobile}>{children}</StyledLozenge>;
+    return (
+        <StyledLozenge className={className} isMobile={isMobile}>
+            {icon && (
+                <StyledIcon
+                    data-testid="lozenge-icon"
+                    name={icon}
+                    size={isMobile ? '16' : '12'}
+                    isMobile={isMobile}
+                />
+            )}
+            {children}
+        </StyledLozenge>
+    );
 };

--- a/packages/storybook/stories/lozenge.stories.tsx
+++ b/packages/storybook/stories/lozenge.stories.tsx
@@ -16,3 +16,7 @@ export const Mobile: Story = () => (
     <Lozenge>This is to highlight some text</Lozenge>
 );
 Mobile.decorators = [MobileDecorator];
+
+export const WithIcon: Story = () => (
+    <Lozenge icon="eye">With icon</Lozenge>
+);


### PR DESCRIPTION
## PR Description
Cette PR update les couleurs du component Lozenge (j'ai confirmé avec @maboilard avant de faire le changement) et ajoute la prop `icon` qui permet de définir un icône placé avant le texte.

Ce changement sera utilisé dans CPanel2 pour les lozenges `READ-ONLY` à travers l'app.

![image](https://user-images.githubusercontent.com/53787300/142228120-f931d03d-721c-4558-8ee3-fef619cf80c3.png)
