### PR TITLE
feat(Badge): add offset props

### DIFF
--- a/packages/react/src/components/badge/badge.test.tsx
+++ b/packages/react/src/components/badge/badge.test.tsx
@@ -64,6 +64,23 @@ describe('Badge', () => {
         expect(animationValue).not.toBe('');
     });
 
+    it('is positioned according to the offset props', () => {
+        const offsetX = 10;
+        const offsetY = 10;
+
+        const wrapper = mountWithTheme(
+            <Badge value={1} position="top-right" offsetX={offsetX} offsetY={offsetY} />,
+        );
+
+        const badgeNode = wrapper.find(BadgeCircle).getDOMNode();
+        const badgeStyle = getComputedStyle(badgeNode);
+
+        expect(badgeStyle.getPropertyValue('top')).toEqual(`${offsetY}px`);
+        expect(badgeStyle.getPropertyValue('right')).toEqual(`-${offsetX}px`);
+        expect(badgeStyle.getPropertyValue('bottom')).toEqual('');
+        expect(badgeStyle.getPropertyValue('left')).toEqual('');
+    });
+
     test('matches the snapshot', () => {
         const tree = renderWithTheme(
             <>


### PR DESCRIPTION
## PR Description
DS-624

Ajout des props `offsetX` et `offsetY` pour permettre de positionner plus précisément le badge (par exemple dans le cas où l'élément qu'il accompagne a un padding et qu'on veut que le badge soit plus près). Ces nouvelles props acceptent une valeur numérique en px, motivé par le fait que nos variables de spacing soient aussi en px.

## New component checklist
- [x] The component is unit tested and/or snapshot tested.
- [x] There are no linting errors or warnings in the modified/new code.
- [x] All GitHub checks are successful.
