### PR TITLE
chore(ThemeEntryPoint): add a webpack entry point to export theme dat…

### DIFF
--- a/packages/react/src/theme.ts
+++ b/packages/react/src/theme.ts
@@ -1,0 +1,2 @@
+export { equisoftTheme } from './themes/equisoft';
+export { Theme } from './themes/theme';

--- a/packages/react/webpack/webpack.config.common.js
+++ b/packages/react/webpack/webpack.config.common.js
@@ -3,7 +3,10 @@ const ReactDocgenTypescriptPlugin = require('react-docgen-typescript-plugin').de
 const pkg = require('../package');
 
 module.exports = {
-    entry: './src/index.ts',
+    entry: {
+        bundle: './src/index.ts',
+        theme: './src/theme.ts',
+    },
     externals: Object.keys(pkg.peerDependencies),
     module: {
         rules: [
@@ -59,7 +62,7 @@ module.exports = {
         }),
     ],
     output: {
-        filename: 'bundle.js',
+        filename: '[name].js',
         path: path.resolve(__dirname, '../dist'),
         libraryTarget: 'umd',
     },


### PR DESCRIPTION
[CRM-14417](https://jira.equisoft.com/browse/CRM-14417)

Dans le cadre de la thématisation pour Beamer, il est requis de produire un CSS standalone qui utilise entre autres les valeurs de configuration du thème Equisoft. La compilation et l'hébergement du CSS est faite dans theme-directory. Pour permettre d'importer ces valeurs de configuration sans toutes les dépendances associées, j'ai ajouté un nouveau entry point dans la configuration webpack. La thématisation sera disponible via un `import { equisoftTheme, Theme } from '@equisoft/design-elements-react/dist/theme.js'`

C'est une solution qui pourrait être temporaire. Une issue a été créée (DS-629) pour proposer une piste de solution pour le futur.

