### PR TITLE
feat(All): add controllable data-testid to inputs

### DIFF
--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -515,7 +515,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   </button>
   <div
     class="c4 c5 c6"
-    data-testid="menu-list"
+    data-testid="menu-dropdownMenu"
     hidden=""
   >
     <h3
@@ -1362,7 +1362,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   </button>
   <div
     class="c4 c5 c6"
-    data-testid="menu-list"
+    data-testid="menu-dropdownMenu"
     hidden=""
   >
     <h3
@@ -2121,7 +2121,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   </button>
   <div
     class="c4 c5 c6"
-    data-testid="menu-list"
+    data-testid="menu-dropdownMenu"
     hidden=""
   >
     <h3

--- a/packages/react/src/components/checkbox-group/checkbox-group.test.tsx.snap
+++ b/packages/react/src/components/checkbox-group/checkbox-group.test.tsx.snap
@@ -106,6 +106,7 @@ Array [
     Boat
     <input
       class="c1"
+      data-testid="checkboxGroup-boat"
       name="vehicule1"
       type="checkbox"
       value="boat"
@@ -222,6 +223,7 @@ Array [
     <input
       checked=""
       class="c1"
+      data-testid="checkboxGroup-plane"
       name="vehicule2"
       type="checkbox"
       value="plane"
@@ -338,6 +340,7 @@ Array [
     Car
     <input
       class="c1"
+      data-testid="checkboxGroup-car"
       disabled=""
       name="vehicule3"
       type="checkbox"
@@ -455,6 +458,7 @@ Array [
     Bike
     <input
       class="c1"
+      data-testid="checkboxGroup-bike"
       name="vehicule4"
       type="checkbox"
       value="bike"

--- a/packages/react/src/components/checkbox-group/checkbox-group.tsx
+++ b/packages/react/src/components/checkbox-group/checkbox-group.tsx
@@ -1,5 +1,6 @@
 import { ChangeEvent, ReactElement } from 'react';
 import styled from 'styled-components';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { Checkbox } from '../checkbox/checkbox';
 
 const Legend = styled.legend`
@@ -24,8 +25,15 @@ interface CheckboxProps {
 }
 
 export function CheckboxGroup({
-    label, checkedValues, checkboxGroup, onChange,
+    label,
+    checkedValues,
+    checkboxGroup,
+    onChange,
+    ...props
 }: CheckboxProps): ReactElement {
+    const dataAttributes = useDataAttributes(props);
+    const dataTestId = dataAttributes['data-testid'] ?? 'checkboxGroup';
+
     return (
         <>
             {label && <Legend>{label}</Legend>}
@@ -39,6 +47,7 @@ export function CheckboxGroup({
                 <Checkbox
                     key={`${name}-${value}`}
                     checked={checkedValues?.includes(value)}
+                    data-testid={`${dataTestId}-${value}`}
                     defaultChecked={defaultChecked}
                     disabled={disabled}
                     label={checkboxLabel}

--- a/packages/react/src/components/checkbox/checkbox.test.tsx
+++ b/packages/react/src/components/checkbox/checkbox.test.tsx
@@ -1,5 +1,6 @@
 import { doNothing } from '../../test-utils/callbacks';
 import { mountWithTheme } from '../../test-utils/renderer';
+import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { Checkbox } from './checkbox';
 
 const defaultProps = {
@@ -9,6 +10,15 @@ const defaultProps = {
 };
 
 describe('Checkbox', () => {
+    test('has controllable data-testid', () => {
+        const callback = jest.fn();
+        const wrapper = mountWithTheme(
+            <Checkbox data-testid="some-data-testid" {...defaultProps} onChange={callback} />,
+        );
+
+        expect(getByTestId(wrapper, 'some-data-testid').exists()).toBe(true);
+    });
+
     test('onChange callback should be called when checkbox is checked / unchecked', () => {
         const callback = jest.fn();
         const wrapper = mountWithTheme(<Checkbox {...defaultProps} onChange={callback} />);

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, forwardRef, FunctionComponent, Ref, useEffect, useImperati
 import styled, { css } from 'styled-components';
 import { focus } from '../../utils/css-state';
 import { Icon } from '../icon/icon';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 
 const checkboxWidth = '16px';
 
@@ -111,10 +112,12 @@ export const Checkbox: FunctionComponent<Props> = forwardRef(({
     name,
     value,
     onChange,
+    ...otherProps
 }, ref: Ref<HTMLInputElement | null>) => {
     const checkboxRef = useRef<HTMLInputElement>(null);
 
     useImperativeHandle(ref, () => checkboxRef.current, [checkboxRef]);
+    const dataAttributes = useDataAttributes(otherProps);
 
     useEffect(() => {
         if (checkboxRef.current) {
@@ -141,6 +144,7 @@ export const Checkbox: FunctionComponent<Props> = forwardRef(({
                 defaultChecked={defaultChecked}
                 disabled={disabled}
                 onChange={onChange}
+                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
             />
             <CustomCheckbox disabled={disabled}>
                 <CheckMarkIcon />

--- a/packages/react/src/components/chooser-button-group/chooser-button-group.test.tsx.snap
+++ b/packages/react/src/components/chooser-button-group/chooser-button-group.test.tsx.snap
@@ -216,6 +216,7 @@ input[type="radio"]:disabled + .c3 {
   >
     <input
       class="c1"
+      data-testid="chooser-button-group-skip"
       name="maritalStatus"
       type="radio"
       value="skip"

--- a/packages/react/src/components/chooser-button-group/chooser-button-group.tsx
+++ b/packages/react/src/components/chooser-button-group/chooser-button-group.tsx
@@ -1,5 +1,6 @@
 import { ReactElement, useCallback, useMemo, useState } from 'react';
 import styled from 'styled-components';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { ChooserButton } from '../chooser-button/chooser-button';
 
 export interface ChooserButtonOption {
@@ -40,8 +41,16 @@ const Skip = styled.div`
 `;
 
 export function ChooserButtonGroup({
-    inColumns, groupName, onChange, options, skipOption, value,
+    inColumns,
+    groupName,
+    onChange,
+    options,
+    skipOption,
+    value,
+    ...props
 }: ChooserButtonGroupProps): ReactElement {
+    const dataAttributes = useDataAttributes(props);
+    const dataTestId = dataAttributes['data-testid'] ?? 'chooser-button-group';
     const [isControlled] = useState(value !== undefined);
 
     const handleChange = useCallback((option: ChooserButtonOption): void => {
@@ -72,6 +81,7 @@ export function ChooserButtonGroup({
             {skipOption && (
                 <Skip>
                     <ChooserButton
+                        data-testid={`${dataTestId}-${skipOption.value}`}
                         groupName={groupName}
                         onChange={() => handleChange(skipOption)}
                         type="radio"

--- a/packages/react/src/components/chooser-button/chooser-button.tsx
+++ b/packages/react/src/components/chooser-button/chooser-button.tsx
@@ -1,6 +1,7 @@
 import { ChangeEvent, ChangeEventHandler, forwardRef, ReactNode, Ref, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { v4 as uuid } from '../../utils/uuid';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { hiddenStyle } from '../visually-hidden/styles/visuallyhidden';
 import { Label } from './styles/choose';
 
@@ -22,11 +23,19 @@ interface ChooserButtonProps {
 export const ChooserButton = forwardRef(
     (
         {
-            defaultChecked, checked, children, groupName, onChange, type, value,
+            defaultChecked,
+            checked,
+            children,
+            groupName,
+            onChange,
+            type,
+            value,
+            ...otherProps
         }: ChooserButtonProps,
         ref: Ref<HTMLInputElement>,
     ) => {
         const id = useMemo(() => uuid(), []);
+        const dataAttributes = useDataAttributes(otherProps);
 
         const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback((event) => {
             onChange(event);
@@ -43,6 +52,7 @@ export const ChooserButton = forwardRef(
                     ref={ref}
                     type={type}
                     value={value}
+                    {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
                 />
                 <Label htmlFor={id}>{children}</Label>
             </>

--- a/packages/react/src/components/chooser-card/chooser-card.tsx
+++ b/packages/react/src/components/chooser-card/chooser-card.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, ReactElement, ReactNode, useCallback, useEffect, useMemo, 
 import { eventIsInside } from '../../utils/events';
 import { v4 as uuid } from '../../utils/uuid';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import * as S from './styled-components';
 
 interface ChooserCardProps {
@@ -31,12 +32,14 @@ export function ChooserCard({
     required,
     value,
     onChange,
+    ...otherProps
 }: ChooserCardProps): ReactElement {
     const { isMobile } = useDeviceContext();
     const id = useMemo(() => providedId || uuid(), [providedId]);
     const inputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLLabelElement>(null);
     const [isInputChecked, setInputCheck] = useState(defaultChecked);
+    const dataAttributes = useDataAttributes(otherProps);
 
     const handleClickOutside: (event: MouseEvent) => void = useCallback((event) => {
         const clickIsOutside = !eventIsInside(event, containerRef.current);
@@ -94,6 +97,7 @@ export function ChooserCard({
                     onBlur={handleBlur}
                     onChange={handleChange}
                     onMouseDown={(e) => e.preventDefault()}
+                    {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
                 />
                 <S.RadioInput disabled={disabled} isMobile={isMobile} />
             </S.InputContainer>

--- a/packages/react/src/components/datepicker/datepicker.test.tsx
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx
@@ -178,6 +178,18 @@ describe('Datepicker', () => {
         expect(getByTestId(wrapper, 'text-input').props().value).toBe('2002-02-02');
     });
 
+    test('has controllable data-testid)', () => {
+        const wrapper = mountWithTheme(<Datepicker data-testid="some-data-test-id" label="date" />);
+
+        expect(getByTestId(wrapper, 'some-data-test-id').exists()).toBeTruthy();
+    });
+
+    test('matches snapshot (data-testid)', () => {
+        const tree = renderWithProviders(<Datepicker data-testid="some-data-test-id" label="date" />, 'desktop');
+
+        expect(tree).toMatchSnapshot();
+    });
+
     test('matches snapshot (desktop)', () => {
         const tree = renderWithProviders(<Datepicker label="date" />, 'desktop');
 

--- a/packages/react/src/components/datepicker/datepicker.test.tsx.snap
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx.snap
@@ -290,6 +290,296 @@ label + .c3 {
 </div>
 `;
 
+exports[`Datepicker matches snapshot (data-testid) 1`] = `
+.c2 {
+  color: #000000;
+  display: block;
+  font-size: 0.75rem;
+  font-weight: var(--font-normal);
+  -webkit-letter-spacing: 0.02rem;
+  -moz-letter-spacing: 0.02rem;
+  -ms-letter-spacing: 0.02rem;
+  letter-spacing: 0.02rem;
+  line-height: 1.25rem;
+  margin: 0;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+}
+
+input + .c1 {
+  margin-left: var(--spacing-half);
+}
+
+.c0 {
+  margin: 0 0 var(--spacing-3x);
+}
+
+.c0 input,
+.c0 select,
+.c0 textarea {
+  border-color: #60666E;
+}
+
+.c0:focus {
+  border-color: #006296;
+}
+
+.c0 > :nth-child(1) {
+  margin-bottom: var(--spacing-half);
+}
+
+.c4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c4 .popper {
+  z-index: 1000;
+}
+
+.c4 .popper[data-placement^="bottom"] {
+  margin-top: 0;
+}
+
+.c4 .react-datepicker {
+  border: 1px solid #DBDEE1;
+  box-shadow: 0 10px 20px 0 rgba(0,0,0,0.19);
+  font-family: var(--font-family);
+  padding: var(--spacing-3x) var(--spacing-2x);
+}
+
+.c4 .react-datepicker__day {
+  border: 1px solid transparent;
+  box-sizing: border-box;
+  height: 32px;
+  line-height: 30px;
+  margin: 0;
+  width: 32px;
+}
+
+.c4 .react-datepicker__day:hover {
+  background-color: #DBDEE1;
+  border-radius: 50%;
+}
+
+.c4 .react-datepicker__day:focus {
+  outline: none;
+}
+
+.c4 .react-datepicker__day--disabled {
+  color: #B7BBC2;
+}
+
+.c4 .react-datepicker__day--disabled:hover {
+  background-color: #FFFFFF;
+}
+
+.c4 .react-datepicker__day--keyboard-selected {
+  background-color: #FFFFFF;
+  border-radius: 50%;
+  box-sizing: border-box;
+  color: #000000;
+}
+
+.c4 .react-datepicker__day--keyboard-selected:focus {
+  border: 1px solid #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
+}
+
+.c4 .react-datepicker__day-names {
+  margin: 0;
+}
+
+.c4 .react-datepicker__day-name {
+  font-size: 0.875rem;
+  font-weight: var(--font-bold);
+  line-height: 1.25rem;
+  margin: 0;
+  text-transform: uppercase;
+  width: 32px;
+}
+
+.c4 .react-datepicker__day--outside-month {
+  color: #60666E;
+}
+
+.c4 .react-datepicker__day--outside-month.react-datepicker__day--selected {
+  color: #FFFFFF;
+}
+
+.c4 .react-datepicker__day--selected {
+  background-color: #006296;
+  border-radius: 50%;
+}
+
+.c4 .react-datepicker__day--selected:focus {
+  box-shadow: 0 0 0 2px #84C6EA;
+}
+
+.c4 .react-datepicker__day--selected:hover {
+  color: #000000;
+}
+
+.c4 .react-datepicker__day--today {
+  color: #006296;
+  font-weight: var(--font-normal);
+}
+
+.c4 .react-datepicker__day--today.react-datepicker__day--selected {
+  color: #FFFFFF;
+}
+
+.c4 .react-datepicker__header {
+  background-color: #FFFFFF;
+  border-bottom: none;
+  margin-bottom: var(--spacing-half);
+  padding: 0;
+}
+
+.c4 .react-datepicker__month {
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.c4 .react-datepicker__portal {
+  background-color: rgba(0,0,0,0.5);
+}
+
+.c4 .react-datepicker__portal .react-datepicker__day-name {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  width: 40px;
+}
+
+.c4 .react-datepicker__portal .react-datepicker__day {
+  height: 40px;
+  line-height: 2.5rem;
+  width: 40px;
+}
+
+label + .c3 {
+  margin-top: var(--spacing-half);
+}
+
+.c5.datePickerInput {
+  background-color: #FFFFFF;
+  border: 1px solid #60666E;
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: 0.875rem;
+  height: 32px;
+  padding: var(--spacing-half) 0 var(--spacing-half) var(--spacing-1x);
+  width: 109px;
+}
+
+.c5.datePickerInput:focus {
+  border: 1px solid #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
+  outline: none;
+}
+
+.c5.datePickerInput:focus {
+  border: 1px solid #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
+  outline: none;
+}
+
+.c5.datePickerInput:focus {
+  border: 1px solid #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
+  outline: none;
+}
+
+.c5.datePickerInput:focus {
+  border: 1px solid #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
+  outline: none;
+}
+
+.c6 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFFFFF;
+  border: 1px solid #60666E;
+  border-left: none;
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+  box-sizing: border-box;
+  color: #60666E;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: 32px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  width: 32px;
+}
+
+.c6:hover {
+  background-color: #DBDEE1;
+}
+
+.c6:focus {
+  border: 1px solid #006296;
+  border-left: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  outline: none;
+  z-index: 10;
+}
+
+<div
+  class="c0"
+>
+  <label
+    class="c1 c2"
+  >
+    date
+  </label>
+  <div
+    class="c3 c4"
+  >
+    <div
+      class="react-datepicker-wrapper"
+    >
+      <div
+        class="react-datepicker__input-container"
+      >
+        <input
+          class="c5 datePickerInput"
+          data-testid="some-data-test-id"
+          placeholder="YYYY-MM-DD"
+          type="text"
+          value=""
+        />
+      </div>
+    </div>
+    <button
+      aria-label="Choose date"
+      class="c6"
+      data-testid="calendar-button"
+      tabindex="0"
+      type="button"
+    >
+      <svg
+        color="currentColor"
+        focusable="false"
+        height="16"
+        width="16"
+      />
+    </button>
+  </div>
+</div>
+`;
+
 exports[`Datepicker matches snapshot (desktop) 1`] = `
 .c2 {
   color: #000000;
@@ -1997,7 +2287,7 @@ label + .c3 {
                             aria-label="Select a month"
                             aria-multiline="false"
                             class="c13"
-                            data-testid="input"
+                            data-testid="month-select"
                             type="text"
                             value="Oct"
                           />
@@ -2037,7 +2327,7 @@ label + .c3 {
                             aria-label="Select a year"
                             aria-multiline="false"
                             class="c13"
-                            data-testid="input"
+                            data-testid="year-select"
                             type="text"
                             value="2010"
                           />
@@ -3132,7 +3422,7 @@ label + .c3 {
                             aria-label="Select a month"
                             aria-multiline="false"
                             class="c13"
-                            data-testid="input"
+                            data-testid="month-select"
                             type="text"
                             value="Oct"
                           />
@@ -3172,7 +3462,7 @@ label + .c3 {
                             aria-label="Select a year"
                             aria-multiline="false"
                             class="c13"
-                            data-testid="input"
+                            data-testid="year-select"
                             type="text"
                             value="2010"
                           />
@@ -4178,7 +4468,7 @@ label + .c3 {
                             aria-label="Select a month"
                             aria-multiline="false"
                             class="c13"
-                            data-testid="input"
+                            data-testid="month-select"
                             type="text"
                             value="Oct"
                           />
@@ -4218,7 +4508,7 @@ label + .c3 {
                             aria-label="Select a year"
                             aria-multiline="false"
                             class="c13"
-                            data-testid="input"
+                            data-testid="year-select"
                             type="text"
                             value="2010"
                           />

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -279,6 +279,7 @@ interface DatepickerProps {
     className?: string;
     /** Sets date format (e.g.: dd/MM/yyyy). */
     dateFormat?: string;
+    'data-testid'?: string;
     disabled?: boolean;
     /** Disables default margin */
     noMargin?: boolean;
@@ -339,15 +340,15 @@ export const Datepicker = forwardRef(({
     className,
     dateFormat,
     disabled,
-    noMargin,
     firstDayOfWeek,
     hasTodayButton,
+    hint,
     id,
     label,
-    tooltip,
     locale = 'en-CA',
     maxDate,
     minDate,
+    noMargin,
     onBlur,
     onCalendarClose,
     onCalendarOpen,
@@ -357,9 +358,9 @@ export const Datepicker = forwardRef(({
     placeholder,
     startDate,
     startOpen,
+    tooltip,
     valid = true,
     validationErrorMessage,
-    hint,
     ...props
 }: DatepickerProps, ref: Ref<DatepickerHandles>): ReactElement => {
     const { t } = useTranslation('datepicker');
@@ -491,7 +492,12 @@ export const Datepicker = forwardRef(({
             >
                 <Container isMobile={isMobile}>
                     <StyledDatePicker
-                        customInput={<input type="text" data-testid="text-input" />}
+                        customInput={(
+                            <input
+                                type="text"
+                                data-testid={props['data-testid'] ?? 'text-input'}
+                            />
+                        )}
                         isMobile={isMobile}
                         id={fieldId}
                         ref={dateInputRef}

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -467,7 +467,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   </button>
   <div
     class="c5 c6"
-    data-testid="menu-list"
+    data-testid="menu-dropdownMenu"
   >
     <ul
       aria-labelledby="firstGroup"
@@ -1163,7 +1163,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   </button>
   <div
     class="c5 c6"
-    data-testid="menu-list"
+    data-testid="menu-dropdownMenu"
     hidden=""
   >
     <ul

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.tsx
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.tsx
@@ -11,6 +11,7 @@ import {
     VoidFunctionComponent,
 } from 'react';
 import styled from 'styled-components';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { useTranslation } from '../../i18n/use-translation';
 import { getRootDocument } from '../../utils/dom';
 import { eventIsInside } from '../../utils/events';
@@ -91,6 +92,7 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
     onMenuVisibilityChanged,
     render,
     title,
+    ...otherProps
 }) => {
     const { isMobile } = useDeviceContext();
     const { t } = useTranslation('nav-menu-button');
@@ -101,6 +103,8 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
     const navRef = useRef<HTMLDivElement>(null);
     const isIconOnly = icon && !label && !hasCaret;
     const containerAriaLabel = (tag === 'div' || tag === undefined) ? '' : ariaLabel || t('ariaLabel');
+    const dataAttributes = useDataAttributes(otherProps);
+    const dataTestId = dataAttributes['data-testid'] ?? 'menu-dropdownMenu';
 
     const handleClickOutside: (event: MouseEvent) => void = useCallback((event) => {
         const clickIsOutside = !eventIsInside(event, buttonRef.current, navMenuRef.current);
@@ -218,7 +222,7 @@ export const DropdownMenuButton: VoidFunctionComponent<MenuButtonProps> = ({
             )}
             <StyledDropdownMenu
                 ref={navMenuRef}
-                data-testid="menu-dropdownMenu"
+                data-testid={dataTestId}
                 onKeyDown={handleNavMenuKeyDown}
                 hidden={!isOpen}
             >

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx
@@ -1,3 +1,4 @@
+import { shallow } from 'enzyme';
 import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { mountWithProviders, renderWithProviders } from '../../test-utils/renderer';
 import { DropdownMenu } from './dropdown-menu';
@@ -44,5 +45,13 @@ describe('DropdownMenu', () => {
         );
 
         expect(tree).toMatchSnapshot();
+    });
+
+    test('has controllable data-testid', () => {
+        const tree = shallow(
+            <DropdownMenu data-testid="some-data-testid" hidden>{TestGroups}</DropdownMenu>,
+        );
+
+        expect(getByTestId(tree, 'some-data-testid').exists()).toBe(true);
     });
 });

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, KeyboardEvent, ReactElement, Ref, useMemo } from 'react';
 import styled from 'styled-components';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { v4 as uuid } from '../../utils/uuid';
 import { GroupItemProps } from './list-items';
 
@@ -28,8 +29,10 @@ export const DropdownMenu = forwardRef(({
     id: providedId,
     hidden,
     onKeyDown,
+    ...otherProps
 }: DropdownMenuProps, ref: Ref<HTMLDivElement>): ReactElement => {
     const id = useMemo(() => providedId || uuid(), [providedId]);
+    const dataAttributes = useDataAttributes(otherProps);
 
     return (
         <List
@@ -39,6 +42,7 @@ export const DropdownMenu = forwardRef(({
             id={id}
             hidden={hidden}
             onKeyDownCapture={(event: KeyboardEvent<HTMLDivElement>) => onKeyDown?.(event)}
+            {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
         >
             {children}
         </List>

--- a/packages/react/src/components/money-input/money-input.tsx
+++ b/packages/react/src/components/money-input/money-input.tsx
@@ -2,6 +2,7 @@ import { ChangeEvent, ReactElement, useCallback, useEffect, useRef, useState } f
 import styled from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { formatCurrency } from '../../utils/currency';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { TextInput } from '../text-input/text-input';
 
 type Language = 'en' | 'fr';
@@ -76,6 +77,7 @@ export function MoneyInput({
     locale = 'fr-CA',
     currency = 'CAD',
     hint,
+    ...otherProps
 }: Props): ReactElement {
     const { t } = useTranslation('money-input');
     const inputElement = useRef<HTMLInputElement>(null);
@@ -83,6 +85,7 @@ export function MoneyInput({
     const [displayValue, setDisplayValue] = useState(safeFormatCurrency(value, precision, locale, currency));
     const [maskedValue, setMaskedValue] = useState(safeFormatCurrency(value, precision, locale, currency));
     const [hasFocus, setHasFocus] = useState<boolean>(false);
+    const dataAttributes = useDataAttributes(otherProps);
 
     const updateFormattedValue: (rawValue: string) => void = useCallback((rawValue) => {
         const roundedValue = parseAndRound(rawValue, precision);
@@ -154,6 +157,7 @@ export function MoneyInput({
                 onFocus={handleFocusEvent}
                 validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
                 hint={hint}
+                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
             />
         </InputWrapper>
     );

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { menuDimensions } from '../../tokens/menuDimensions';
 import { getRootDocument } from '../../utils/dom';
 import { eventIsInside } from '../../utils/events';
@@ -102,6 +103,7 @@ export function NavMenuButton({
     onMenuVisibilityChanged,
     options,
     title,
+    ...props
 }: MenuButtonProps): ReactElement {
     const { isMobile } = useDeviceContext();
     const { t } = useTranslation('nav-menu-button');
@@ -109,6 +111,7 @@ export function NavMenuButton({
     const [focusedValue, setFocusedValue] = useState('');
     const [isOpen, setOpen] = useState(defaultOpen);
     const containerAriaLabel = tag === 'div' ? '' : ariaLabel || t('ariaLabel');
+    const dataAttributes = useDataAttributes(props);
 
     useEffect(() => {
         onMenuVisibilityChanged?.(isOpen);
@@ -196,6 +199,8 @@ export function NavMenuButton({
                     type="button"
                     buttonType={buttonType}
                     inverted={inverted}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...dataAttributes}
                 >
                     {iconName && <StyledLeftIcon aria-hidden="true" name={iconName} size="16" />}
                     {children}

--- a/packages/react/src/components/option-button/option-button.tsx
+++ b/packages/react/src/components/option-button/option-button.tsx
@@ -1,6 +1,7 @@
 import { useMemo, VoidFunctionComponent } from 'react';
 import styled, { css } from 'styled-components';
 import { v4 as uuid } from '../../utils/uuid';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 
 const Input = styled.input`
     ${({ theme }) => css`
@@ -36,13 +37,26 @@ interface OptionButtonProps {
 }
 
 export const OptionButton: VoidFunctionComponent<OptionButtonProps> = ({
-    checked, className, label, name, value,
+    checked,
+    className,
+    label,
+    name,
+    value,
+    ...otherProps
 }: OptionButtonProps) => {
     const id = useMemo(uuid, []);
+    const dataAttributes = useDataAttributes(otherProps);
 
     return (
         <div className={className}>
-            <Input checked={checked} id={id} name={name} type="radio" value={value} />
+            <Input
+                checked={checked}
+                id={id}
+                name={name}
+                type="radio"
+                value={value}
+                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
+            />
             <label htmlFor={id}>{label}</label>
         </div>
     );

--- a/packages/react/src/components/select/select.test.tsx
+++ b/packages/react/src/components/select/select.test.tsx
@@ -55,6 +55,14 @@ describe('Select', () => {
         expect(findByTestId(wrapper, 'listbox').length).toEqual(1);
     });
 
+    test('input should have controllable data-test-id', () => {
+        const wrapper = shallow(
+            <Select data-testid="a-controlled-id" options={provinces} defaultValue="qc" />,
+        );
+
+        expect(getByTestId(wrapper, 'a-controlled-id').props().value).toBe('Quebec');
+    });
+
     test('input should have default value', () => {
         const wrapper = shallow(<Select options={provinces} defaultValue="qc" />);
 

--- a/packages/react/src/components/select/select.test.tsx.snap
+++ b/packages/react/src/components/select/select.test.tsx.snap
@@ -805,6 +805,7 @@ input + .c2 {
 
 <input
     class="c0"
+    data-testid="select-skip-option"
     name="undefined_skip"
     type="radio"
     value="skip"
@@ -1270,6 +1271,7 @@ input + .c2 {
 
 <input
     class="c0"
+    data-testid="select-skip-option"
     name="undefined_skip"
     type="radio"
     value="skip"

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -7,6 +7,7 @@ import { isLetterOrNumber } from '../../utils/regex';
 import { v4 as uuid } from '../../utils/uuid';
 import { ChooserButton } from '../chooser-button/chooser-button';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { FieldContainer, FieldContainerProps } from '../field-container/field-container';
 import { Icon } from '../icon/icon';
 import { Listbox, ListboxOption } from '../listbox/listbox';
@@ -204,10 +205,12 @@ export function Select({
     validationErrorMessage,
     value,
     hint,
+    ...otherProps
 }: SelectProps): ReactElement {
     const { t } = useTranslation('select');
     const { device, isMobile } = useDeviceContext();
     const fieldId = useMemo(() => id || uuid(), [id]);
+    const dataAttributes = useDataAttributes(otherProps);
 
     const [autoFocus, setAutofocus] = useState(false);
     const [containerOutline, setContainerOutline] = useState(false);
@@ -553,6 +556,7 @@ export function Select({
                         searchable={searchable}
                         type="text"
                         value={inputValue}
+                        {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
                     />
                     <Arrow
                         aria-labelledby={fieldId}

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -1039,6 +1039,7 @@ exports[`Table has selectable rows styles 1`] = `
         >
           <input
             class="c2"
+            data-testid="row-checkbox-all"
             type="checkbox"
           />
           <span
@@ -1096,6 +1097,7 @@ exports[`Table has selectable rows styles 1`] = `
         >
           <input
             class="c2"
+            data-testid="row-checkbox-0"
             type="checkbox"
           />
           <span
@@ -1145,6 +1147,7 @@ exports[`Table has selectable rows styles 1`] = `
         >
           <input
             class="c2"
+            data-testid="row-checkbox-1"
             type="checkbox"
           />
           <span
@@ -1194,6 +1197,7 @@ exports[`Table has selectable rows styles 1`] = `
         >
           <input
             class="c2"
+            data-testid="row-checkbox-2"
             type="checkbox"
           />
           <span

--- a/packages/react/src/components/text-area/text-area.test.tsx
+++ b/packages/react/src/components/text-area/text-area.test.tsx
@@ -50,8 +50,19 @@ describe('TextArea', () => {
         expect(callback).toHaveBeenCalledTimes(0);
     });
 
+    test('onFocus callback cannot be called when disabled', () => {
+        const callback = jest.fn();
+        const wrapper = mountWithTheme(<TextArea onBlur={callback} {...defaultProps} disabled />);
+
+        wrapper.find('textarea').simulate('focus');
+
+        expect(callback).toHaveBeenCalledTimes(0);
+    });
+
     test('Matches the snapshot', () => {
-        const tree = renderWithTheme(<TextArea onChange={doNothing} onBlur={doNothing} {...defaultProps} />);
+        const tree = renderWithTheme(
+            <TextArea data-testid="some-data-testid" onChange={doNothing} onBlur={doNothing} {...defaultProps} />,
+        );
 
         expect(tree).toMatchSnapshot();
     });

--- a/packages/react/src/components/text-area/text-area.test.tsx.snap
+++ b/packages/react/src/components/text-area/text-area.test.tsx.snap
@@ -260,7 +260,7 @@ input + .c1 {
   </label>
   <textarea
     class="c3"
-    data-testid="textarea"
+    data-testid="some-data-testid"
     placeholder="Enter your comment"
     required=""
   >

--- a/packages/react/src/components/text-area/text-area.tsx
+++ b/packages/react/src/components/text-area/text-area.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { Theme } from '../../themes';
 import { v4 as uuid } from '../../utils/uuid';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { FieldContainer } from '../field-container/field-container';
 import { inputsStyle } from '../text-input/styles/inputs';
 import { TooltipProps } from '../tooltip/tooltip';
@@ -77,12 +78,14 @@ export function TextArea({
     validationErrorMessage,
     value,
     maxLength,
+    ...otherProps
 }: TextAreaProps): ReactElement {
     const { t } = useTranslation('text-area');
     const [validity, setValidity] = useState(true);
     const [inputValueLength, setInputValueLength] = useState(getInitialValue(value, defaultValue));
     const idTextArea = useMemo(uuid, []);
     const idCounter = useMemo(uuid, []);
+    const dataAttributes = useDataAttributes(otherProps);
 
     function handleBlur(event: FocusEvent<HTMLTextAreaElement>): void {
         if (maxLength === undefined || inputValueLength <= maxLength) {
@@ -149,6 +152,7 @@ export function TextArea({
                 placeholder={placeholder}
                 required={required}
                 value={value}
+                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
             />
             {maxLength && (
                 <Counter

--- a/packages/react/src/components/toggle-switch/toggle-switch.tsx
+++ b/packages/react/src/components/toggle-switch/toggle-switch.tsx
@@ -4,6 +4,7 @@ import { Theme } from '../../themes';
 import { focus } from '../../utils/css-state';
 import { v4 as uuid } from '../../utils/uuid';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
+import { useDataAttributes } from '../../hooks/use-data-attributes';
 
 interface StyledLabelProps {
     theme: Theme;
@@ -90,11 +91,16 @@ interface ToggleSwitchProps {
 }
 
 export function ToggleSwitch({
-    label, disabled, onToggle, toggled,
+    label,
+    disabled,
+    onToggle,
+    toggled,
+    ...otherProps
 } : ToggleSwitchProps): ReactElement {
     const { isMobile } = useDeviceContext();
     const labelId = useMemo(uuid, []);
     const buttonId = useMemo(uuid, []);
+    const dataAttributes = useDataAttributes(otherProps);
 
     const handleClick = (): void => {
         onToggle(!toggled);
@@ -113,6 +119,7 @@ export function ToggleSwitch({
                 isMobile={isMobile}
                 disabled={disabled}
                 onClick={handleClick}
+                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
             >
                 <StyledButtonSpan isMobile={isMobile} />
             </StyledButton>

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -363,7 +363,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   </button>
   <div
     class="c7 c8"
-    data-testid="menu-list"
+    data-testid="user-profile"
   >
     <ul
       aria-labelledby="user-label"
@@ -852,7 +852,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   </button>
   <div
     class="c7 c8"
-    data-testid="menu-list"
+    data-testid="user-profile"
     hidden=""
   >
     <ul
@@ -1332,7 +1332,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   </button>
   <div
     class="c6 c7"
-    data-testid="menu-list"
+    data-testid="user-profile"
     hidden=""
   >
     <ul
@@ -1822,7 +1822,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
   </button>
   <div
     class="c7 c8"
-    data-testid="menu-list"
+    data-testid="user-profile"
     hidden=""
   >
     <ul

--- a/packages/storybook/stories/bento-menu-button.stories.tsx
+++ b/packages/storybook/stories/bento-menu-button.stories.tsx
@@ -64,7 +64,7 @@ const resources: ExternalItemProps[] = [
 
 export const Desktop: Story = () => (
     <GlobalHeader>
-        <BentoMenuButton productLinks={products} externalLinks={resources} />
+        <BentoMenuButton data-testid="some-bento-data-testid" productLinks={products} externalLinks={resources} />
     </GlobalHeader>
 );
 Desktop.decorators = [DesktopDecorator];

--- a/packages/storybook/stories/checkbox-group.stories.tsx
+++ b/packages/storybook/stories/checkbox-group.stories.tsx
@@ -39,7 +39,7 @@ function handleChange(event: ChangeEvent<HTMLInputElement>): void {
 }
 
 export const Normal: Story = () => (
-    <CheckboxGroup label="Vehicule" checkboxGroup={Checkboxes} />
+    <CheckboxGroup data-testid='some-checkbox-group-data-testid' label="Vehicule" checkboxGroup={Checkboxes} />
 );
 
 export const Disabled: Story = () => (

--- a/packages/storybook/stories/checkbox.stories.tsx
+++ b/packages/storybook/stories/checkbox.stories.tsx
@@ -8,7 +8,7 @@ export default {
 
 export const Normal: Story = () => (
     <>
-        <Checkbox name="checkbox1" value="no label" />
+        <Checkbox data-testid="some-checkbox-data-testid" name="checkbox1" value="no label" />
         <Checkbox label="Normal" name="checkbox2" value="normal" />
         <Checkbox label="Disabled" name="checkbox3" value="disabled" disabled />
         <Checkbox label="Checked" name="checkbox4" value="checked" checked />

--- a/packages/storybook/stories/chooser-button-group.stories.tsx
+++ b/packages/storybook/stories/chooser-button-group.stories.tsx
@@ -29,6 +29,7 @@ export default {
 
 export const Normal: Story = () => (
     <ChooserButtonGroup
+        data-testid='chooser-button-group'
         groupName="maritalStatus"
         inColumns={false}
         options={maritalStatus}

--- a/packages/storybook/stories/chooser-card.stories.tsx
+++ b/packages/storybook/stories/chooser-card.stories.tsx
@@ -10,7 +10,7 @@ export default {
 
 export const Normal: Story = () => (
     <>
-        <ChooserCard name="story1" label="Card 1" value="card1">
+        <ChooserCard data-testid="some-data-testid" name="story1" label="Card 1" value="card1">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit.
             Donec commodo nulla sapien, at condimentum ipsum tristique id.
         </ChooserCard>

--- a/packages/storybook/stories/datepicker.stories.tsx
+++ b/packages/storybook/stories/datepicker.stories.tsx
@@ -22,7 +22,7 @@ export default {
 };
 
 export const Normal: Story = () => (
-    <Datepicker label="Date" hint="Hint" />
+    <Datepicker label="Date" data-testid="a-data-test-id" hint="Hint" />
 );
 
 export const WithTooltip: Story = () => (

--- a/packages/storybook/stories/money-input.stories.tsx
+++ b/packages/storybook/stories/money-input.stories.tsx
@@ -10,7 +10,7 @@ export default {
 
 export const Normal: Story = () => (
     <>
-        <MoneyInput hint="Hint" label="Entrez un montant" />
+        <MoneyInput data-testid='some-data-testid' hint="Hint" label="Entrez un montant" />
         <MoneyInput hint="Hint" label="Choose a number" locale="en-CA" />
     </>
 );

--- a/packages/storybook/stories/nav-menu-button.stories.tsx
+++ b/packages/storybook/stories/nav-menu-button.stories.tsx
@@ -97,7 +97,7 @@ const optionsDisabled: NavMenuOption[] = [
 
 export const Desktop: Story = () => (
     <GlobalHeader>
-        <NavMenuButton options={options}>Menu</NavMenuButton>
+        <NavMenuButton data-testid="some-data-testid" options={options}>Menu</NavMenuButton>
     </GlobalHeader>
 );
 Desktop.decorators = [DesktopDecorator];

--- a/packages/storybook/stories/select.stories.tsx
+++ b/packages/storybook/stories/select.stories.tsx
@@ -39,7 +39,7 @@ export default {
 };
 
 export const Normal: Story = () => (
-    <Select label="Select an option" hint="Hint" options={provinces} />
+    <Select data-testid="some-data-test-id" label="Select an option" hint="Hint" options={provinces} />
 );
 
 export const WithTooltip: Story = () => (

--- a/packages/storybook/stories/textarea.stories.tsx
+++ b/packages/storybook/stories/textarea.stories.tsx
@@ -10,6 +10,7 @@ export default {
 
 export const Normal: Story = () => (
     <TextArea
+        data-testid="some-data-test-id"
         label="Text area label"
         hint="Hint"
     />

--- a/packages/storybook/stories/toggle-switch.stories.tsx
+++ b/packages/storybook/stories/toggle-switch.stories.tsx
@@ -13,7 +13,7 @@ export const Normal: Story = () => {
     const [toggled, setToggled] = useState(false);
 
     return (
-        <ToggleSwitch label="Switch" toggled={toggled} onToggle={setToggled} />
+        <ToggleSwitch data-testid='some-data-testid' label="Switch" toggled={toggled} onToggle={setToggled} />
     );
 };
 


### PR DESCRIPTION
[DS-588](https://jira.equisoft.com/browse/DS-588)

Ajout de la possibilité de controller le data-testid dans les components suivants : 

- [x] bento-menu-button
- [x] checkbox group
- [x] date-picker
- [x] select
- [x] text-area
- [x] chooser-button group et chooser button
- [x] chooser-card
- [x] dropdown-menu-button
- [x] dropdown-menu
- [x] money-input
- [x] nav-menu-button
- [x] option-button
- [x] toggle-switch