### PR TITLE
feat(Select): fix select options when a value is already selected

### DIFF
--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -226,7 +226,16 @@ export function Select({
     const inputRef = useRef<HTMLInputElement>(null);
     const wrapperRef = useRef<HTMLDivElement>(null);
     const listboxRef = useRef<HTMLDivElement>(null);
-    const filteredOptions = useMemo(() => filterOptions(options, searchValue), [options, searchValue]);
+    const [shouldFilterOptions, setShouldFilterOptions] = useState<boolean | undefined>(searchable);
+    const filteredOptions = useMemo(
+        () => {
+            if (!shouldFilterOptions) {
+                return options;
+            }
+            return filterOptions(options, searchValue);
+        },
+        [options, searchValue, shouldFilterOptions],
+    );
 
     const findOptionByValue: (needle?: string) => Option | undefined = useCallback(
         (needle) => options.find((option) => option.value === needle),
@@ -342,6 +351,7 @@ export function Select({
         setFocusedValue('');
         setInputValue(option.label);
         setSelectedOptionValue(option.value);
+        setShouldFilterOptions(false);
         onChange?.(option);
         if (searchable) {
             setAutofocus(false);
@@ -365,6 +375,9 @@ export function Select({
         if (searchable) {
             const newValue = event.currentTarget.value;
             const newFilteredOptions = filterOptions(options, newValue);
+            if (inputValue !== newValue) {
+                setShouldFilterOptions(true);
+            }
 
             if (newValue === '') {
                 setFocusedValue('');


### PR DESCRIPTION
[DS-626](https://jira.equisoft.com/browse/DS-626)
Problème : Lorsqu'un élément est déjà sélectionné, on ne peut pas voir les autres options dans le dropdown si on est en mode searchable. Les options devraient seulement être filtrées lorsqu'on est en mode "recherche" (en train d'écrire quelque chose dans le input). 

Comment reproduire : 
1. Utilisez la recherche pour sélectionner un élément du dropdown. Le Select doit être en mode searchable (prop searchable à true). 
2. Sélectionnez un élément du dropdown
3. Quand on essaies de sélectionner un élément à nouveau, la liste est filtré sur l'élément sélectionné précédemment.