### PR TITLE
fix(TextInput): allow checking validity in form when untouched

### DIFF
--- a/packages/react/src/components/money-input/money-input.test.tsx.snap
+++ b/packages/react/src/components/money-input/money-input.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`CurrencyInput Component matches snapshot (en-CA) 1`] = `
 >
   <div
     className="c1"
+    data-testid="field-container"
   >
     <input
       className="c2"
@@ -109,6 +110,7 @@ exports[`CurrencyInput Component matches snapshot (en-CA) 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
+      onInvalid={[Function]}
       placeholder="$"
       type="text"
       value="$100.00"
@@ -218,6 +220,7 @@ exports[`CurrencyInput Component matches snapshot (en-US) 1`] = `
 >
   <div
     className="c1"
+    data-testid="field-container"
   >
     <input
       className="c2"
@@ -226,6 +229,7 @@ exports[`CurrencyInput Component matches snapshot (en-US) 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
+      onInvalid={[Function]}
       placeholder="$"
       type="text"
       value="$100.00"
@@ -335,6 +339,7 @@ exports[`CurrencyInput Component matches snapshot (fr-CA) 1`] = `
 >
   <div
     className="c1"
+    data-testid="field-container"
   >
     <input
       className="c2"
@@ -343,6 +348,7 @@ exports[`CurrencyInput Component matches snapshot (fr-CA) 1`] = `
       onBlur={[Function]}
       onChange={[Function]}
       onFocus={[Function]}
+      onInvalid={[Function]}
       placeholder="$"
       type="text"
       value="100,00 $"

--- a/packages/react/src/components/text-input/text-input.test.tsx
+++ b/packages/react/src/components/text-input/text-input.test.tsx
@@ -49,6 +49,22 @@ describe('TextInput', () => {
         expect(wrapper.find('input').prop('name')).toBe('test');
     });
 
+    test('should be valid by default', () => {
+        const wrapper = shallow(<TextInput {...initialProps} />);
+
+        const container = getByTestId(wrapper, 'field-container');
+        expect(container.prop('valid')).toBe(true);
+    });
+
+    test('should set as invalid when invalid event is triggered', () => {
+        const wrapper = shallow(<TextInput {...initialProps} />);
+
+        getByTestId(wrapper, 'text-input').simulate('invalid');
+
+        const container = getByTestId(wrapper, 'field-container');
+        expect(container.prop('valid')).toBe(false);
+    });
+
     test('onChange callback is called when content is changed', () => {
         const callback = jest.fn();
         const wrapper = setup(callback);

--- a/packages/react/src/components/text-input/text-input.test.tsx.snap
+++ b/packages/react/src/components/text-input/text-input.test.tsx.snap
@@ -111,6 +111,7 @@ input + .c1 {
 
 <div
   className="c0"
+  data-testid="field-container"
 >
   <label
     className="c1 c2"
@@ -125,6 +126,7 @@ input + .c1 {
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    onInvalid={[Function]}
     pattern="[0-9]{3}-?[0-9]{3}-?[0-9]{4}"
     placeholder="Ex.: 555-123-4567"
     type="tel"
@@ -243,6 +245,7 @@ input + .c1 {
 
 <div
   className="c0"
+  data-testid="field-container"
 >
   <label
     className="c1 c2"
@@ -256,6 +259,7 @@ input + .c1 {
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    onInvalid={[Function]}
     pattern="[0-9]{3}-?[0-9]{3}-?[0-9]{4}"
     placeholder="Ex.: 555-123-4567"
     required={true}
@@ -375,6 +379,7 @@ input + .c1 {
 
 <div
   className="c0"
+  data-testid="field-container"
 >
   <label
     className="c1 c2"
@@ -388,6 +393,7 @@ input + .c1 {
     onBlur={[Function]}
     onChange={[Function]}
     onFocus={[Function]}
+    onInvalid={[Function]}
     pattern="[0-9]{3}-?[0-9]{3}-?[0-9]{4}"
     placeholder="Ex.: 555-123-4567"
     type="tel"

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -2,6 +2,7 @@ import React, {
     ChangeEvent,
     DetailedHTMLProps,
     FocusEvent,
+    FormEventHandler,
     forwardRef,
     InputHTMLAttributes,
     KeyboardEvent,
@@ -94,6 +95,10 @@ export const TextInput = forwardRef(({
         }
     }, [onBlur]);
 
+    const handleOnInvalid: FormEventHandler<HTMLInputElement> = useCallback(() => {
+        setValidity({ validity: false });
+    }, []);
+
     const handleChange: (event: ChangeEvent<HTMLInputElement>) => void = useCallback((event) => {
         if (onChange) {
             onChange(event);
@@ -115,6 +120,7 @@ export const TextInput = forwardRef(({
             valid={validity}
             validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
             hint={hint}
+            data-testid="field-container"
         >
             <Input
                 autoComplete={autoComplete}
@@ -132,6 +138,7 @@ export const TextInput = forwardRef(({
                 onMouseUp={onMouseUp}
                 onKeyUp={onKeyUp}
                 onKeyDown={onKeyDown}
+                onInvalid={handleOnInvalid}
                 pattern={pattern}
                 placeholder={placeholder}
                 required={required}

--- a/packages/storybook/stories/text-input.stories.tsx
+++ b/packages/storybook/stories/text-input.stories.tsx
@@ -1,6 +1,6 @@
-import { TextInput } from '@equisoft/design-elements-react';
+import { Button, TextInput } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
-import React from 'react';
+import React, { FormEventHandler } from 'react';
 import { rawCodeParameters } from './utils/parameters';
 
 export default {
@@ -116,3 +116,23 @@ export const Disabled: Story = () => (
         validationErrorMessage="Error message"
     />
 );
+
+export const RequiredInForm: Story = () => {
+    const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+        event.currentTarget.checkValidity();
+    };
+
+    return (
+        <form noValidate onSubmit={handleSubmit}>
+            <TextInput
+                disabled={false}
+                required
+                label="Last Name (required)"
+                type="text"
+                validationErrorMessage="This field is required"
+            />
+            <Button type="submit" buttonType="primary">Submit</Button>
+        </form>
+    );
+};


### PR DESCRIPTION
Le check de validity se faisait juste sur le onBlur sinon. Il n'y a pas moyen d'afficher le message d'erreur si le user clique directement pour soumettre le form.