### PR TITLE
chore(Modal): update overlay background-color

### DIFF
--- a/packages/react/src/components/modal/modal-dialog.test.tsx.snap
+++ b/packages/react/src/components/modal/modal-dialog.test.tsx.snap
@@ -298,7 +298,7 @@ exports[`Modal-Dialog Matches snapshot (custom button labels) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -547,7 +547,7 @@ exports[`Modal-Dialog Matches snapshot (custom footer content) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -842,7 +842,7 @@ exports[`Modal-Dialog Matches snapshot (not titles) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -1170,7 +1170,7 @@ exports[`Modal-Dialog Matches snapshot (only subtitle) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -1506,7 +1506,7 @@ exports[`Modal-Dialog Matches snapshot (only title) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -1849,7 +1849,7 @@ exports[`Modal-Dialog Matches snapshot (opened, desktop) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -2197,7 +2197,7 @@ exports[`Modal-Dialog Matches snapshot (opened, mobile) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"

--- a/packages/react/src/components/modal/modal.test.tsx.snap
+++ b/packages/react/src/components/modal/modal.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`Modal Matches snapshot (no close button, desktop) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -191,7 +191,7 @@ exports[`Modal Matches snapshot (no close button, mobile) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -386,7 +386,7 @@ exports[`Modal Matches snapshot (noPadding) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -595,7 +595,7 @@ exports[`Modal Matches snapshot (opened, desktop) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"
@@ -804,7 +804,7 @@ exports[`Modal Matches snapshot (opened, mobile) 1`] = `
   >
     <div
       class="ReactModal__Overlay"
-      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(255, 255, 255, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
+      style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.75); align-items: center; display: flex; justify-content: center; z-index: 10000;"
     >
       <div
         aria-describedby="modal-description"

--- a/packages/react/src/components/modal/modal.tsx
+++ b/packages/react/src/components/modal/modal.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, ReactNode, useCallback, useEffect, useState } from 'react';
 import ReactModal from 'react-modal';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { IconButton } from '../buttons/icon-button';
 import { DeviceContextProps, useDeviceContext } from '../device-context-provider/device-context-provider';
@@ -106,15 +106,6 @@ const Footer = styled.footer<FooterProps>`
     padding: var(--spacing-4x) ${getPadding} 0;
 `;
 
-const customStyles = {
-    overlay: { /* stylelint-disable-line selector-type-no-unknown */
-        alignItems: 'center',
-        display: 'flex',
-        justifyContent: 'center',
-        zIndex: 10000,
-    },
-};
-
 export interface ModalProps {
     /** Takes a query selector targeting the app Element. */
     appElement?: string;
@@ -184,6 +175,16 @@ export function Modal({
     const { breakpoints, isMobile } = useDeviceContext();
     const mainRefCallback = useCallback((node: HTMLUListElement) => setMainRef(node), []);
     const { t } = useTranslation('modal');
+    const theme = useTheme();
+    const customStyles = {
+        overlay: { /* stylelint-disable-line selector-type-no-unknown */
+            alignItems: 'center',
+            backgroundColor: theme.tokens['modal-overlay-background-color'],
+            display: 'flex',
+            justifyContent: 'center',
+            zIndex: 10000,
+        },
+    };
 
     const handleScroll = useCallback((): void => {
         if (mainRef) {

--- a/packages/react/src/themes/theme.ts
+++ b/packages/react/src/themes/theme.ts
@@ -35,6 +35,7 @@ export interface Theme {
         'focus-border-box-shadow': string;
         'focus-border-box-shadow-inset': string;
         'focus-border': string;
+        'modal-overlay-background-color': string;
         'overlay-box-shadow': string;
     };
 }

--- a/packages/react/src/themes/tokens.ts
+++ b/packages/react/src/themes/tokens.ts
@@ -6,5 +6,6 @@ export const tokens: Theme['tokens'] = {
     'focus-border-box-shadow': ` 0 0 0 1px ${main['primary-1.1']}, 0 0 0 3px ${main['primary-1.2']}`,
     'focus-border-box-shadow-inset': `inset 0 0 0 2px ${main['primary-1.2']}, inset 0 0 0 3px ${main['primary-1.1']}`,
     'focus-border': `${main['primary-1.1']}`,
+    'modal-overlay-background-color': 'rgba(0, 0, 0, 0.75)',
     'overlay-box-shadow': '0 10px 20px 0 rgba(0, 0, 0, 0.19)',
 };


### PR DESCRIPTION
## PR Description
Update la couleur de l'overlay des modales qui est maintenant `rgba(0, 0, 0, 0.75)`.

[Maquettes CPanel](https://app.abstract.com/projects/f39bb9a0-d2db-11e8-b657-63d973464341/branches/master/commits/latest/files/8e822eb0-bc0e-440a-b9bd-d23e4c77c00d/layers/FE415DBA-6319-4464-9F05-2B9DE56E3D2D?collectionId=ecf361b5-ff5a-43b9-8127-80e5a291a1ba&collectionLayerId=7b70a200-7dbc-4327-9581-6569aa4018cb&mode=design&selected=root-4FDB52F1-D0A2-4C36-947C-46B4FEBDA6C3)
[Maquettes Centralize](https://app.abstract.com/projects/fde2bf20-a028-4108-8678-0960c9adac2f/branches/e9d04caa-7b50-4da1-87a0-147986c5ea89/commits/latest/files/5f68a04e-999d-4807-b21f-993f689ea406/layers/4D5C37B1-D84F-4E6D-9C83-8FBE2B89BBDA?collectionId=463e5c17-5cf5-40da-a5c8-61e1d19b6c3f&collectionLayerId=71462e4c-cef7-4171-a8f4-78e89604541a&mode=build&selected=root-4B684945-17FD-465C-A901-D4C9384479B1)
