### PR TITLE
refactor(Table): inverse sort icons

### DIFF
--- a/packages/react/src/components/table/sort-button-icon.test.tsx.snap
+++ b/packages/react/src/components/table/sort-button-icon.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SortButtonIcon should display arrow down when sort is descending 1`] = `
 <Icon
   color="#60666E"
-  name="arrowDown"
+  name="arrowUp"
   size="16"
 />
 `;
@@ -11,7 +11,7 @@ exports[`SortButtonIcon should display arrow down when sort is descending 1`] = 
 exports[`SortButtonIcon should display arrow up when sort is ascending 1`] = `
 <Icon
   color="#60666E"
-  name="arrowUp"
+  name="arrowDown"
   size="16"
 />
 `;

--- a/packages/react/src/components/table/sort-button-icon.tsx
+++ b/packages/react/src/components/table/sort-button-icon.tsx
@@ -13,9 +13,9 @@ export const SortButtonIcon: VoidFunctionComponent<SortButtonIconProps> = ({ sor
 
     switch (sort) {
         case 'ascending':
-            return <Icon name="arrowUp" size="16" color={theme.greys['dark-grey']} />;
-        case 'descending':
             return <Icon name="arrowDown" size="16" color={theme.greys['dark-grey']} />;
+        case 'descending':
+            return <Icon name="arrowUp" size="16" color={theme.greys['dark-grey']} />;
         default:
             return <Icon name="reorder" size="16" color={theme.greys['dark-grey']} />;
     }


### PR DESCRIPTION
## PR Description
Ce PR met les icônes de sorting du component Table dans le bon ordre, car ils étaient inversés. J'ai vérrifié avec @maboilard et c'est bien le visuel qu'on veut.

[Exemple maquettes CPanel2](https://app.abstract.com/projects/f39bb9a0-d2db-11e8-b657-63d973464341/branches/master/commits/latest/files/8e822eb0-bc0e-440a-b9bd-d23e4c77c00d/layers/D1BD0356-F2B3-4A77-A7CE-6757A2B0EDE5?collectionId=084f6dc7-7b05-458e-a2b8-ac054250c5de&collectionLayerId=f5aaa9aa-704e-41b0-a62f-e816dbec0da5)