### PR TITLE
feat(MenuButton): support inverted props

### DIFF
--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -22,11 +22,12 @@ interface Props {
     className?: string;
     defaultOpen?: boolean;
     iconName?: IconName;
+    inverted?: boolean;
     options: MenuOption[];
 }
 
 export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
-    autofocus, buttonType, children, className, defaultOpen, iconName, options,
+    autofocus, buttonType, children, className, defaultOpen, iconName, inverted, options,
 }) => {
     const [controlledVisible, setControlledVisible] = useState(!!defaultOpen);
     const {
@@ -65,6 +66,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
                     aria-haspopup="menu"
                     aria-expanded={visible}
                     buttonType={buttonType}
+                    inverted={inverted}
                     iconName={iconName}
                     onClick={() => setControlledVisible(!controlledVisible)}
                     ref={setTriggerRef}
@@ -77,6 +79,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
                     aria-haspopup="menu"
                     aria-expanded={visible}
                     buttonType={buttonType}
+                    inverted={inverted}
                     onClick={() => setControlledVisible(!controlledVisible)}
                     ref={setTriggerRef}
                 >

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -75,6 +75,7 @@ const submenuOptions = [
 export const Normal: Story = () => (
     <>
         <MenuButton options={options} buttonType="primary">Button</MenuButton>
+        <MenuButton options={options} buttonType="primary" inverted>Button</MenuButton>
         <MenuButton options={options} buttonType="secondary">Button</MenuButton>
         <MenuButton options={options} buttonType="tertiary">Button</MenuButton>
         <MenuButton options={options} buttonType="destructive">Button</MenuButton>


### PR DESCRIPTION
## PR Description
Dans `/plan` nous avons besoin que les MenuButtons supportent un style Inverted

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] All GitHub checks are successful.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] All GitHub checks are successful.
