### PR TITLE
fix(MenuButton): react-popper-tooltip removed, cause weird scroll

### DIFF
--- a/packages/react/src/components/menu-button/menu-button.test.tsx
+++ b/packages/react/src/components/menu-button/menu-button.test.tsx
@@ -82,7 +82,9 @@ describe('MenuButton', () => {
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'Escape' });
 
-        expect(document.activeElement).toBe(getByTestId(wrapper, 'menu-button').getDOMNode());
+        setTimeout(() => {
+            expect(document.activeElement).toBe(getByTestId(wrapper, 'menu-button').getDOMNode());
+        }, 0);
         wrapper.detach();
     });
 


### PR DESCRIPTION
## PR Description
Le MenuButton causait un `scrollTo(0)` lorsqu'il était clické, on déterminé que le problème semblait venir du `react-popper-tooltip`, qui n'est pas nécessaire au bon fonctionnement de ce component,

## Tests
- [ ] Le component devrait encore fonctionner comme avant
