### PR TITLE
DS-42 feat: add autofocus prop to buttons

### DIFF
--- a/packages/react/src/components/buttons/button.tsx
+++ b/packages/react/src/components/buttons/button.tsx
@@ -9,6 +9,7 @@ export type ButtonType = 'primary' | 'secondary' | 'tertiary' | 'destructive';
 type Type = 'submit' | 'button' | 'reset';
 
 interface ButtonProps {
+    autofocus?: boolean;
     /**
      * Visual style
      * @default primary
@@ -32,12 +33,13 @@ const StyledButton = styled(AbstractButton)<{ theme: Theme } & ButtonProps>`
 `;
 
 export const Button = forwardRef(({
-    children, className, label, title, type = 'submit', buttonType, disabled, onClick, onKeyDown, ...props
+    autofocus, children, className, label, title, type = 'submit', buttonType, disabled, onClick, onKeyDown, ...props
 }: ButtonProps, ref: Ref<HTMLButtonElement>): ReactElement => {
     const { isMobile } = useDeviceContext();
 
     return (
         <StyledButton
+            autoFocus={autofocus}
             ref={ref}
             title={title}
             isMobile={isMobile}

--- a/packages/react/src/components/buttons/icon-button.tsx
+++ b/packages/react/src/components/buttons/icon-button.tsx
@@ -10,6 +10,7 @@ type ButtonType = 'primary' | 'secondary' | 'tertiary' | 'destructive';
 type Type = 'submit' | 'button' | 'reset';
 
 export interface IconButtonProps {
+    autofocus?: boolean;
     children?: ReactElement<IconProps | AvatarProps>;
     /**
      * Visual style
@@ -43,6 +44,7 @@ const StyledButton = styled(AbstractButton)`
 `;
 
 export const IconButton = forwardRef(({
+    autofocus,
     children,
     className,
     iconName,
@@ -60,6 +62,7 @@ export const IconButton = forwardRef(({
     return (
         <StyledButton
             ref={ref}
+            autoFocus={autofocus}
             aria-label={label}
             className={className}
             isMobile={isMobile}

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -17,6 +17,7 @@ const StyledIcon = styled(Icon)`
 `;
 
 interface Props {
+    autofocus?: boolean;
     buttonType: ButtonType;
     className?: string;
     defaultOpen?: boolean;
@@ -25,7 +26,7 @@ interface Props {
 }
 
 export const MenuButton: FunctionComponent<Props> = ({
-    buttonType, children, className, defaultOpen, iconName, options,
+    autofocus, buttonType, children, className, defaultOpen, iconName, options,
 }) => {
     const [controlledVisible, setControlledVisible] = useState(!!defaultOpen);
     const {
@@ -58,6 +59,7 @@ export const MenuButton: FunctionComponent<Props> = ({
         <div className={className}>
             {iconName ? (
                 <IconButton
+                    autofocus={autofocus}
                     data-testid="menu-button"
                     type="button"
                     aria-haspopup="menu"
@@ -69,6 +71,7 @@ export const MenuButton: FunctionComponent<Props> = ({
                 />
             ) : (
                 <Button
+                    autofocus={autofocus}
                     data-testid="menu-button"
                     type="button"
                     aria-haspopup="menu"

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
@@ -58,6 +58,7 @@ interface MenuButtonProps {
      * @default 'Menu'
      * */
     ariaLabel?: string;
+    autofocus?: boolean;
     tag?: 'div' | 'nav';
     buttonAriaLabel?: string;
     children?: ReactNode;
@@ -86,6 +87,7 @@ interface MenuButtonProps {
 export function NavMenuButton({
     tag,
     ariaLabel,
+    autofocus,
     buttonAriaLabel,
     buttonType = 'tertiary',
     children,
@@ -185,6 +187,7 @@ export function NavMenuButton({
                 <StyledButton
                     aria-label={buttonAriaLabel}
                     aria-expanded={isOpen}
+                    autofocus={autofocus}
                     data-testid="menu-button"
                     isMobile={isMobile}
                     onClick={handleButtonClick}
@@ -209,6 +212,7 @@ export function NavMenuButton({
                 <IconButton
                     aria-label={buttonAriaLabel}
                     aria-expanded={isOpen}
+                    autofocus={autofocus}
                     data-testid="menu-button"
                     iconName={iconName}
                     onClick={handleButtonClick}


### PR DESCRIPTION
## PR Description
Cette PR ajoute la prop `autofocus` aux boutons qui permet de diriger le focus sur un élément au premier load de la page. C'est une propriété HTML de base, donc j'ai fait des tests fonctionnels sur chacuns des components ciblés mais sans plus.
