### PR TITLE
ci: change '>' to '>>' in npm publish

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -282,7 +282,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TAG: ${{ needs.setup.outputs.qualifier }}
         run: |
-          echo -e "npmRegistries: \n  //registry.yarnpkg.com:\n    npmAlwaysAuth: true\n    npmAuthToken: ${NPM_TOKEN}" > ~/.yarnrc.yml
+          echo -e "npmRegistries: \n  //registry.yarnpkg.com:\n    npmAlwaysAuth: true\n    npmAuthToken: ${NPM_TOKEN}" >> ~/.yarnrc.yml
           yarn npm publish --tag "${NPM_TAG}" --tolerate-republish
 
   storybook_eslint:


### PR DESCRIPTION
## PR Description
Change `>` pour `>>` dans le `echo` de npm publish en espérant fixer la publication sur npm.
