### PR TITLE
feat(Badge): add badge component

### DIFF
--- a/packages/react/src/components/badge/badge.test.tsx
+++ b/packages/react/src/components/badge/badge.test.tsx
@@ -1,0 +1,77 @@
+import { shallow } from 'enzyme';
+import { mountWithTheme, renderWithTheme } from '../../test-utils/renderer';
+import { Badge, BadgeCircle, BadgeDot } from './badge';
+
+describe('Badge', () => {
+    it('is visible when the value is not zero', () => {
+        const wrapper = shallow(
+            <Badge value={1} />,
+        );
+
+        expect(wrapper.find(BadgeCircle).exists()).toBe(true);
+    });
+
+    it('is not visible when the value is zero', () => {
+        const wrapper = shallow(
+            <Badge value={0} />,
+        );
+
+        expect(wrapper.find(BadgeCircle).exists()).toBe(false);
+        expect(wrapper.find(BadgeDot).exists()).toBe(false);
+    });
+
+    it('is visible when the value is zero and showZero is true', () => {
+        const wrapper = shallow(
+            <Badge value={0} showZero />,
+        );
+
+        expect(wrapper.find(BadgeCircle).exists()).toBe(true);
+    });
+
+    it('contains the value if below maxValue', () => {
+        const wrapper = shallow(
+            <Badge value={2} maxValue={9} />,
+        );
+
+        expect(wrapper.find(BadgeCircle).text()).toBe('2');
+    });
+
+    it('contains the max value and a plus sign if the value is above maxValue', () => {
+        const wrapper = shallow(
+            <Badge value={12} maxValue={9} />,
+        );
+
+        expect(wrapper.find(BadgeCircle).text()).toBe('9+');
+    });
+
+    it('shows as a dot if showValue is false', () => {
+        const wrapper = shallow(
+            <Badge value={1} showValue={false} />,
+        );
+
+        expect(wrapper.find(BadgeCircle).exists()).toBe(false);
+        expect(wrapper.find(BadgeDot).exists()).toBe(true);
+    });
+
+    it('is animated if animate is true', () => {
+        const wrapper = mountWithTheme(
+            <Badge value={1} animate />,
+        );
+
+        const badgeNode = wrapper.find(BadgeCircle).getDOMNode();
+        const animationValue = getComputedStyle(badgeNode).getPropertyValue('animation');
+
+        expect(animationValue).not.toBe('');
+    });
+
+    test('matches the snapshot', () => {
+        const tree = renderWithTheme(
+            <>
+                <Badge value={1} />
+                <Badge value={1} showValue={false} />
+            </>,
+        );
+
+        expect(tree).toMatchSnapshot();
+    });
+});

--- a/packages/react/src/components/badge/badge.test.tsx.snap
+++ b/packages/react/src/components/badge/badge.test.tsx.snap
@@ -1,0 +1,120 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Badge matches the snapshot 1`] = `
+Array [
+  .c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.c1 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #CD2C23;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+  color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 400;
+  height: 1rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1;
+  min-width: 1rem;
+  padding: 0 0.25rem;
+  position: absolute;
+  text-align: center;
+  right: 0;
+  top: 0;
+  -webkit-transform: translate(50%,-50%);
+  -ms-transform: translate(50%,-50%);
+  transform: translate(50%,-50%);
+}
+
+<span
+    class="c0"
+  >
+    <span
+      class="c1"
+    >
+      1
+    </span>
+  </span>,
+  .c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  position: relative;
+}
+
+.c1 {
+  -webkit-align-content: center;
+  -ms-flex-line-pack: center;
+  align-content: center;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #CD2C23;
+  border-radius: 0.5rem;
+  box-sizing: border-box;
+  color: #FFFFFF;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.75rem;
+  font-weight: 400;
+  height: 1rem;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 1;
+  min-width: 1rem;
+  padding: 0 0.25rem;
+  position: absolute;
+  text-align: center;
+  right: 0;
+  top: 0;
+  -webkit-transform: translate(50%,-50%);
+  -ms-transform: translate(50%,-50%);
+  transform: translate(50%,-50%);
+}
+
+.c2 {
+  height: 0.5rem;
+  min-width: 0.5rem;
+  padding: 0;
+}
+
+<span
+    class="c0"
+  >
+    <span
+      class="c1 c2"
+    />
+  </span>,
+]
+`;

--- a/packages/react/src/components/badge/badge.tsx
+++ b/packages/react/src/components/badge/badge.tsx
@@ -1,0 +1,130 @@
+import { FunctionComponent } from 'react';
+import styled, { css, keyframes, SimpleInterpolation, CSSObject } from 'styled-components';
+
+const BadgeRoot = styled.span`
+    display: inline-flex;
+    flex-shrink: 0;
+    position: relative;
+`;
+
+type BadgePosition = 'top-right' | 'bottom-right' | 'top-left' | 'bottom-left';
+
+const positionStyles: {[name: string]: CSSObject} = {
+    topRight: {
+        right: 0,
+        top: 0,
+        transform: 'translate(50%, -50%)',
+    },
+    bottomRight: {
+        bottom: 0,
+        right: 0,
+        transform: 'translate(50%, 50%)',
+    },
+    topLeft: {
+        left: 0,
+        top: 0,
+        transform: 'translate(-50%, -50%)',
+    },
+    bottomLeft: {
+        bottom: 0,
+        left: 0,
+        transform: 'translate(-50%, 50%)',
+    },
+};
+
+function capitalize(string: string): string {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function getPositionRules(position: BadgePosition): CSSObject {
+    const [vertical, horizontal] = position.split('-', 2);
+    const positionName = `${vertical}${capitalize(horizontal)}`;
+
+    return positionStyles[positionName];
+}
+
+function getAnimationRules(position: BadgePosition): SimpleInterpolation {
+    const baseTransform = getPositionRules(position).transform || '';
+
+    const bounceKeyframes = keyframes`
+        10% { transform: ${baseTransform} translateY(-5px); }
+        20% { transform: ${baseTransform}; }
+        27% { transform: ${baseTransform} translateY(-3px); }
+        34% { transform: ${baseTransform}; }`;
+
+    return css`
+        animation: ${bounceKeyframes} 2s ease-in infinite;
+
+        @media (prefers-reduced-motion: reduce) {
+            animation: none;
+        }`;
+}
+
+export const BadgeCircle = styled.span<{
+    $animate?: boolean;
+    $position: BadgePosition;
+}>`
+    align-content: center;
+    align-items: center;
+    background-color: ${(props) => props.theme.notifications['alert-2.1']};
+    border-radius: 0.5rem;
+    box-sizing: border-box;
+    color: ${(props) => props.theme.greys.white};
+    display: flex;
+    font-size: 0.75rem;
+    font-weight: 400;
+    height: 1rem;
+    justify-content: center;
+    line-height: 1;
+    min-width: 1rem;
+    padding: 0 0.25rem;
+    position: absolute;
+    text-align: center;
+    ${({ $position }) => getPositionRules($position)}
+    ${({ $animate, $position }) => $animate && getAnimationRules($position)}
+`;
+
+export const BadgeDot = styled(BadgeCircle)`
+    height: 0.5rem;
+    min-width: 0.5rem;
+    padding: 0;
+`;
+
+interface BadgeProps {
+    animate?: boolean;
+    className?: string;
+    /** The largest value to display, beyond which a + sign is shown */
+    maxValue?: number;
+    position?: BadgePosition;
+    /** When false, the badge is displayed as a small dot */
+    showValue?: boolean;
+    /** Set to true to show the badge even when its value is 0 */
+    showZero?: boolean;
+    value: number;
+}
+
+export const Badge: FunctionComponent<BadgeProps> = ({
+    children,
+    className,
+    animate = false,
+    maxValue = 99,
+    position = 'top-right',
+    showValue = true,
+    showZero = false,
+    value,
+}) => {
+    const BadgeShape = showValue ? BadgeCircle : BadgeDot;
+    const text = Math.min(value, maxValue).toString() + (value > maxValue ? '+' : '');
+    const visible = value !== 0 || showZero;
+
+    return (
+        <BadgeRoot>
+            {children}
+            {visible && (
+                <BadgeShape className={className} $animate={animate} $position={position}>
+                    {showValue ? text : ''}
+                </BadgeShape>
+            )}
+        </BadgeRoot>
+    );
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -40,6 +40,7 @@ export { IntlProvider } from './components/internationalization-provider/interna
 export { Listbox, ListboxOption } from './components/listbox/listbox';
 
 // Miscellaneous
+export { Badge } from './components/badge/badge';
 export { Card } from './components/card/card';
 export { CardLink } from './components/card-link/card-link';
 export * from './components/carousel/carousel';

--- a/packages/storybook/stories/badge.stories.tsx
+++ b/packages/storybook/stories/badge.stories.tsx
@@ -1,0 +1,61 @@
+import { Badge, Icon } from '@equisoft/design-elements-react';
+import { Story } from '@storybook/react';
+import styled from 'styled-components';
+
+export default {
+    title: 'Notification/Badge',
+    component: Badge,
+};
+
+export const Normal: Story = () => (
+    <Badge value={1}>
+        <Icon name="bell" />
+    </Badge>
+);
+
+export const Dot: Story = () => (
+    <Badge value={1} showValue={false}>
+        <Icon name="bell" />
+    </Badge>
+);
+
+export const Overflow: Story = () => (
+    <Badge value={10} maxValue={9}>
+        <Icon name="bell" />
+    </Badge>
+);
+
+const Spacer = styled.span`
+    margin-right: 4rem;
+`;
+
+export const Positions: Story = () => (
+    <>
+        <Spacer>
+            <Badge value={1} position="top-right">
+                <Icon name="bell" />
+            </Badge>
+        </Spacer>
+        <Spacer>
+            <Badge value={1} position="bottom-right">
+                <Icon name="bell" />
+            </Badge>
+        </Spacer>
+        <Spacer>
+            <Badge value={1} position="top-left">
+                <Icon name="bell" />
+            </Badge>
+        </Spacer>
+        <Spacer>
+            <Badge value={1} position="bottom-left">
+                <Icon name="bell" />
+            </Badge>
+        </Spacer>
+    </>
+);
+
+export const Animated: Story = () => (
+    <Badge value={1} animate>
+        <Icon name="bell" />
+    </Badge>
+);


### PR DESCRIPTION
## PR Description
DS-618

Ajout d'un composant pour afficher un badge sur une icône (ou tout autre élément).
- Affichage avec ou sans valeur (cercle ou point)
- Possibilité de configurer la valeur maximale (pour l'affichage du +)
- Option pour animer le badge (bounce)

<img width="168" alt="Screen Shot 2022-05-12 at 10 03 50" src="https://user-images.githubusercontent.com/1416333/168093632-d493c40b-5a2d-4995-b463-0855f6f22571.png">


## New component checklist
- [x] The new component and its tests are in the same component folder.
- [x] The component is unit tested and/or snapshot tested.
- [x] All of the relevant Storybook stories have been added to the `storybook` package.
- [x] There are no linting errors or warnings in the modified/new code.
- [x] All GitHub checks are successful.
