### PR TITLE
DS-573 chore(Tabs): update styles

### DIFF
--- a/packages/react/src/components/card/card.test.tsx
+++ b/packages/react/src/components/card/card.test.tsx
@@ -1,13 +1,20 @@
-import renderer from 'react-test-renderer';
-import { ThemeWrapped } from '../../test-utils/theme-wrapped';
+import { shallow } from 'enzyme';
+import { getByTestId } from '../../test-utils/enzyme-selectors';
+import { renderWithProviders } from '../../test-utils/renderer';
 import { Card } from './card';
 
 describe('Card', () => {
-    test('Matches the snapshot', () => {
-        const tree = renderer.create(
-            ThemeWrapped(<Card>Hello World</Card>),
-        ).toJSON();
+    test('adds data-testid', () => {
+        const testId = 'test-id';
 
-        expect(tree).toMatchSnapshot();
+        const wrapper = shallow(<Card data-testid={testId}>Test</Card>);
+
+        expect(getByTestId(wrapper, testId).exists()).toBe(true);
+    });
+
+    test('Matches the snapshot', () => {
+        const wrapper = renderWithProviders(<Card>Hello World</Card>);
+
+        expect(wrapper).toMatchSnapshot();
     });
 });

--- a/packages/react/src/components/card/card.test.tsx.snap
+++ b/packages/react/src/components/card/card.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Card Matches the snapshot 1`] = `
 }
 
 <div
-  className="c0"
+  class="c0"
 >
   Hello World
 </div>

--- a/packages/react/src/components/card/card.tsx
+++ b/packages/react/src/components/card/card.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent } from 'react';
 import styled from 'styled-components';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 
 const StyledDiv = styled.div<{ $noPadding?: boolean }>`
     background: ${(props) => props.theme.greys.white};
@@ -16,8 +17,22 @@ interface Props {
     noPadding?: boolean;
 }
 
-export const Card: FunctionComponent<Props> = ({ children, className, noPadding }) => (
-    <StyledDiv className={className} $noPadding={noPadding}>
-        {children}
-    </StyledDiv>
-);
+export const Card: FunctionComponent<Props> = ({
+    children,
+    className,
+    noPadding,
+    ...otherProps
+}) => {
+    const dataAttributes = useDataAttributes(otherProps);
+
+    return (
+        <StyledDiv
+            className={className}
+            $noPadding={noPadding}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...dataAttributes}
+        >
+            {children}
+        </StyledDiv>
+    );
+};

--- a/packages/react/src/components/card/card.tsx
+++ b/packages/react/src/components/card/card.tsx
@@ -1,13 +1,23 @@
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 
-const Card = styled.div`
+const StyledDiv = styled.div<{ $noPadding?: boolean }>`
     background: ${(props) => props.theme.greys.white};
     border: 1px solid ${(props) => props.theme.greys['light-grey']};
     border-radius: var(--border-radius-2x);
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
     box-sizing: border-box;
     margin-bottom: var(--spacing-3x);
-    padding: var(--spacing-3x) var(--spacing-4x) var(--spacing-4x);
+    padding: ${({ $noPadding }) => ($noPadding ? '0' : 'var(--spacing-3x) var(--spacing-4x) var(--spacing-4x)')};
 `;
 
-export { Card };
+interface Props {
+    className?: string;
+    noPadding?: boolean;
+}
+
+export const Card: FunctionComponent<Props> = ({ children, className, noPadding }) => (
+    <StyledDiv className={className} $noPadding={noPadding}>
+        {children}
+    </StyledDiv>
+);

--- a/packages/react/src/components/datepicker/datepicker.test.tsx.snap
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx.snap
@@ -57,7 +57,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -343,7 +343,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -629,7 +629,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -945,7 +945,7 @@ input + .c1 {
 .c7 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -1253,7 +1253,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -1696,7 +1696,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -2821,7 +2821,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 
@@ -3879,7 +3879,7 @@ input + .c1 {
 .c4 .react-datepicker {
   border: 1px solid #DBDEE1;
   box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
-  font-family: 'Open Sans',sans-serif;
+  font-family: var(--font-family);
   padding: var(--spacing-3x) var(--spacing-2x);
 }
 

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -62,7 +62,7 @@ const Container = styled.div<{ isMobile: boolean, theme: Theme }>`
     .react-datepicker {
         border: 1px solid ${({ theme }) => theme.greys.grey};
         box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.19);
-        font-family: 'Open Sans', sans-serif;
+        font-family: var(--font-family);
         padding: var(--spacing-3x) var(--spacing-2x);
     }
 

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -3,9 +3,13 @@ import styled, { css } from 'styled-components';
 import { focus } from '../../utils/css-state';
 import { Icon, IconName } from '../icon/icon';
 
-const StyledButton = styled.button<{ isSelected: boolean }>`
+interface $isSelected {
+    $isSelected: boolean;
+}
+
+const StyledButton = styled.button<$isSelected & { $isGlobal?: boolean; }>`
     align-items: center;
-    border-bottom: 1px solid #878f9a; /* TODO change colors when updating thematization */
+    border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     bottom: -1px;
     cursor: pointer;
     display: flex;
@@ -15,7 +19,6 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
     min-width: 82px;
     padding: 0 var(--spacing-2x);
     position: relative;
-    z-index: 1;
 
     &:hover {
         background-color: ${({ theme }) => theme.greys.grey};
@@ -23,7 +26,9 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
 
     ${focus};
 
-    /* ${({ isSelected, theme }) => isSelected && `
+    ${({ $isGlobal, $isSelected, theme }) => ($isGlobal && $isSelected) && css`
+        z-index: 1;
+
         ::after {
             content: '';
             background-color: ${theme.main['primary-1.1']};
@@ -34,47 +39,41 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
             position: absolute;
             width: 100%;
         }
-    `} */
+    `}
 
-    ${({ isSelected, theme }) => isSelected && css`
+    ${({ $isGlobal, $isSelected, theme }) => (!$isGlobal && $isSelected) && css`
         background-color: ${theme.greys.white};
 
         /* TODO change with next thematization */
         border: 1px solid #878f9a;
         border-bottom: 1px solid transparent;
         border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+        z-index: 1;
     `}
 `;
 
-const StyledButtonText = styled.span<{ isSelected: boolean }>`
+const StyledButtonText = styled.span<$isSelected>`
     color: ${({ theme }) => theme.greys.black};
     font-family: var(--font-family);
     font-size: 0.875rem;
-    font-weight: ${({ isSelected }) => (isSelected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
+    font-weight: ${({ $isSelected }) => ($isSelected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
 `;
 
-const LeftIcon = styled(Icon)<{ $isSelected: boolean }>`
-    color: ${({ $isSelected, theme }) => ($isSelected ? theme.main['primary-1.1'] : theme.greys['dark-grey'])};
+const LeftIcon = styled(Icon)<$isSelected>`
+    color: ${({ theme }) => theme.greys.black};
     padding-right: var(--spacing-half);
-
-    ${/* sc-select */ StyledButton}:hover & {
-        color: ${({ theme }) => theme.main['primary-2']};
-    }
 `;
 
-const RightIcon = styled(Icon)<{ $isSelected: boolean }>`
-    color: ${({ $isSelected, theme }) => ($isSelected ? theme.main['primary-1.1'] : theme.greys['dark-grey'])};
+const RightIcon = styled(Icon)<$isSelected>`
+    color: ${({ theme }) => theme.greys.black};
     padding-left: var(--spacing-half);
-
-    ${/* sc-select */ StyledButton}:hover & {
-        color: ${({ theme }) => theme.main['primary-2']};
-    }
 `;
 
 interface TabButtonProps {
+    global?: boolean;
     id: string;
-    panelId: string;
     children: string;
+    panelId: string;
     leftIcon?: IconName
     rightIcon?: IconName;
     isSelected: boolean;
@@ -85,6 +84,7 @@ interface TabButtonProps {
 }
 
 export const TabButton = forwardRef(({
+    global,
     id,
     panelId,
     children,
@@ -102,7 +102,8 @@ export const TabButton = forwardRef(({
         ref={ref}
         data-testid="tab-button"
         tabIndex={isSelected ? undefined : -1}
-        isSelected={isSelected}
+        $isGlobal={global}
+        $isSelected={isSelected}
         onClick={onClick}
         onKeyDown={onKeyDown}
     >
@@ -114,7 +115,7 @@ export const TabButton = forwardRef(({
                 size="16"
             />
         )}
-        <StyledButtonText data-testid="tab-button-text" isSelected={isSelected}>
+        <StyledButtonText data-testid="tab-button-text" $isSelected={isSelected}>
             {children}
         </StyledButtonText>
         {rightIcon && (

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -1,6 +1,6 @@
 import { KeyboardEvent, ReactElement, forwardRef, Ref } from 'react';
 import styled, { css } from 'styled-components';
-import { focus } from '../../utils/css-state';
+import { focus, focusVisibleReset } from '../../utils/css-state';
 import { Icon, IconName } from '../icon/icon';
 
 interface $isSelected {
@@ -24,15 +24,17 @@ const StyledButton = styled.button<$isSelected & { $isGlobal?: boolean; }>`
         background-color: ${({ theme }) => theme.greys.grey};
     }
 
-    ${focus};
+    ${focus}
+    ${({ theme }) => focus({ theme }, false, ':focus-visible')}
+    ${focusVisibleReset}
 
     ${({ $isGlobal, $isSelected, theme }) => ($isGlobal && $isSelected) && css`
         z-index: 1;
 
         ::after {
-            content: '';
             background-color: ${theme.main['primary-1.1']};
             bottom: 0;
+            content: '';
             display: block;
             height: 4px;
             left: 0;

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -17,6 +17,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     align-items: center;
     border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     bottom: -1px;
+    color: ${({ $isGlobal }) => ($isGlobal ? '#1B1C1E' : '#878f9a')}; /* TODO change colors when updating thematization */
     cursor: pointer;
     display: flex;
     justify-content: center;
@@ -35,7 +36,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     ${focusVisibleReset}
 
     &:focus {
-        z-index: 1;
+        z-index: 2;
     }
 
     ${({ $isGlobal, $isSelected, theme }) => ($isGlobal && $isSelected) && css`
@@ -55,11 +56,10 @@ const StyledButton = styled.button<StyledButtonProps>`
 
     ${({ $isGlobal, $isSelected, theme }) => (!$isGlobal && $isSelected) && css`
         background-color: ${theme.greys.white};
-
-        /* TODO change with next thematization */
-        border: 1px solid #878f9a;
+        border: 1px solid #878f9a; /* TODO change colors when updating thematization */
         border-bottom: 1px solid transparent;
         border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+        color: #1b1c1e; /* TODO change colors when updating thematization */
         z-index: 1;
     `}
 `;

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -1,10 +1,11 @@
 import { KeyboardEvent, ReactElement, forwardRef, Ref } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { focus } from '../../utils/css-state';
 import { Icon, IconName } from '../icon/icon';
 
 const StyledButton = styled.button<{ isSelected: boolean }>`
     align-items: center;
+    border-bottom: 1px solid #878f9a; /* TODO change colors when updating thematization */
     bottom: -1px;
     cursor: pointer;
     display: flex;
@@ -12,10 +13,17 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
     line-height: 1.5rem;
     min-height: 48px;
     min-width: 82px;
+    padding: 0 var(--spacing-2x);
+    position: relative;
+    z-index: 1;
+
+    &:hover {
+        background-color: ${({ theme }) => theme.greys.grey};
+    }
 
     ${focus};
 
-    ${({ isSelected, theme }) => isSelected && `
+    /* ${({ isSelected, theme }) => isSelected && `
         ::after {
             content: '';
             background-color: ${theme.main['primary-1.1']};
@@ -26,23 +34,23 @@ const StyledButton = styled.button<{ isSelected: boolean }>`
             position: absolute;
             width: 100%;
         }
-    `}
+    `} */
 
-    padding-left: var(--spacing-2x);
-    padding-right: var(--spacing-2x);
-    position: relative;
-    z-index: 1;
+    ${({ isSelected, theme }) => isSelected && css`
+        background-color: ${theme.greys.white};
+
+        /* TODO change with next thematization */
+        border: 1px solid #878f9a;
+        border-bottom: 1px solid transparent;
+        border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+    `}
 `;
 
 const StyledButtonText = styled.span<{ isSelected: boolean }>`
-    color: ${({ isSelected, theme }) => (isSelected ? `${theme.main['primary-1.1']}` : `${theme.greys['dark-grey']}`)};
-    font-family: Open Sans, sans-serif;
+    color: ${({ theme }) => theme.greys.black};
+    font-family: var(--font-family);
     font-size: 0.875rem;
-    -webkit-text-stroke-width: ${({ isSelected }) => (isSelected ? '0.4px' : '0')};
-
-    ${/* sc-select */ StyledButton}:hover & {
-        color: ${({ theme }) => theme.main['primary-2']};
-    }
+    font-weight: ${({ isSelected }) => (isSelected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
 `;
 
 const LeftIcon = styled(Icon)<{ $isSelected: boolean }>`

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -2,12 +2,18 @@ import { KeyboardEvent, ReactElement, forwardRef, Ref } from 'react';
 import styled, { css } from 'styled-components';
 import { focus, focusVisibleReset } from '../../utils/css-state';
 import { Icon, IconName } from '../icon/icon';
+import { useDeviceContext } from '../device-context-provider/device-context-provider';
 
-interface $isSelected {
+interface IsSelected {
     $isSelected: boolean;
 }
 
-const StyledButton = styled.button<$isSelected & { $isGlobal?: boolean; }>`
+interface StyledButtonProps extends IsSelected {
+    $isGlobal?: boolean;
+    $isMobile: boolean;
+}
+
+const StyledButton = styled.button<StyledButtonProps>`
     align-items: center;
     border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     bottom: -1px;
@@ -15,7 +21,7 @@ const StyledButton = styled.button<$isSelected & { $isGlobal?: boolean; }>`
     display: flex;
     justify-content: center;
     line-height: 1.5rem;
-    min-height: 48px;
+    min-height: ${({ $isMobile }) => ($isMobile ? 56 : 48)}px;
     min-width: 82px;
     padding: 0 var(--spacing-2x);
     position: relative;
@@ -27,6 +33,10 @@ const StyledButton = styled.button<$isSelected & { $isGlobal?: boolean; }>`
     ${focus}
     ${({ theme }) => focus({ theme }, false, ':focus-visible')}
     ${focusVisibleReset}
+
+    &:focus {
+        z-index: 1;
+    }
 
     ${({ $isGlobal, $isSelected, theme }) => ($isGlobal && $isSelected) && css`
         z-index: 1;
@@ -54,20 +64,23 @@ const StyledButton = styled.button<$isSelected & { $isGlobal?: boolean; }>`
     `}
 `;
 
-const StyledButtonText = styled.span<$isSelected>`
+const StyledButtonText = styled.span<IsSelected & { $isMobile: boolean; }>`
     color: ${({ theme }) => theme.greys.black};
     font-family: var(--font-family);
-    font-size: 0.875rem;
+    font-size: ${({ $isMobile }) => ($isMobile ? 1 : 0.875)}rem;
     font-weight: ${({ $isSelected }) => ($isSelected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
+    line-height: 1.5rem;
 `;
 
-const LeftIcon = styled(Icon)<$isSelected>`
+const LeftIcon = styled(Icon)<IsSelected>`
     color: ${({ theme }) => theme.greys.black};
+    min-width: fit-content;
     padding-right: var(--spacing-half);
 `;
 
-const RightIcon = styled(Icon)<$isSelected>`
+const RightIcon = styled(Icon)<IsSelected>`
     color: ${({ theme }) => theme.greys.black};
+    min-width: fit-content;
     padding-left: var(--spacing-half);
 `;
 
@@ -95,38 +108,43 @@ export const TabButton = forwardRef(({
     isSelected,
     onClick,
     onKeyDown,
-}: TabButtonProps, ref: Ref<HTMLButtonElement>): ReactElement => (
-    <StyledButton
-        id={id}
-        aria-controls={panelId}
-        role="tab"
-        aria-selected={isSelected}
-        ref={ref}
-        data-testid="tab-button"
-        tabIndex={isSelected ? undefined : -1}
-        $isGlobal={global}
-        $isSelected={isSelected}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-    >
-        {leftIcon && (
-            <LeftIcon
-                data-testid="tab-button-left-icon"
-                $isSelected={isSelected}
-                name={leftIcon}
-                size="16"
-            />
-        )}
-        <StyledButtonText data-testid="tab-button-text" $isSelected={isSelected}>
-            {children}
-        </StyledButtonText>
-        {rightIcon && (
-            <RightIcon
-                data-testid="tab-button-right-icon"
-                $isSelected={isSelected}
-                name={rightIcon}
-                size="16"
-            />
-        )}
-    </StyledButton>
-));
+}: TabButtonProps, ref: Ref<HTMLButtonElement>): ReactElement => {
+    const { isMobile } = useDeviceContext();
+
+    return (
+        <StyledButton
+            id={id}
+            aria-controls={panelId}
+            role="tab"
+            aria-selected={isSelected}
+            ref={ref}
+            data-testid="tab-button"
+            tabIndex={isSelected ? undefined : -1}
+            $isGlobal={global}
+            $isMobile={isMobile}
+            $isSelected={isSelected}
+            onClick={onClick}
+            onKeyDown={onKeyDown}
+        >
+            {leftIcon && (
+                <LeftIcon
+                    data-testid="tab-button-left-icon"
+                    $isSelected={isSelected}
+                    name={leftIcon}
+                    size="16"
+                />
+            )}
+            <StyledButtonText data-testid="tab-button-text" $isSelected={isSelected} $isMobile={isMobile}>
+                {children}
+            </StyledButtonText>
+            {rightIcon && (
+                <RightIcon
+                    data-testid="tab-button-right-icon"
+                    $isSelected={isSelected}
+                    name={rightIcon}
+                    size="16"
+                />
+            )}
+        </StyledButton>
+    );
+});

--- a/packages/react/src/components/tabs/tab-panel.tsx
+++ b/packages/react/src/components/tabs/tab-panel.tsx
@@ -11,7 +11,7 @@ interface TabPanelProps {
 }
 
 const StyledDiv = styled.div<{ $contained?: boolean }>`
-    border: ${({ $contained }) => $contained && '1px solid #878F9A'}; // TODO change with next thematization
+    border: ${({ $contained }) => ($contained ? '1px solid #878F9A' : 'none')}; /* TODO change with next thematization */
     border-top: none;
 
     ${focus}

--- a/packages/react/src/components/tabs/tab-panel.tsx
+++ b/packages/react/src/components/tabs/tab-panel.tsx
@@ -3,31 +3,37 @@ import styled from 'styled-components';
 import { focus, focusVisibleReset } from '../../utils/css-state';
 
 interface TabPanelProps {
-    id: string,
     buttonId: string,
-    hidden: boolean,
     children: ReactNode;
+    contained?: boolean;
+    hidden: boolean,
+    id: string,
 }
 
-const StyledDiv = styled.div`
+const StyledDiv = styled.div<{ $contained?: boolean }>`
+    border: ${({ $contained }) => $contained && '1px solid #878F9A'}; // TODO change with next thematization
+    border-top: none;
+
     ${focus}
     ${({ theme }) => focus({ theme }, false, ':focus-visible')}
     ${focusVisibleReset}
 `;
 
 export function TabPanel({
-    id,
     buttonId,
-    hidden,
     children,
+    contained,
+    hidden,
+    id,
 }: TabPanelProps): ReactElement {
     return (
         <StyledDiv
-            id={id}
-            role="tabpanel"
-            hidden={hidden}
+            $contained={contained}
             aria-hidden={hidden}
             aria-labelledby={buttonId}
+            hidden={hidden}
+            id={id}
+            role="tabpanel"
             tabIndex={0}
         >
             {children}

--- a/packages/react/src/components/tabs/tabs.test.tsx
+++ b/packages/react/src/components/tabs/tabs.test.tsx
@@ -2,7 +2,7 @@ import { ReactWrapper } from 'enzyme';
 import ReactDOM from 'react-dom';
 import { findByTestId, getByTestId } from '../../test-utils/enzyme-selectors';
 import { expectFocusToBeOn } from '../../test-utils/enzyme-utils';
-import { mountWithProviders, mountWithTheme } from '../../test-utils/renderer';
+import { mountWithProviders, mountWithTheme, renderWithProviders } from '../../test-utils/renderer';
 import { Tab, Tabs } from './tabs';
 
 function givenTabs(amount: number): Tab[] {
@@ -21,6 +21,8 @@ function expectPanelToBeRendered(wrapper: ReactWrapper, tabPanelTestId: string):
     const tabPanel = findByTestId(wrapper, tabPanelTestId);
     expect(tabPanel.isEmptyRender()).toBe(false);
 }
+
+jest.mock('../../utils/uuid');
 
 describe('Tabs', () => {
     test('should display the first tab panel by default', () => {
@@ -96,6 +98,30 @@ describe('Tabs', () => {
         getByTestId(wrapper, 'tab-button-2').simulate('click');
 
         expectPanelToBeRendered(wrapper, 'tab-panel-2');
+    });
+
+    test('matches snapshot', () => {
+        const tabs: Tab[] = givenTabs(2);
+
+        const wrapper = renderWithProviders(<Tabs tabs={tabs} forceRenderTabPanels />);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('matches snapshot (global)', () => {
+        const tabs: Tab[] = givenTabs(2);
+
+        const wrapper = renderWithProviders(<Tabs tabs={tabs} global forceRenderTabPanels />);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('matches snapshot (mobile)', () => {
+        const tabs: Tab[] = givenTabs(2);
+
+        const wrapper = renderWithProviders(<Tabs tabs={tabs} forceRenderTabPanels />, 'mobile');
+
+        expect(wrapper).toMatchSnapshot();
     });
 
     describe('focus', () => {

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -1,0 +1,677 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tabs matches snapshot (global) 1`] = `
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: none;
+  bottom: -1px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  min-height: 48px;
+  min-width: 82px;
+  padding: 0 var(--spacing-2x);
+  position: relative;
+  z-index: 1;
+}
+
+.c1:hover {
+  background-color: #DBDEE1;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c1:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c1:focus {
+  z-index: 1;
+}
+
+.c1::after {
+  background-color: #006296;
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 4px;
+  left: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: none;
+  bottom: -1px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  min-height: 48px;
+  min-width: 82px;
+  padding: 0 var(--spacing-2x);
+  position: relative;
+}
+
+.c3:hover {
+  background-color: #DBDEE1;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c3:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c3:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c3:focus {
+  z-index: 1;
+}
+
+.c2 {
+  color: #000000;
+  font-family: var(--font-family);
+  font-size: 0.875rem;
+  font-weight: var(--font-semi-bold);
+  line-height: 1.5rem;
+}
+
+.c4 {
+  color: #000000;
+  font-family: var(--font-family);
+  font-size: 0.875rem;
+  font-weight: var(--font-normal);
+  line-height: 1.5rem;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c5:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0;
+}
+
+<div>
+  <div
+    aria-label="tabs label"
+    class="c0"
+    role="tablist"
+  >
+    <button
+      aria-selected="true"
+      class="c1"
+      data-testid="tab-button"
+      id="button 1-0"
+      role="tab"
+    >
+      <span
+        class="c2"
+        data-testid="tab-button-text"
+      >
+        button 1
+      </span>
+    </button>
+    <button
+      aria-selected="false"
+      class="c3"
+      data-testid="tab-button"
+      id="button 2-1"
+      role="tab"
+      tabindex="-1"
+    >
+      <span
+        class="c4"
+        data-testid="tab-button-text"
+      >
+        button 2
+      </span>
+    </button>
+  </div>
+  <div
+    aria-hidden="false"
+    aria-labelledby="button 1-0"
+    class="c5"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-1"
+    >
+      content
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    aria-labelledby="button 2-1"
+    class="c5"
+    hidden=""
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-2"
+    >
+      content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Tabs matches snapshot (mobile) 1`] = `
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #878f9a;
+  bottom: -1px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  min-height: 56px;
+  min-width: 82px;
+  padding: 0 var(--spacing-2x);
+  position: relative;
+  background-color: #FFFFFF;
+  border: 1px solid #878f9a;
+  border-bottom: 1px solid transparent;
+  border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+  z-index: 1;
+}
+
+.c1:hover {
+  background-color: #DBDEE1;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c1:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c1:focus {
+  z-index: 1;
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #878f9a;
+  bottom: -1px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  min-height: 56px;
+  min-width: 82px;
+  padding: 0 var(--spacing-2x);
+  position: relative;
+}
+
+.c3:hover {
+  background-color: #DBDEE1;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c3:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c3:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c3:focus {
+  z-index: 1;
+}
+
+.c2 {
+  color: #000000;
+  font-family: var(--font-family);
+  font-size: 1rem;
+  font-weight: var(--font-semi-bold);
+  line-height: 1.5rem;
+}
+
+.c4 {
+  color: #000000;
+  font-family: var(--font-family);
+  font-size: 1rem;
+  font-weight: var(--font-normal);
+  line-height: 1.5rem;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c5:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #878f9a;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 var(--spacing-2x);
+}
+
+<div>
+  <div
+    aria-label="tabs label"
+    class="c0"
+    role="tablist"
+  >
+    <button
+      aria-selected="true"
+      class="c1"
+      data-testid="tab-button"
+      id="button 1-0"
+      role="tab"
+    >
+      <span
+        class="c2"
+        data-testid="tab-button-text"
+      >
+        button 1
+      </span>
+    </button>
+    <button
+      aria-selected="false"
+      class="c3"
+      data-testid="tab-button"
+      id="button 2-1"
+      role="tab"
+      tabindex="-1"
+    >
+      <span
+        class="c4"
+        data-testid="tab-button-text"
+      >
+        button 2
+      </span>
+    </button>
+  </div>
+  <div
+    aria-hidden="false"
+    aria-labelledby="button 1-0"
+    class="c5"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-1"
+    >
+      content
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    aria-labelledby="button 2-1"
+    class="c5"
+    hidden=""
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-2"
+    >
+      content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Tabs matches snapshot 1`] = `
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #878f9a;
+  bottom: -1px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  min-height: 48px;
+  min-width: 82px;
+  padding: 0 var(--spacing-2x);
+  position: relative;
+  background-color: #FFFFFF;
+  border: 1px solid #878f9a;
+  border-bottom: 1px solid transparent;
+  border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+  z-index: 1;
+}
+
+.c1:hover {
+  background-color: #DBDEE1;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c1:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c1:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c1:focus {
+  z-index: 1;
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #878f9a;
+  bottom: -1px;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1.5rem;
+  min-height: 48px;
+  min-width: 82px;
+  padding: 0 var(--spacing-2x);
+  position: relative;
+}
+
+.c3:hover {
+  background-color: #DBDEE1;
+}
+
+.c3:focus {
+  outline: none;
+}
+
+.c3:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c3:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c3:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c3:focus {
+  z-index: 1;
+}
+
+.c2 {
+  color: #000000;
+  font-family: var(--font-family);
+  font-size: 0.875rem;
+  font-weight: var(--font-semi-bold);
+  line-height: 1.5rem;
+}
+
+.c4 {
+  color: #000000;
+  font-family: var(--font-family);
+  font-size: 0.875rem;
+  font-weight: var(--font-normal);
+  line-height: 1.5rem;
+}
+
+.c5:focus {
+  outline: none;
+}
+
+.c5:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c5:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c5:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-bottom: 1px solid #878f9a;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 0 var(--spacing-2x);
+}
+
+<div>
+  <div
+    aria-label="tabs label"
+    class="c0"
+    role="tablist"
+  >
+    <button
+      aria-selected="true"
+      class="c1"
+      data-testid="tab-button"
+      id="button 1-0"
+      role="tab"
+    >
+      <span
+        class="c2"
+        data-testid="tab-button-text"
+      >
+        button 1
+      </span>
+    </button>
+    <button
+      aria-selected="false"
+      class="c3"
+      data-testid="tab-button"
+      id="button 2-1"
+      role="tab"
+      tabindex="-1"
+    >
+      <span
+        class="c4"
+        data-testid="tab-button-text"
+      >
+        button 2
+      </span>
+    </button>
+  </div>
+  <div
+    aria-hidden="false"
+    aria-labelledby="button 1-0"
+    class="c5"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-1"
+    >
+      content
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    aria-labelledby="button 2-1"
+    class="c5"
+    hidden=""
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-2"
+    >
+      content
+    </div>
+  </div>
+</div>
+`;

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   align-items: center;
   border-bottom: none;
   bottom: -1px;
+  color: #1B1C1E;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -50,7 +51,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c1:focus {
-  z-index: 1;
+  z-index: 2;
 }
 
 .c1::after {
@@ -71,6 +72,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   align-items: center;
   border-bottom: none;
   bottom: -1px;
+  color: #1B1C1E;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -112,7 +114,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c3:focus {
-  z-index: 1;
+  z-index: 2;
 }
 
 .c2 {
@@ -129,6 +131,11 @@ exports[`Tabs matches snapshot (global) 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: 1.5rem;
+}
+
+.c5 {
+  border: none;
+  border-top: none;
 }
 
 .c5:focus {
@@ -238,6 +245,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   align-items: center;
   border-bottom: 1px solid #878f9a;
   bottom: -1px;
+  color: #878f9a;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -256,6 +264,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   border: 1px solid #878f9a;
   border-bottom: 1px solid transparent;
   border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+  color: #1b1c1e;
   z-index: 1;
 }
 
@@ -284,7 +293,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 }
 
 .c1:focus {
-  z-index: 1;
+  z-index: 2;
 }
 
 .c3 {
@@ -294,6 +303,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   align-items: center;
   border-bottom: 1px solid #878f9a;
   bottom: -1px;
+  color: #878f9a;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -335,7 +345,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 }
 
 .c3:focus {
-  z-index: 1;
+  z-index: 2;
 }
 
 .c2 {
@@ -352,6 +362,11 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-normal);
   line-height: 1.5rem;
+}
+
+.c5 {
+  border: none;
+  border-top: none;
 }
 
 .c5:focus {
@@ -384,7 +399,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0 var(--spacing-2x);
+  padding: 0 0 0 var(--spacing-4x);
 }
 
 <div>
@@ -461,6 +476,7 @@ exports[`Tabs matches snapshot 1`] = `
   align-items: center;
   border-bottom: 1px solid #878f9a;
   bottom: -1px;
+  color: #878f9a;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -479,6 +495,7 @@ exports[`Tabs matches snapshot 1`] = `
   border: 1px solid #878f9a;
   border-bottom: 1px solid transparent;
   border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+  color: #1b1c1e;
   z-index: 1;
 }
 
@@ -507,7 +524,7 @@ exports[`Tabs matches snapshot 1`] = `
 }
 
 .c1:focus {
-  z-index: 1;
+  z-index: 2;
 }
 
 .c3 {
@@ -517,6 +534,7 @@ exports[`Tabs matches snapshot 1`] = `
   align-items: center;
   border-bottom: 1px solid #878f9a;
   bottom: -1px;
+  color: #878f9a;
   cursor: pointer;
   display: -webkit-box;
   display: -webkit-flex;
@@ -558,7 +576,7 @@ exports[`Tabs matches snapshot 1`] = `
 }
 
 .c3:focus {
-  z-index: 1;
+  z-index: 2;
 }
 
 .c2 {
@@ -575,6 +593,11 @@ exports[`Tabs matches snapshot 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: 1.5rem;
+}
+
+.c5 {
+  border: none;
+  border-top: none;
 }
 
 .c5:focus {
@@ -607,7 +630,7 @@ exports[`Tabs matches snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding: 0 var(--spacing-2x);
+  padding: 0 0 0 var(--spacing-4x);
 }
 
 <div>

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -6,12 +6,12 @@ import { IconName } from '../icon/icon';
 import { TabButton } from './tab-button';
 import { TabPanel } from './tab-panel';
 
-const CenteredContentDiv = styled.div`
+const CenteredContentDiv = styled.div<{ $isGlobal?: boolean }>`
     align-items: center;
-    border-bottom: 1px solid #878f9a; /* TODO change colors when updating thematization */
+    border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     display: flex;
     margin-bottom: var(--spacing-1x);
-    padding: 0 var(--spacing-2x);
+    padding: ${({ $isGlobal }) => ($isGlobal ? '0' : '0 var(--spacing-2x)')};
 `;
 
 export interface Tab {
@@ -30,10 +30,13 @@ interface TabItem extends Tab {
 interface Props {
     className?: string;
     forceRenderTabPanels?: boolean;
+    global?: boolean;
     tabs: Tab[];
 }
 
-export const Tabs: VoidFunctionComponent<Props> = ({ className, forceRenderTabPanels, tabs }) => {
+export const Tabs: VoidFunctionComponent<Props> = ({
+    className, global, forceRenderTabPanels, tabs,
+}) => {
     const tabItems: TabItem[] = useMemo((): TabItem[] => tabs.map(
         (tab, i) => ({
             ...tab,
@@ -101,9 +104,11 @@ export const Tabs: VoidFunctionComponent<Props> = ({ className, forceRenderTabPa
             <CenteredContentDiv
                 role="tablist"
                 aria-label="tabs label"
+                $isGlobal={global}
             >
                 {tabItems.map((tabItem, i) => (
                     <TabButton
+                        global={global}
                         id={tabItem.id}
                         panelId={tabItem.panelId}
                         key={tabItem.panelId}

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -28,13 +28,15 @@ interface TabItem extends Tab {
 
 interface Props {
     className?: string;
+    /** Not available in global mode */
+    contained?: boolean;
     forceRenderTabPanels?: boolean;
     global?: boolean;
     tabs: Tab[];
 }
 
 export const Tabs: VoidFunctionComponent<Props> = ({
-    className, global, forceRenderTabPanels, tabs,
+    className, contained, global, forceRenderTabPanels, tabs,
 }) => {
     const tabItems: TabItem[] = useMemo((): TabItem[] => tabs.map(
         (tab, i) => ({
@@ -127,10 +129,11 @@ export const Tabs: VoidFunctionComponent<Props> = ({
                 if (forceRenderTabPanels || isTabSelected(tabItem.id)) {
                     return (
                         <TabPanel
-                            id={tabItem.panelId}
                             buttonId={tabItem.id}
-                            key={tabItem.panelId}
+                            contained={contained && !global}
                             hidden={!isTabSelected(tabItem.id)}
+                            id={tabItem.panelId}
+                            key={tabItem.panelId}
                         >
                             {tabItem.panelContent}
                         </TabPanel>

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -6,7 +6,7 @@ import { IconName } from '../icon/icon';
 import { TabButton } from './tab-button';
 import { TabPanel } from './tab-panel';
 
-const CenteredContentDiv = styled.div<{ $isGlobal?: boolean }>`
+const TabButtonsContainer = styled.div<{ $isGlobal?: boolean; }>`
     align-items: center;
     border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     display: flex;
@@ -100,7 +100,7 @@ export const Tabs: VoidFunctionComponent<Props> = ({
 
     return (
         <div className={className}>
-            <CenteredContentDiv
+            <TabButtonsContainer
                 role="tablist"
                 aria-label="tabs label"
                 $isGlobal={global}
@@ -122,7 +122,7 @@ export const Tabs: VoidFunctionComponent<Props> = ({
                         {tabItem.title}
                     </TabButton>
                 ))}
-            </CenteredContentDiv>
+            </TabButtonsContainer>
             {tabItems.map((tabItem) => {
                 if (forceRenderTabPanels || isTabSelected(tabItem.id)) {
                     return (

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -10,7 +10,7 @@ const TabButtonsContainer = styled.div<{ $isGlobal?: boolean; }>`
     align-items: center;
     border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     display: flex;
-    padding: ${({ $isGlobal }) => ($isGlobal ? '0' : '0 var(--spacing-2x)')};
+    padding: ${({ $isGlobal }) => ($isGlobal ? '0' : '0 0 0 var(--spacing-4x)')};
 `;
 
 export interface Tab {

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -10,7 +10,6 @@ const CenteredContentDiv = styled.div<{ $isGlobal?: boolean }>`
     align-items: center;
     border-bottom: ${({ $isGlobal }) => ($isGlobal ? 'none' : '1px solid #878f9a')}; /* TODO change colors when updating thematization */
     display: flex;
-    margin-bottom: var(--spacing-1x);
     padding: ${({ $isGlobal }) => ($isGlobal ? '0' : '0 var(--spacing-2x)')};
 `;
 

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -11,6 +11,7 @@ const CenteredContentDiv = styled.div`
     border-bottom: 1px solid #878f9a; /* TODO change colors when updating thematization */
     display: flex;
     margin-bottom: var(--spacing-1x);
+    padding: 0 var(--spacing-2x);
 `;
 
 export interface Tab {

--- a/packages/react/src/styles/_variables.scss
+++ b/packages/react/src/styles/_variables.scss
@@ -1,5 +1,6 @@
 :root, :host {
   // var for typo
+  --font-family: 'Open Sans', sans-serif;
   --font-normal: 400;
   --font-semi-bold: 600;
   --font-bold: 700;

--- a/packages/react/src/styles/body.scss
+++ b/packages/react/src/styles/body.scss
@@ -4,7 +4,7 @@
 body {
   background: rgb(248, 248, 250);
   color: rgb(0, 0, 0);
-  font-family: "Open Sans", sans-serif;
+  font-family: var(--font-family);
   font-size: 0.875rem;
   -moz-osx-font-smoothing: grayscale;
   letter-spacing: 0.015rem;
@@ -14,7 +14,7 @@ body {
 
 :host {
   color: rgb(0, 0, 0);
-  font-family: "Open Sans", sans-serif;
+  font-family: var(--font-family);
   font-size: 0.875rem;
   -moz-osx-font-smoothing: grayscale;
   letter-spacing: 0.025rem;

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -9,6 +9,15 @@ export default {
     parameters: rawCodeParameters,
 };
 
+const StyledCard = styled(Card)`
+    background-color: ${({ theme }) => theme.greys['light-grey']};
+`;
+
+const TabPanel = styled.div`
+    background-color: ${({ theme }) => theme.greys.white};
+    padding: var(--spacing-2x);
+`;
+
 interface Data {
     column1: string;
     column2: string;
@@ -88,15 +97,6 @@ export const Global: Story = () => {
 };
 
 export const InCard: Story = () => {
-    const StyledCard = styled(Card)`
-        background-color: ${({ theme }) => theme.greys['light-grey']};
-    `;
-
-    const TabPanel = styled.div`
-        background-color: ${({ theme }) => theme.greys.white};
-        padding: var(--spacing-2x);
-    `;
-
     const tabs: Tab[] = [
         {
             title: 'First Button',

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -61,6 +61,31 @@ export const Normal: Story = () => {
     );
 };
 
+export const Global: Story = () => {
+    const tabs: Tab[] = [
+        {
+            title: 'First Button',
+            leftIcon: 'chevronUp',
+            panelContent: <Card>First panel</Card>,
+        },
+        {
+            title: 'Second Button',
+            leftIcon: 'chevronLeft',
+            rightIcon: 'chevronRight',
+            panelContent: <Card>Second panel</Card>,
+        },
+        {
+            title: 'Third Button',
+            rightIcon: 'chevronDown',
+            panelContent: <Card>Third panel</Card>,
+        },
+    ];
+
+    return (
+        <Tabs global tabs={tabs} />
+    );
+};
+
 export const WithIcons: Story = () => {
     const tabs: Tab[] = [
         {

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -1,5 +1,6 @@
 import { Card, Tab, Table, TableColumn, Tabs, TextArea } from '@equisoft/design-elements-react';
 import { Story } from '@storybook/react';
+import styled from 'styled-components';
 import { rawCodeParameters } from './utils/parameters';
 
 export default {
@@ -83,6 +84,42 @@ export const Global: Story = () => {
 
     return (
         <Tabs global tabs={tabs} />
+    );
+};
+
+export const InCard: Story = () => {
+    const StyledCard = styled(Card)`
+        background-color: ${({ theme }) => theme.greys['light-grey']};
+    `;
+
+    const TabPanel = styled.div`
+        background-color: ${({ theme }) => theme.greys.white};
+        padding: var(--spacing-2x);
+    `;
+
+    const tabs: Tab[] = [
+        {
+            title: 'First Button',
+            leftIcon: 'chevronUp',
+            panelContent: <TabPanel>First panel</TabPanel>,
+        },
+        {
+            title: 'Second Button',
+            leftIcon: 'chevronLeft',
+            rightIcon: 'chevronRight',
+            panelContent: <TabPanel>Second panel</TabPanel>,
+        },
+        {
+            title: 'Third Button',
+            rightIcon: 'chevronDown',
+            panelContent: <TabPanel>Third panel</TabPanel>,
+        },
+    ];
+
+    return (
+        <StyledCard noPadding>
+            <Tabs tabs={tabs} />
+        </StyledCard>
     );
 };
 

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -9,12 +9,7 @@ export default {
     parameters: rawCodeParameters,
 };
 
-const StyledCard = styled(Card)`
-    background-color: ${({ theme }) => theme.greys['light-grey']};
-`;
-
-const TabPanel = styled.div`
-    background-color: ${({ theme }) => theme.greys.white};
+const StyledDiv = styled.div`
     padding: var(--spacing-2x);
 `;
 
@@ -49,20 +44,28 @@ export const Normal: Story = () => {
     const tabs: Tab[] = [
         {
             title: 'Contact',
-            panelContent: <Table columns={contactTableColumns} data={contactTableData} />,
+            panelContent: (
+                <StyledDiv>
+                    <Table columns={contactTableColumns} data={contactTableData} />
+                </StyledDiv>
+            ),
         },
         {
             title: 'Calendar',
             panelContent: (
-                <div>
+                <StyledDiv>
                     <Card>Monday : Doing something meaningful</Card>
                     <Card>Tuesday : Doing something else</Card>
-                </div>
+                </StyledDiv>
             ),
         },
         {
             title: 'Note',
-            panelContent: <TextArea label="Notes" />,
+            panelContent: (
+                <StyledDiv>
+                    <TextArea label="Notes" />
+                </StyledDiv>
+            ),
         },
     ];
 
@@ -76,18 +79,18 @@ export const Global: Story = () => {
         {
             title: 'First Button',
             leftIcon: 'chevronUp',
-            panelContent: <Card>First panel</Card>,
+            panelContent: <StyledDiv>First tab content</StyledDiv>,
         },
         {
             title: 'Second Button',
             leftIcon: 'chevronLeft',
             rightIcon: 'chevronRight',
-            panelContent: <Card>Second panel</Card>,
+            panelContent: <StyledDiv>Second tab content</StyledDiv>,
         },
         {
             title: 'Third Button',
             rightIcon: 'chevronDown',
-            panelContent: <Card>Third panel</Card>,
+            panelContent: <StyledDiv>Third tab content</StyledDiv>,
         },
     ];
 
@@ -96,50 +99,23 @@ export const Global: Story = () => {
     );
 };
 
-export const InCard: Story = () => {
-    const tabs: Tab[] = [
-        {
-            title: 'First Button',
-            leftIcon: 'chevronUp',
-            panelContent: <TabPanel>First panel</TabPanel>,
-        },
-        {
-            title: 'Second Button',
-            leftIcon: 'chevronLeft',
-            rightIcon: 'chevronRight',
-            panelContent: <TabPanel>Second panel</TabPanel>,
-        },
-        {
-            title: 'Third Button',
-            rightIcon: 'chevronDown',
-            panelContent: <TabPanel>Third panel</TabPanel>,
-        },
-    ];
-
-    return (
-        <StyledCard noPadding>
-            <Tabs tabs={tabs} />
-        </StyledCard>
-    );
-};
-
 export const WithIcons: Story = () => {
     const tabs: Tab[] = [
         {
             title: 'First Button',
             leftIcon: 'chevronUp',
-            panelContent: <Card>First panel</Card>,
+            panelContent: <StyledDiv>First tab content</StyledDiv>,
         },
         {
             title: 'Second Button',
             leftIcon: 'chevronLeft',
             rightIcon: 'chevronRight',
-            panelContent: <Card>Second panel</Card>,
+            panelContent: <StyledDiv>Second tab content</StyledDiv>,
         },
         {
             title: 'Third Button',
             rightIcon: 'chevronDown',
-            panelContent: <Card>Third panel</Card>,
+            panelContent: <StyledDiv>Third tab content</StyledDiv>,
         },
     ];
 
@@ -152,15 +128,15 @@ export const WithForceRenderTabPanels: Story = () => {
     const tabs: Tab[] = [
         {
             title: 'First Button',
-            panelContent: <Card>First panel</Card>,
+            panelContent: <StyledDiv>First tab content</StyledDiv>,
         },
         {
             title: 'Second Button',
-            panelContent: <Card>Second panel</Card>,
+            panelContent: <StyledDiv>Second tab content</StyledDiv>,
         },
         {
             title: 'Third Button',
-            panelContent: <Card>Third panel</Card>,
+            panelContent: <StyledDiv>Third tab content</StyledDiv>,
         },
     ];
 
@@ -173,15 +149,15 @@ export const Contained: Story = () => {
     const tabs: Tab[] = [
         {
             title: 'First Button',
-            panelContent: <span>First panel</span>,
+            panelContent: <StyledDiv>First tab content</StyledDiv>,
         },
         {
             title: 'Second Button',
-            panelContent: <span>Second panel</span>,
+            panelContent: <StyledDiv>Second tab content</StyledDiv>,
         },
         {
             title: 'Third Button',
-            panelContent: <span>Third panel</span>,
+            panelContent: <StyledDiv>Third tab content</StyledDiv>,
         },
     ];
 

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -168,3 +168,24 @@ export const WithForceRenderTabPanels: Story = () => {
         <Tabs tabs={tabs} forceRenderTabPanels />
     );
 };
+
+export const Contained: Story = () => {
+    const tabs: Tab[] = [
+        {
+            title: 'First Button',
+            panelContent: <span>First panel</span>,
+        },
+        {
+            title: 'Second Button',
+            panelContent: <span>Second panel</span>,
+        },
+        {
+            title: 'Third Button',
+            panelContent: <span>Third panel</span>,
+        },
+    ];
+
+    return (
+        <Tabs tabs={tabs} contained />
+    );
+};


### PR DESCRIPTION
## PR Description
Cette PR update le visuel du component Tabs avec les nouvelles maquettes. Les nouvelles tabs comportent un style par défaut et un style global. Un peu de refactor a été fait et j'ai ajouté la prop `noPadding` sur le component Card.

DS-573

### Default
![image](https://user-images.githubusercontent.com/53787300/145416828-8e6c541c-3bfd-4c6e-83b1-4741b13624dd.png)

### Global
![image](https://user-images.githubusercontent.com/53787300/145417233-8ae115f5-2c15-482b-8e0c-bcd1f96cf70e.png)

### In card
![image](https://user-images.githubusercontent.com/53787300/145417321-e3f484b3-6a6f-42e8-b2d0-96da501635e3.png)
