### PR TITLE
feat(NavLink): fix NavLinkProps is not generic

### DIFF
--- a/packages/react/src/components/dropdown-menu/list-items/nav-item.test.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/nav-item.test.tsx
@@ -1,6 +1,8 @@
 import { shallow } from 'enzyme';
 import { getByTestId } from '../../../test-utils/enzyme-selectors';
-import { NavItem } from './nav-item';
+import { breakpoints } from '../../../tokens/breakpoints';
+import { DesignSystem } from '../../design-system';
+import { NavItem, StyledNavItem } from './nav-item';
 
 describe('NavItem', () => {
     it('displays screen-reader-only text when router link opens in a new tab (target="_blank")', () => {
@@ -13,5 +15,25 @@ describe('NavItem', () => {
         const wrapper = shallow(<NavItem value="test" isHtmlLink href="test" target="_blank" />);
 
         expect(getByTestId(wrapper, 'screen-reader-text').exists()).toBe(true);
+    });
+
+    it('styled nav item has access to NavLinkProps', () => {
+        shallow(
+            <DesignSystem>
+                <StyledNavItem
+                    $device={{
+                        device: 'desktop',
+                        isDesktop: true,
+                        isTablet: false,
+                        isMobile: false,
+                        breakpoints,
+                    }}
+                    to="some-route"
+                    title="some title"
+                    exact
+                    isActive={() => true}
+                />
+            </DesignSystem>,
+        );
     });
 });

--- a/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, MouseEvent, ReactElement, Ref } from 'react';
-import { NavLink, NavLinkProps } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { useTranslation } from '../../../i18n/use-translation';
 import { focus } from '../../../utils/css-state';
@@ -55,7 +55,7 @@ const NavItemStyle = css<LinkProps>`
     }
 `;
 
-export const StyledNavItem = styled(NavLink)<LinkProps & NavLinkProps>`
+export const StyledNavItem = styled(NavLink)<LinkProps>`
     ${NavItemStyle}
 `;
 


### PR DESCRIPTION
[DS-648](https://jira.equisoft.com/browse/DS-648)

Règle le problème de générique avec NavLinkProps  avec react-router 6. Le build des projets en react 18 qui utilise le DS ne peuvent pas passer sans ce changements là. De toute façon, ce type là n'était pas nécessaire pour le styled components étant donné qu'on hérite déjà de NavLinkProps directement avec styled(NavLink)... 

"Type 'NavLinkProps' is not generic."
