### PR TITLE
feat(MenuButton): add iconName and label props

### DIFF
--- a/packages/react/src/components/menu-button/menu-button.test.tsx
+++ b/packages/react/src/components/menu-button/menu-button.test.tsx
@@ -29,7 +29,7 @@ describe('MenuButton', () => {
     });
 
     it('should open menu when menu-button is clicked', () => {
-        const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options} />);
+        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" options={options} />);
         waitForComponentToPaint(wrapper);
 
         getByTestId(wrapper, 'menu-button').simulate('click');
@@ -38,13 +38,13 @@ describe('MenuButton', () => {
     });
 
     it('should be default open when defaultOpen prop is set to true', () => {
-        const wrapper = mountWithTheme(<MenuButton buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
 
         expect(getByTestId(wrapper, 'menu').exists()).toBe(true);
     });
 
     it('should close menu when escape key is pressed inside menu', () => {
-        const wrapper = mountWithTheme(<MenuButton buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'Escape' });
 
@@ -53,7 +53,7 @@ describe('MenuButton', () => {
 
     it('should focus menu-button when escape key is pressed inside menu', () => {
         const wrapper = mountWithTheme(
-            <MenuButton buttonType="primary" defaultOpen options={options} />,
+            <MenuButton label="test" buttonType="primary" defaultOpen options={options} />,
             { attachTo: document.body },
         );
 
@@ -64,7 +64,7 @@ describe('MenuButton', () => {
     });
 
     it('should close menu when tab key is pressed inside menu', () => {
-        const wrapper = mountWithTheme(<MenuButton buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'Tab' });
 
@@ -72,7 +72,7 @@ describe('MenuButton', () => {
     });
 
     it('should close menu when an option is selected inside menu', () => {
-        const wrapper = mountWithTheme(<MenuButton buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('click');
 
@@ -81,13 +81,20 @@ describe('MenuButton', () => {
 
     describe('chevron icon', () => {
         it('should point downwards when menu is not open', () => {
-            const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options} />);
+            const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" options={options} />);
 
             expect(getByTestId(wrapper, 'chevron-icon').prop('name')).toBe('chevronDown');
         });
 
         it('should point upwards when menu is open', () => {
-            const wrapper = mountWithTheme(<MenuButton buttonType="primary" defaultOpen options={options} />);
+            const wrapper = mountWithTheme(
+                <MenuButton
+                    label="test"
+                    buttonType="primary"
+                    defaultOpen
+                    options={options}
+                />,
+            );
 
             expect(getByTestId(wrapper, 'chevron-icon').prop('name')).toBe('chevronUp');
         });

--- a/packages/react/src/components/menu-button/menu-button.test.tsx
+++ b/packages/react/src/components/menu-button/menu-button.test.tsx
@@ -1,8 +1,11 @@
+import { shallow } from 'enzyme';
 import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { waitForComponentToPaint } from '../../test-utils/enzyme-utils';
 import { mountWithTheme } from '../../test-utils/renderer';
 import { MenuOption } from '../menu/menu';
 import { MenuButton } from './menu-button';
+import { Button } from '../buttons/button';
+import { IconButton } from '../buttons/icon-button';
 
 function givenOptions(): MenuOption[] {
     return [
@@ -26,6 +29,18 @@ describe('MenuButton', () => {
 
     beforeEach(() => {
         options = givenOptions();
+    });
+
+    it('should return Button component by default', () => {
+        const wrapper = shallow(<MenuButton label="test" buttonType="primary" options={options} />);
+
+        expect(getByTestId(wrapper, 'menu-button').type()).toBe(Button);
+    });
+
+    it('should return IconButton component when iconName prop is defined', () => {
+        const wrapper = shallow(<MenuButton label="test" iconName="home" buttonType="primary" options={options} />);
+
+        expect(getByTestId(wrapper, 'menu-button').type()).toBe(IconButton);
     });
 
     it('should open menu when menu-button is clicked', () => {

--- a/packages/react/src/components/menu-button/menu-button.test.tsx
+++ b/packages/react/src/components/menu-button/menu-button.test.tsx
@@ -32,19 +32,19 @@ describe('MenuButton', () => {
     });
 
     it('should return Button component by default', () => {
-        const wrapper = shallow(<MenuButton label="test" buttonType="primary" options={options} />);
+        const wrapper = shallow(<MenuButton buttonType="primary" options={options}>Test</MenuButton>);
 
         expect(getByTestId(wrapper, 'menu-button').type()).toBe(Button);
     });
 
     it('should return IconButton component when iconName prop is defined', () => {
-        const wrapper = shallow(<MenuButton label="test" iconName="home" buttonType="primary" options={options} />);
+        const wrapper = shallow(<MenuButton iconName="home" buttonType="primary" options={options}>Test</MenuButton>);
 
         expect(getByTestId(wrapper, 'menu-button').type()).toBe(IconButton);
     });
 
     it('should open menu when menu-button is clicked', () => {
-        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" options={options} />);
+        const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options}>Test</MenuButton>);
         waitForComponentToPaint(wrapper);
 
         getByTestId(wrapper, 'menu-button').simulate('click');
@@ -53,13 +53,21 @@ describe('MenuButton', () => {
     });
 
     it('should be default open when defaultOpen prop is set to true', () => {
-        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(
+            <MenuButton buttonType="primary" defaultOpen options={options}>
+                Test
+            </MenuButton>,
+        );
 
         expect(getByTestId(wrapper, 'menu').exists()).toBe(true);
     });
 
     it('should close menu when escape key is pressed inside menu', () => {
-        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(
+            <MenuButton buttonType="primary" defaultOpen options={options}>
+                Test
+            </MenuButton>,
+        );
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'Escape' });
 
@@ -68,7 +76,7 @@ describe('MenuButton', () => {
 
     it('should focus menu-button when escape key is pressed inside menu', () => {
         const wrapper = mountWithTheme(
-            <MenuButton label="test" buttonType="primary" defaultOpen options={options} />,
+            <MenuButton buttonType="primary" defaultOpen options={options}>Test</MenuButton>,
             { attachTo: document.body },
         );
 
@@ -79,7 +87,11 @@ describe('MenuButton', () => {
     });
 
     it('should close menu when tab key is pressed inside menu', () => {
-        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(
+            <MenuButton buttonType="primary" defaultOpen options={options}>
+                Test
+            </MenuButton>,
+        );
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'Tab' });
 
@@ -87,7 +99,11 @@ describe('MenuButton', () => {
     });
 
     it('should close menu when an option is selected inside menu', () => {
-        const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" defaultOpen options={options} />);
+        const wrapper = mountWithTheme(
+            <MenuButton buttonType="primary" defaultOpen options={options}>
+                Test
+            </MenuButton>,
+        );
 
         getByTestId(wrapper, 'menu-option-0').simulate('click');
 
@@ -96,7 +112,7 @@ describe('MenuButton', () => {
 
     describe('chevron icon', () => {
         it('should point downwards when menu is not open', () => {
-            const wrapper = mountWithTheme(<MenuButton label="test" buttonType="primary" options={options} />);
+            const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options}>Test</MenuButton>);
 
             expect(getByTestId(wrapper, 'chevron-icon').prop('name')).toBe('chevronDown');
         });
@@ -104,11 +120,12 @@ describe('MenuButton', () => {
         it('should point upwards when menu is open', () => {
             const wrapper = mountWithTheme(
                 <MenuButton
-                    label="test"
                     buttonType="primary"
                     defaultOpen
                     options={options}
-                />,
+                >
+                    Test
+                </MenuButton>,
             );
 
             expect(getByTestId(wrapper, 'chevron-icon').prop('name')).toBe('chevronUp');

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -20,12 +20,11 @@ interface Props {
     buttonType: ButtonType;
     defaultOpen?: boolean;
     iconName?: IconName;
-    label?: string;
     options: MenuOption[];
 }
 
 export const MenuButton: FunctionComponent<Props> = ({
-    buttonType, defaultOpen, iconName, label, options,
+    buttonType, children, defaultOpen, iconName, options,
 }) => {
     const [controlledVisible, setControlledVisible] = useState(!!defaultOpen);
     const {
@@ -77,7 +76,7 @@ export const MenuButton: FunctionComponent<Props> = ({
                     onClick={() => setControlledVisible(!controlledVisible)}
                     ref={setTriggerRef}
                 >
-                    {label}
+                    {children}
                     <StyledIcon
                         aria-hidden="true"
                         data-testid="chevron-icon"

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import { Menu, MenuOption } from '../menu/menu';
 import { Button, ButtonType } from '../buttons/button';
-import { Icon } from '../icon/icon';
+import { Icon, IconName } from '../icon/icon';
+import { IconButton } from '../buttons/icon-button';
 import { menuDimensions } from '../../tokens/menuDimensions';
 
 const StyledMenu = styled(Menu)`
@@ -18,12 +19,13 @@ const StyledIcon = styled(Icon)`
 interface Props {
     buttonType: ButtonType;
     defaultOpen?: boolean;
-    label: string;
+    iconName?: IconName;
+    label?: string;
     options: MenuOption[];
 }
 
 export const MenuButton: FunctionComponent<Props> = ({
-    buttonType, defaultOpen, label, options,
+    buttonType, defaultOpen, iconName, label, options,
 }) => {
     const [controlledVisible, setControlledVisible] = useState(!!defaultOpen);
     const {
@@ -54,23 +56,36 @@ export const MenuButton: FunctionComponent<Props> = ({
 
     return (
         <div>
-            <Button
-                data-testid="menu-button"
-                type="button"
-                aria-haspopup="menu"
-                aria-expanded={visible}
-                buttonType={buttonType}
-                onClick={() => setControlledVisible(!controlledVisible)}
-                ref={setTriggerRef}
-            >
-                {label}
-                <StyledIcon
-                    aria-hidden="true"
-                    data-testid="chevron-icon"
-                    name={visible ? 'chevronUp' : 'chevronDown'}
-                    size="16"
+            {iconName ? (
+                <IconButton
+                    data-testid="menu-button"
+                    type="button"
+                    aria-haspopup="menu"
+                    aria-expanded={visible}
+                    buttonType={buttonType}
+                    iconName={iconName}
+                    onClick={() => setControlledVisible(!controlledVisible)}
+                    ref={setTriggerRef}
                 />
-            </Button>
+            ) : (
+                <Button
+                    data-testid="menu-button"
+                    type="button"
+                    aria-haspopup="menu"
+                    aria-expanded={visible}
+                    buttonType={buttonType}
+                    onClick={() => setControlledVisible(!controlledVisible)}
+                    ref={setTriggerRef}
+                >
+                    {label}
+                    <StyledIcon
+                        aria-hidden="true"
+                        data-testid="chevron-icon"
+                        name={visible ? 'chevronUp' : 'chevronDown'}
+                        size="16"
+                    />
+                </Button>
+            )}
             {visible && (
                 <StyledMenu
                     initialFocusIndex={0}

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -18,10 +18,13 @@ const StyledIcon = styled(Icon)`
 interface Props {
     buttonType: ButtonType;
     defaultOpen?: boolean;
+    label: string;
     options: MenuOption[];
 }
 
-export const MenuButton: FunctionComponent<Props> = ({ buttonType, defaultOpen, options }) => {
+export const MenuButton: FunctionComponent<Props> = ({
+    buttonType, defaultOpen, label, options,
+}) => {
     const [controlledVisible, setControlledVisible] = useState(!!defaultOpen);
     const {
         getTooltipProps,
@@ -60,7 +63,7 @@ export const MenuButton: FunctionComponent<Props> = ({ buttonType, defaultOpen, 
                 onClick={() => setControlledVisible(!controlledVisible)}
                 ref={setTriggerRef}
             >
-                Trigger
+                {label}
                 <StyledIcon
                     aria-hidden="true"
                     data-testid="chevron-icon"

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -74,10 +74,10 @@ const submenuOptions = [
 
 export const Normal: Story = () => (
     <>
-        <MenuButton label="Button" options={options} buttonType="primary" />
-        <MenuButton label="Button" options={options} buttonType="secondary" />
-        <MenuButton label="Button" options={options} buttonType="tertiary" />
-        <MenuButton label="Button" options={options} buttonType="destructive" />
+        <MenuButton options={options} buttonType="primary">Button</MenuButton>
+        <MenuButton options={options} buttonType="secondary">Button</MenuButton>
+        <MenuButton options={options} buttonType="tertiary">Button</MenuButton>
+        <MenuButton options={options} buttonType="destructive">Button</MenuButton>
     </>
 );
 
@@ -86,13 +86,13 @@ export const IconButton: Story = () => (
 );
 
 export const DefaultOpen: Story = () => (
-    <MenuButton label="Button" options={options} defaultOpen buttonType="primary" />
+    <MenuButton options={options} defaultOpen buttonType="primary">Button</MenuButton>
 );
 
 export const WithSubmenu: Story = () => (
-    <MenuButton label="Button" options={submenuOptions} buttonType="primary" />
+    <MenuButton options={submenuOptions} buttonType="primary">Button</MenuButton>
 );
 
 export const Scrollable: Story = () => (
-    <MenuButton label="Button" options={scrollableOptions} buttonType="primary" />
+    <MenuButton options={scrollableOptions} buttonType="primary">Button</MenuButton>
 );

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -74,21 +74,21 @@ const submenuOptions = [
 
 export const Normal: Story = () => (
     <>
-        <MenuButton options={options} buttonType="primary" />
-        <MenuButton options={options} buttonType="secondary" />
-        <MenuButton options={options} buttonType="tertiary" />
-        <MenuButton options={options} buttonType="destructive" />
+        <MenuButton label="Button" options={options} buttonType="primary" />
+        <MenuButton label="Button" options={options} buttonType="secondary" />
+        <MenuButton label="Button" options={options} buttonType="tertiary" />
+        <MenuButton label="Button" options={options} buttonType="destructive" />
     </>
 );
 
 export const DefaultOpen: Story = () => (
-    <MenuButton options={options} defaultOpen buttonType="primary" />
+    <MenuButton label="Button" options={options} defaultOpen buttonType="primary" />
 );
 
 export const WithSubmenu: Story = () => (
-    <MenuButton options={submenuOptions} buttonType="primary" />
+    <MenuButton label="Button" options={submenuOptions} buttonType="primary" />
 );
 
 export const Scrollable: Story = () => (
-    <MenuButton options={scrollableOptions} buttonType="primary" />
+    <MenuButton label="Button" options={scrollableOptions} buttonType="primary" />
 );

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -81,6 +81,10 @@ export const Normal: Story = () => (
     </>
 );
 
+export const IconButton: Story = () => (
+    <MenuButton iconName="moreVertical" options={options} buttonType="primary" />
+);
+
 export const DefaultOpen: Story = () => (
     <MenuButton label="Button" options={options} defaultOpen buttonType="primary" />
 );


### PR DESCRIPTION
## PR Description
Cette PR ajoute les features suivantes au component MenuButton qui sont nécessaires pour une story CPanel2:

- Permettre de changer le label du bouton avec la prop `label`
- Permettre d'utiliser un IconButton via la prop `iconName`

Je ne sais pas vraiment comment on a fait pour manquer le fait qu'on n'avait pas encore la possibilité de changer le label sur MenuButton, mais bon ça va être là après cette PR 😄 
