### PR TITLE
chore(SectionalBanner): update heading font-weight

### DIFF
--- a/packages/react/src/components/sectional-banner/sectional-banner.test.tsx.snap
+++ b/packages/react/src/components/sectional-banner/sectional-banner.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`SectionalBanner should match snapshot (desktop) 1`] = `
 
 .c4 {
   font-size: 1rem;
-  font-weight: var(--font-bold);
+  font-weight: var(--font-semi-bold);
 }
 
 <div
@@ -113,7 +113,7 @@ exports[`SectionalBanner should match snapshot (mobile) 1`] = `
 
 .c4 {
   font-size: 1.125rem;
-  font-weight: var(--font-bold);
+  font-weight: var(--font-semi-bold);
 }
 
 <div

--- a/packages/react/src/components/sectional-banner/sectional-banner.tsx
+++ b/packages/react/src/components/sectional-banner/sectional-banner.tsx
@@ -96,7 +96,7 @@ const DismissIconButton = styled(IconButton)
 
 const Heading = styled.span<MobileDeviceContext>`
     font-size: ${(props) => (props.isMobile ? '1.125rem' : '1rem')};
-    font-weight: var(--font-bold);
+    font-weight: var(--font-semi-bold);
 `;
 
 const StyledActionButton = styled(Button)`


### PR DESCRIPTION
## PR Description
Le font-weight du titre dans le component SectionalBanner n'était pas le bon selon les maquettes. Il est donc passé de `bold` à `semi-bold`.

[Maquettes UI](https://app.abstract.com/projects/55967ec0-e299-11e8-90ab-3dc3d95512a4/branches/master/commits/3685dba233f3283115bf52e1cf0fd508d29cf0ae/files/09D85555-DE1E-4B3F-9AE5-3217CD24A5C6/layers/C6882BB2-5662-43A9-9D28-5EB1AC9791C0?collectionId=c74cd4cc-f540-45d7-a054-28650433c5bd&collectionLayerId=7430ff19-3c28-4739-b21a-b3caf71cb3b9&mode=design)
