### PR TITLE
fix(Icon): revert some changes for organization icon visual integrity

### DIFF
--- a/packages/react/src/icons/organization.svg
+++ b/packages/react/src/icons/organization.svg
@@ -7,7 +7,7 @@
     <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Avatar" transform="translate(-20.000000, -19.000000)">
             <g id="Icon/Organisation" transform="translate(16.000000, 16.000000)">
-                <mask id="mask-2" fill="transparent">
+                <mask id="mask-2" fill="white">
                     <use xlink:href="#path-1"></use>
                 </mask>
                 <use id="Icon" fill="currentColor" fill-rule="nonzero" xlink:href="#path-1"></use>


### PR DESCRIPTION
## PR Description
C'était une erreur de mettre `transparent` sur le `<mask>` dans ma PR précédente. Ça brise un peu le visuel de l'icône. J'ai ramené comme c'était avant mon changement.

[PR précédente](https://github.com/kronostechnologies/design-elements/pull/350)
