### PR TITLE
fix: a11y zoom 200% all non-control components

### DIFF
--- a/packages/react/src/components/avatar/avatar.test.tsx.snap
+++ b/packages/react/src/components/avatar/avatar.test.tsx.snap
@@ -20,12 +20,12 @@ exports[`Avatar Matches Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.625rem;
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-letter-spacing: 0.011rem;
   -moz-letter-spacing: 0.011rem;
   -ms-letter-spacing: 0.011rem;
   letter-spacing: 0.011rem;
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 <div
@@ -61,8 +61,8 @@ exports[`Avatar Matches large avatar Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 1.5rem;
-  height: 80px;
-  width: 80px;
+  height: var(--size-5x);
+  width: var(--size-5x);
 }
 
 <div
@@ -83,8 +83,8 @@ exports[`Avatar Matches large avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 1.5rem;
-  height: 80px;
-  width: 80px;
+  height: var(--size-5x);
+  width: var(--size-5x);
 }
 
 <img
@@ -114,8 +114,8 @@ exports[`Avatar Matches medium avatar Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 1rem;
-  height: 48px;
-  width: 48px;
+  height: var(--size-3x);
+  width: var(--size-3x);
 }
 
 <div
@@ -136,8 +136,8 @@ exports[`Avatar Matches medium avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 1rem;
-  height: 48px;
-  width: 48px;
+  height: var(--size-3x);
+  width: var(--size-3x);
 }
 
 <img
@@ -167,12 +167,12 @@ exports[`Avatar Matches mobile Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.75rem;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-letter-spacing: 0.013rem;
   -moz-letter-spacing: 0.013rem;
   -ms-letter-spacing: 0.013rem;
   letter-spacing: 0.013rem;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 <div
@@ -193,12 +193,12 @@ exports[`Avatar Matches mobile avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 0.75rem;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-letter-spacing: 0.013rem;
   -moz-letter-spacing: 0.013rem;
   -ms-letter-spacing: 0.013rem;
   letter-spacing: 0.013rem;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 <img
@@ -228,8 +228,8 @@ exports[`Avatar Matches mobile large avatar Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 1.5rem;
-  height: 72px;
-  width: 72px;
+  height: var(--size-4halfx);
+  width: var(--size-4halfx);
 }
 
 <div
@@ -250,8 +250,8 @@ exports[`Avatar Matches mobile large avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 1.5rem;
-  height: 72px;
-  width: 72px;
+  height: var(--size-4halfx);
+  width: var(--size-4halfx);
 }
 
 <img
@@ -281,8 +281,8 @@ exports[`Avatar Matches mobile medium avatar Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 1rem;
-  height: 48px;
-  width: 48px;
+  height: var(--size-3x);
+  width: var(--size-3x);
 }
 
 <div
@@ -303,8 +303,8 @@ exports[`Avatar Matches mobile medium avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 1rem;
-  height: 48px;
-  width: 48px;
+  height: var(--size-3x);
+  width: var(--size-3x);
 }
 
 <img
@@ -334,12 +334,12 @@ exports[`Avatar Matches mobile small avatar Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.875rem;
-  height: 40px;
+  height: var(--size-2halfx);
   -webkit-letter-spacing: 0.014rem;
   -moz-letter-spacing: 0.014rem;
   -ms-letter-spacing: 0.014rem;
   letter-spacing: 0.014rem;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <div
@@ -360,12 +360,12 @@ exports[`Avatar Matches mobile small avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 0.875rem;
-  height: 40px;
+  height: var(--size-2halfx);
   -webkit-letter-spacing: 0.014rem;
   -moz-letter-spacing: 0.014rem;
   -ms-letter-spacing: 0.014rem;
   letter-spacing: 0.014rem;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <img
@@ -395,12 +395,12 @@ exports[`Avatar Matches small avatar Snapshot 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.75rem;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-letter-spacing: 0.013rem;
   -moz-letter-spacing: 0.013rem;
   -ms-letter-spacing: 0.013rem;
   letter-spacing: 0.013rem;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 <div
@@ -421,12 +421,12 @@ exports[`Avatar Matches small avatar with image Snapshot 1`] = `
   border-radius: 50%;
   object-fit: cover;
   font-size: 0.75rem;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-letter-spacing: 0.013rem;
   -moz-letter-spacing: 0.013rem;
   -ms-letter-spacing: 0.013rem;
   letter-spacing: 0.013rem;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 <img
@@ -456,12 +456,12 @@ exports[`Avatar Should use bigger user icon when username is empty on mobile 1`]
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.75rem;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-letter-spacing: 0.013rem;
   -moz-letter-spacing: 0.013rem;
   -ms-letter-spacing: 0.013rem;
   letter-spacing: 0.013rem;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 <div
@@ -502,12 +502,12 @@ exports[`Avatar Should use user icon when username is empty on desktop 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.625rem;
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-letter-spacing: 0.011rem;
   -moz-letter-spacing: 0.011rem;
   -ms-letter-spacing: 0.011rem;
   letter-spacing: 0.011rem;
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 <div
@@ -548,12 +548,12 @@ exports[`Avatar Should use user icon when username is undefined 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.625rem;
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-letter-spacing: 0.011rem;
   -moz-letter-spacing: 0.011rem;
   -ms-letter-spacing: 0.011rem;
   letter-spacing: 0.011rem;
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 <div

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -26,28 +26,28 @@ function getSpecificSizeStyle({ size, isMobile }: SizeStyleProps): FlattenInterp
         case 'xsmall':
             return css`
                 font-size: ${(isMobile ? '0.75' : '0.625')}rem;
-                height: ${(isMobile ? '32' : '24')}px;
+                height: ${(isMobile ? 'var(--size-2x)' : 'var(--size-1halfx)')};
                 letter-spacing: ${(isMobile ? '0.013' : '0.011')}rem;
-                width: ${(isMobile ? '32' : '24')}px;
+                width: ${(isMobile ? 'var(--size-2x)' : 'var(--size-1halfx)')};
             `;
         case 'small':
             return css`
                 font-size: ${(isMobile ? '0.875' : '0.75')}rem;
-                height: ${(isMobile ? '40' : '32')}px;
+                height: ${(isMobile ? 'var(--size-2halfx)' : 'var(--size-2x)')};
                 letter-spacing: ${(isMobile ? '0.014' : '0.013')}rem;
-                width: ${(isMobile ? '40' : '32')}px;
+                width: ${(isMobile ? 'var(--size-2halfx)' : 'var(--size-2x)')};
             `;
         case 'medium':
             return css`
                 font-size: 1rem;
-                height: 48px;
-                width: 48px;
+                height: var(--size-3x);
+                width: var(--size-3x);
             `;
         case 'large':
             return css`
                 font-size: 1.5rem;
-                height: ${(isMobile ? '72' : '80')}px;
-                width: ${(isMobile ? '72' : '80')}px;
+                height: ${(isMobile ? 'var(--size-4halfx)' : 'var(--size-5x)')};
+                width: ${(isMobile ? 'var(--size-4halfx)' : 'var(--size-5x)')};
             `;
     }
 }

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {
@@ -92,6 +94,11 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   background-color: #012639;
   border-color: #006296;
   color: #FFFFFF;
+}
+
+.c3 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -878,6 +885,8 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {
@@ -913,6 +922,11 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   background-color: #012639;
   border-color: #006296;
   color: #FFFFFF;
+}
+
+.c3 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -1611,6 +1625,8 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {
@@ -1646,6 +1662,11 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   background-color: #012639;
   border-color: #006296;
   color: #FFFFFF;
+}
+
+.c3 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -135,6 +135,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -179,6 +180,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -965,6 +967,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -1009,6 +1012,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -1707,6 +1711,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -1751,6 +1756,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -222,8 +222,10 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c19 {
@@ -529,7 +531,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -541,7 +543,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
                 Option A
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -568,7 +570,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -580,7 +582,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
                 Option B
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -606,7 +608,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -618,7 +620,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
                 Option C
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -644,7 +646,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -656,7 +658,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
                 Option D
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -694,7 +696,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -706,7 +708,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
                 Option E
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -732,7 +734,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -744,7 +746,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
                 Option F
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -1050,8 +1052,10 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c19 {
@@ -1357,7 +1361,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -1369,7 +1373,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
                 Option A
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -1396,7 +1400,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -1408,7 +1412,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
                 Option B
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -1434,7 +1438,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -1446,7 +1450,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
                 Option C
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -1472,7 +1476,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -1484,7 +1488,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
                 Option D
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -1790,8 +1794,10 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c19 {
@@ -2097,7 +2103,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -2109,7 +2115,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
                 Option A
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -2136,7 +2142,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -2148,7 +2154,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
                 Option B
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -2174,7 +2180,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -2186,7 +2192,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
                 Option C
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"
@@ -2212,7 +2218,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
             height="22"
             width="22"
           />
-          <span
+          <div
             class="c13"
           >
             <div
@@ -2224,7 +2230,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
                 Option D
               </span>
             </div>
-          </span>
+          </div>
           <span
             class="c16"
             data-testid="screen-reader-text"

--- a/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
@@ -23,6 +23,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -55,15 +56,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -155,6 +147,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -187,15 +180,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -346,6 +330,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -378,15 +363,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -467,6 +443,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -499,15 +476,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);

--- a/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
@@ -55,8 +55,19 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c3 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c3:visited svg {
@@ -176,8 +187,19 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c3 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c3:visited svg {
@@ -356,8 +378,19 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c3 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c3:visited svg {
@@ -466,8 +499,19 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c3 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c3 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c3:visited svg {

--- a/packages/react/src/components/buttons/abstract-button.tsx
+++ b/packages/react/src/components/buttons/abstract-button.tsx
@@ -55,6 +55,8 @@ export const defaultButtonStyles = css<{ isMobile: boolean, size?: Size }>`
 
     > svg {
         color: inherit;
+        height: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
+        width: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
     }
 `;
 

--- a/packages/react/src/components/buttons/button.test.tsx.snap
+++ b/packages/react/src/components/buttons/button.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`Button has destructive styles (inverted) 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -155,6 +157,8 @@ exports[`Button has destructive styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -253,6 +257,8 @@ exports[`Button has disabled styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -348,6 +354,8 @@ exports[`Button has mobile styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c1 {
@@ -442,6 +450,8 @@ exports[`Button has primary styles (inverted) 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -538,6 +548,8 @@ exports[`Button has primary styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -632,6 +644,8 @@ exports[`Button has secondary styles (inverted) 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -731,6 +745,8 @@ exports[`Button has secondary styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -1013,6 +1029,8 @@ exports[`Button has tertiary styles (inverted) 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -1113,6 +1131,8 @@ exports[`Button has tertiary styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {

--- a/packages/react/src/components/buttons/button.test.tsx.snap
+++ b/packages/react/src/components/buttons/button.test.tsx.snap
@@ -841,6 +841,8 @@ exports[`Button has small styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -935,6 +937,8 @@ exports[`Button has small styles on mobile 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c1 {

--- a/packages/react/src/components/buttons/icon-button.test.tsx.snap
+++ b/packages/react/src/components/buttons/icon-button.test.tsx.snap
@@ -498,6 +498,8 @@ exports[`Icon Button Has small styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {

--- a/packages/react/src/components/buttons/icon-button.test.tsx.snap
+++ b/packages/react/src/components/buttons/icon-button.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`Icon Button Has disabled styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -86,6 +88,11 @@ exports[`Icon Button Has disabled styles 1`] = `
 .c1:disabled {
   background-color: #84C6EA;
   border-color: #84C6EA;
+}
+
+.c1 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <button
@@ -161,6 +168,8 @@ exports[`Icon Button Has mobile styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c1 {
@@ -190,6 +199,11 @@ exports[`Icon Button Has mobile styles 1`] = `
 .c1:disabled {
   background-color: #84C6EA;
   border-color: #84C6EA;
+}
+
+.c1 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 <button
@@ -264,6 +278,8 @@ exports[`Icon Button Has primary styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -293,6 +309,11 @@ exports[`Icon Button Has primary styles 1`] = `
 .c1:disabled {
   background-color: #84C6EA;
   border-color: #84C6EA;
+}
+
+.c1 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <button
@@ -367,6 +388,8 @@ exports[`Icon Button Has secondary styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -396,6 +419,11 @@ exports[`Icon Button Has secondary styles 1`] = `
 .c1:disabled {
   border-color: #84C6EA;
   color: #84C6EA;
+}
+
+.c1 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <button
@@ -564,6 +592,8 @@ exports[`Icon Button Has tertiary styles 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -599,6 +629,11 @@ exports[`Icon Button Has tertiary styles 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c1 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <button

--- a/packages/react/src/components/buttons/icon-button.tsx
+++ b/packages/react/src/components/buttons/icon-button.tsx
@@ -67,6 +67,11 @@ const getButtonSizeStyles = (
 const StyledButton = styled(AbstractButton)`
     ${getButtonTypeStyles};
     ${getButtonSizeStyles};
+
+    > svg {
+        height: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
+        width: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
+    }
 `;
 
 export const IconButton = forwardRef(({

--- a/packages/react/src/components/card-link/card-link.test.tsx.snap
+++ b/packages/react/src/components/card-link/card-link.test.tsx.snap
@@ -1,14 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CardLink Matches Snapshot 1`] = `
-.c2 {
-  color: #60666E;
+.c1 {
+  color: currentColor;
+  height: var(--size-1x);
   position: absolute;
   right: var(--spacing-3x);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -36,10 +38,6 @@ exports[`CardLink Matches Snapshot 1`] = `
   box-shadow: inset 0 0 0 1px #60666E,0 1px 4px 0 rgb(0 0 0 / 20%);
 }
 
-.c0:hover .c1 {
-  color: #000000;
-}
-
 .c0:focus {
   outline: none;
 }
@@ -58,7 +56,7 @@ exports[`CardLink Matches Snapshot 1`] = `
   Link Label
   <svg
     aria-hidden="true"
-    class="c1 c2"
+    class="c1"
     color="currentColor"
     focusable="false"
     height="16"

--- a/packages/react/src/components/card-link/card-link.tsx
+++ b/packages/react/src/components/card-link/card-link.tsx
@@ -5,11 +5,13 @@ import { focus } from '../../utils/css-state';
 import { Icon } from '../icon/icon';
 
 const StyledIcon = styled(Icon)`
-    color: ${({ theme }) => theme.greys['dark-grey']};
+    color: currentColor;
+    height: var(--size-1x);
     position: absolute;
     right: var(--spacing-3x);
     top: 50%;
     transform: translateY(-50%);
+    width: var(--size-1x);
 `;
 
 const StyledLink = styled(Link)`
@@ -33,10 +35,6 @@ const StyledLink = styled(Link)`
     &:hover {
         background-color: ${({ theme }) => theme.greys.grey};
         box-shadow: inset 0 0 0 1px ${({ theme }) => theme.greys['dark-grey']}, 0 1px 4px 0 rgb(0 0 0 / 20%);
-
-        ${StyledIcon} {
-            color: ${({ theme }) => theme.greys.black};
-        }
     }
 
     ${focus}

--- a/packages/react/src/components/checkbox-group/checkbox-group.test.tsx.snap
+++ b/packages/react/src/components/checkbox-group/checkbox-group.test.tsx.snap
@@ -41,11 +41,11 @@ exports[`Checkbox Matches the snapshot 1`] = `
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
-  position: absolute;
-  top: 4px;
-  width: 16px;
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c3:hover {
@@ -84,11 +84,16 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   line-height: 1.5rem;
-  min-height: 24px;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -103,7 +108,6 @@ exports[`Checkbox Matches the snapshot 1`] = `
 <label
     class="c0"
   >
-    Boat
     <input
       class="c1"
       data-testid="checkboxGroup-boat"
@@ -129,6 +133,7 @@ exports[`Checkbox Matches the snapshot 1`] = `
         width="24"
       />
     </span>
+    Boat
   </label>,
   .c5 {
   color: #FFFFFF;
@@ -157,11 +162,11 @@ exports[`Checkbox Matches the snapshot 1`] = `
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
-  position: absolute;
-  top: 4px;
-  width: 16px;
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c3:hover {
@@ -200,11 +205,16 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   line-height: 1.5rem;
-  min-height: 24px;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -219,7 +229,6 @@ exports[`Checkbox Matches the snapshot 1`] = `
 <label
     class="c0"
   >
-    Plane
     <input
       checked=""
       class="c1"
@@ -246,6 +255,7 @@ exports[`Checkbox Matches the snapshot 1`] = `
         width="24"
       />
     </span>
+    Plane
   </label>,
   .c5 {
   color: #FFFFFF;
@@ -274,11 +284,11 @@ exports[`Checkbox Matches the snapshot 1`] = `
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
-  position: absolute;
-  top: 4px;
-  width: 16px;
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c3:hover {
@@ -317,11 +327,16 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   cursor: default;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   line-height: 1.5rem;
-  min-height: 24px;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -337,7 +352,6 @@ exports[`Checkbox Matches the snapshot 1`] = `
     class="c0"
     disabled=""
   >
-    Car
     <input
       class="c1"
       data-testid="checkboxGroup-car"
@@ -365,6 +379,7 @@ exports[`Checkbox Matches the snapshot 1`] = `
         width="24"
       />
     </span>
+    Car
   </label>,
   .c5 {
   color: #FFFFFF;
@@ -393,11 +408,11 @@ exports[`Checkbox Matches the snapshot 1`] = `
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
-  position: absolute;
-  top: 4px;
-  width: 16px;
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c3:hover {
@@ -436,11 +451,16 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   line-height: 1.5rem;
-  min-height: 24px;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -455,7 +475,6 @@ exports[`Checkbox Matches the snapshot 1`] = `
 <label
     class="c0"
   >
-    Bike
     <input
       class="c1"
       data-testid="checkboxGroup-bike"
@@ -481,6 +500,7 @@ exports[`Checkbox Matches the snapshot 1`] = `
         width="24"
       />
     </span>
+    Bike
   </label>,
 ]
 `;

--- a/packages/react/src/components/checkbox/checkbox.test.tsx.snap
+++ b/packages/react/src/components/checkbox/checkbox.test.tsx.snap
@@ -28,11 +28,11 @@ exports[`Checkbox matches snapshot 1`] = `
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
-  position: absolute;
-  top: 4px;
-  width: 16px;
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c3:hover {
@@ -71,11 +71,16 @@ exports[`Checkbox matches snapshot 1`] = `
 }
 
 .c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   line-height: 1.5rem;
-  min-height: 24px;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -99,7 +104,6 @@ exports[`Checkbox matches snapshot 1`] = `
     <label
       className="c0"
     >
-      Boat
       <styled.input
         name="vehicule"
         type="checkbox"
@@ -150,6 +154,7 @@ exports[`Checkbox matches snapshot 1`] = `
           </Styled(Icon)>
         </span>
       </styled.span>
+      Boat
     </label>
   </styled.label>
 </Checkbox>

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -13,7 +13,7 @@ import { focus } from '../../utils/css-state';
 import { Icon } from '../icon/icon';
 import { useDataAttributes } from '../../hooks/use-data-attributes';
 
-const checkboxWidth = '16px';
+const checkboxWidth = 'var(--size-1x)';
 
 const iconStyles = css`
     color: ${({ theme }) => theme.greys.white};
@@ -39,10 +39,10 @@ const CustomCheckbox = styled.span<{ disabled?: boolean }>`
     border-radius: var(--border-radius);
     box-sizing: border-box;
     display: inline-block;
-    height: 16px;
+    height: var(--size-1x);
     left: 0;
-    position: absolute;
-    top: 4px;
+    margin-right: var(--spacing-1x);
+    position: relative;
     width: ${checkboxWidth};
 
     &:hover {
@@ -83,11 +83,10 @@ interface StyledLabelProps {
 }
 
 const StyledLabel = styled.label<StyledLabelProps>`
+    align-items: center;
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
-    display: block;
+    display: flex;
     line-height: 1.5rem;
-    min-height: 24px;
-    padding-left: ${({ hasLabel }) => (hasLabel ? 'var(--spacing-3x)' : checkboxWidth)};
     position: relative;
     user-select: none;
 
@@ -142,7 +141,6 @@ export const Checkbox: FunctionComponent<PropsWithChildren<Props>> = forwardRef(
             disabled={disabled}
             key={`${name}-${value}`}
         >
-            {label}
             <StyledInput
                 id={id}
                 ref={checkboxRef}
@@ -159,6 +157,7 @@ export const Checkbox: FunctionComponent<PropsWithChildren<Props>> = forwardRef(
                 <CheckMarkIcon />
                 <IndeterminateIcon />
             </CustomCheckbox>
+            {label}
         </StyledLabel>
     );
 });

--- a/packages/react/src/components/chooser-card/chooser-card.test.tsx.snap
+++ b/packages/react/src/components/chooser-card/chooser-card.test.tsx.snap
@@ -7,14 +7,14 @@ exports[`Chooser Card Matches snapshot (Checked, Desktop) 1`] = `
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   position: absolute;
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 16px;
+  width: var(--size-1x);
 }
 
 .c2 {
@@ -70,13 +70,13 @@ exports[`Chooser Card Matches snapshot (Checked, Desktop) 1`] = `
 }
 
 .c3 {
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   margin: 0;
   opacity: 0;
   position: absolute;
-  top: 2px;
-  width: 16px;
+  top: 0.125rem;
+  width: var(--size-1x);
 }
 
 .c3:checked + .c4 {
@@ -88,14 +88,14 @@ exports[`Chooser Card Matches snapshot (Checked, Desktop) 1`] = `
   background-color: #FFFFFF;
   border-radius: 50%;
   content: "";
-  height: 8px;
+  height: var(--size-half);
   left: 50%;
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 8px;
+  width: var(--size-half);
 }
 
 <label
@@ -136,14 +136,14 @@ exports[`Chooser Card Matches snapshot (Default, Desktop) 1`] = `
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   position: absolute;
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 16px;
+  width: var(--size-1x);
 }
 
 .c2 {
@@ -199,13 +199,13 @@ exports[`Chooser Card Matches snapshot (Default, Desktop) 1`] = `
 }
 
 .c3 {
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   margin: 0;
   opacity: 0;
   position: absolute;
-  top: 2px;
-  width: 16px;
+  top: 0.125rem;
+  width: var(--size-1x);
 }
 
 .c3:checked + .c4 {
@@ -217,14 +217,14 @@ exports[`Chooser Card Matches snapshot (Default, Desktop) 1`] = `
   background-color: #FFFFFF;
   border-radius: 50%;
   content: "";
-  height: 8px;
+  height: var(--size-half);
   left: 50%;
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 8px;
+  width: var(--size-half);
 }
 
 <label
@@ -264,14 +264,14 @@ exports[`Chooser Card Matches snapshot (Default, Mobile) 1`] = `
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;
-  height: 24px;
+  height: var(--size-1halfx);
   left: 0;
   position: absolute;
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 .c2 {
@@ -327,13 +327,13 @@ exports[`Chooser Card Matches snapshot (Default, Mobile) 1`] = `
 }
 
 .c3 {
-  height: 24px;
+  height: var(--size-1halfx);
   left: 0;
   margin: 0;
   opacity: 0;
   position: absolute;
-  top: 2px;
-  width: 24px;
+  top: 0.125rem;
+  width: var(--size-1halfx);
 }
 
 .c3:checked + .c4 {
@@ -345,14 +345,14 @@ exports[`Chooser Card Matches snapshot (Default, Mobile) 1`] = `
   background-color: #FFFFFF;
   border-radius: 50%;
   content: "";
-  height: 8px;
+  height: var(--size-half);
   left: 50%;
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 8px;
+  width: var(--size-half);
 }
 
 <label
@@ -392,14 +392,14 @@ exports[`Chooser Card Matches snapshot (Disabled, Desktop) 1`] = `
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   position: absolute;
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 16px;
+  width: var(--size-1x);
 }
 
 .c2 {
@@ -455,13 +455,13 @@ exports[`Chooser Card Matches snapshot (Disabled, Desktop) 1`] = `
 }
 
 .c3 {
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   margin: 0;
   opacity: 0;
   position: absolute;
-  top: 2px;
-  width: 16px;
+  top: 0.125rem;
+  width: var(--size-1x);
 }
 
 .c3:checked + .c4 {
@@ -473,14 +473,14 @@ exports[`Chooser Card Matches snapshot (Disabled, Desktop) 1`] = `
   background-color: #FFFFFF;
   border-radius: 50%;
   content: "";
-  height: 8px;
+  height: var(--size-half);
   left: 50%;
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 8px;
+  width: var(--size-half);
 }
 
 <label

--- a/packages/react/src/components/chooser-card/styled-components.ts
+++ b/packages/react/src/components/chooser-card/styled-components.ts
@@ -13,12 +13,12 @@ export const RadioInput = styled.span<RadioInputProps>`
     border-radius: 50%;
     box-sizing: border-box;
     display: inline-block;
-    height: ${({ isMobile }) => (isMobile ? 24 : 16)}px;
+    height: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
     left: 0;
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    width: ${({ isMobile }) => (isMobile ? 24 : 16)}px;
+    width: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
 `;
 
 interface InputContainerProps {
@@ -115,13 +115,13 @@ export const Label = styled.label<LabelProps>`
 `;
 
 export const HiddenInput = styled.input<{ isMobile: boolean }>`
-    height: ${({ isMobile }) => (isMobile ? 24 : 16)}px;
+    height: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
     left: 0;
     margin: 0;
     opacity: 0;
     position: absolute;
-    top: 2px;
-    width: ${({ isMobile }) => (isMobile ? 24 : 16)}px;
+    top: 0.125rem;
+    width: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
 
     &:checked + ${RadioInput} {
         background-color: ${({ theme }) => theme.main['primary-1.1']};
@@ -131,12 +131,12 @@ export const HiddenInput = styled.input<{ isMobile: boolean }>`
             background-color: ${({ theme }) => theme.greys.white};
             border-radius: 50%;
             content: "";
-            height: 8px;
+            height: var(--size-half);
             left: 50%;
             position: absolute;
             top: 50%;
             transform: translate(-50%, -50%);
-            width: 8px;
+            width: var(--size-half);
         }
     }
 `;

--- a/packages/react/src/components/datepicker/datepicker.test.tsx.snap
+++ b/packages/react/src/components/datepicker/datepicker.test.tsx.snap
@@ -166,14 +166,14 @@ input + .c1 {
 
 .c4 .react-datepicker__portal .react-datepicker__day-name {
   font-size: 1rem;
-  line-height: 1.5rem;
-  width: var(--size-2halfx);
+  line-height: 2rem;
+  width: var(--size-2x);
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
-  line-height: 2.5rem;
-  width: var(--size-2halfx);
+  height: var(--size-2x);
+  line-height: 2rem;
+  width: var(--size-2x);
 }
 
 label + .c3 {
@@ -250,6 +250,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -468,7 +473,7 @@ input + .c1 {
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
+  height: var(--size-2halfx);
   line-height: 2.5rem;
   width: var(--size-2halfx);
 }
@@ -547,6 +552,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -767,7 +777,7 @@ input + .c1 {
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
+  height: var(--size-2halfx);
   line-height: 2.5rem;
   width: var(--size-2halfx);
 }
@@ -846,6 +856,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -1066,7 +1081,7 @@ input + .c1 {
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
+  height: var(--size-2halfx);
   line-height: 2.5rem;
   width: var(--size-2halfx);
 }
@@ -1143,6 +1158,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -1395,7 +1415,7 @@ input + .c1 {
 }
 
 .c7 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
+  height: var(--size-2halfx);
   line-height: 2.5rem;
   width: var(--size-2halfx);
 }
@@ -1474,6 +1494,11 @@ label + .c6 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c9 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -1713,14 +1738,14 @@ input + .c1 {
 
 .c4 .react-datepicker__portal .react-datepicker__day-name {
   font-size: 1rem;
-  line-height: 1.5rem;
-  width: var(--size-2halfx);
+  line-height: 2rem;
+  width: var(--size-2x);
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
-  line-height: 2.5rem;
-  width: var(--size-2halfx);
+  height: var(--size-2x);
+  line-height: 2rem;
+  width: var(--size-2x);
 }
 
 label + .c3 {
@@ -1797,6 +1822,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -1991,6 +2021,11 @@ input + .c1 {
   display: flex;
 }
 
+.c14 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 .c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -2170,7 +2205,7 @@ input + .c1 {
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
+  height: var(--size-2halfx);
   line-height: 2.5rem;
   width: var(--size-2halfx);
 }
@@ -2249,6 +2284,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c15 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -3002,6 +3042,8 @@ exports[`Datepicker matches snapshot (open, hasTodayButton) 1`] = `
 
 .c16 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c17 {
@@ -3173,6 +3215,11 @@ input + .c1 {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c14 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c6 {
@@ -3354,7 +3401,7 @@ input + .c1 {
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
+  height: var(--size-2halfx);
   line-height: 2.5rem;
   width: var(--size-2halfx);
 }
@@ -3439,6 +3486,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c18 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -4292,6 +4344,11 @@ input + .c1 {
   display: flex;
 }
 
+.c14 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 .c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -4468,14 +4525,14 @@ input + .c1 {
 
 .c4 .react-datepicker__portal .react-datepicker__day-name {
   font-size: 1rem;
-  line-height: 1.5rem;
-  width: var(--size-2halfx);
+  line-height: 2rem;
+  width: var(--size-2x);
 }
 
 .c4 .react-datepicker__portal .react-datepicker__day {
-  height: 40px;
-  line-height: 2.5rem;
-  width: var(--size-2halfx);
+  height: var(--size-2x);
+  line-height: 2rem;
+  width: var(--size-2x);
 }
 
 label + .c3 {
@@ -4552,6 +4609,11 @@ label + .c3 {
   box-shadow: 0 0 0 2px #84C6EA;
   outline: none;
   z-index: 10;
+}
+
+.c15 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div

--- a/packages/react/src/components/datepicker/datepicker.tsx
+++ b/packages/react/src/components/datepicker/datepicker.tsx
@@ -184,14 +184,14 @@ const Container = styled.div<{ isMobile: boolean, theme: Theme }>`
 
         .react-datepicker__day-name {
             font-size: 1rem;
-            line-height: 1.5rem;
-            width: var(--size-2halfx);
+            line-height: ${({ isMobile }) => (isMobile ? 2 : 1.5)}rem;
+            width: ${({ isMobile }) => (isMobile ? 'var(--size-2x)' : 'var(--size-2halfx)')};
         }
 
         .react-datepicker__day {
-            height: 40px;
-            line-height: 2.5rem;
-            width: var(--size-2halfx);
+            height: ${({ isMobile }) => (isMobile ? 'var(--size-2x)' : 'var(--size-2halfx)')};
+            line-height: ${({ isMobile }) => (isMobile ? 2 : 2.5)}rem;
+            width: ${({ isMobile }) => (isMobile ? 'var(--size-2x)' : 'var(--size-2halfx)')};
         }
     }
 
@@ -271,6 +271,11 @@ const CalendarButton = styled.button<CalendarButtonProps>`
         box-shadow: ${({ theme }) => theme.tokens['focus-box-shadow']};
         outline: none;
         z-index: 10;
+    }
+
+    > svg {
+        height: var(--size-1x);
+        width: var(--size-1x);
     }
 `;
 

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c13 {
@@ -727,6 +729,8 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c13 {

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -160,8 +160,10 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c14 {
@@ -461,7 +463,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           href="/testA"
           tabindex="0"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -473,7 +475,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
                 optionA
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -484,7 +486,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           href="/testB"
           tabindex="0"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -496,7 +498,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
                 optionB
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -507,7 +509,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           href="/testC"
           tabindex="0"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -519,7 +521,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
                 optionC
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -531,7 +533,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           href="/testD"
           tabindex="-1"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -543,7 +545,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
                 optionD
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
     </ul>
@@ -832,8 +834,10 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c14 {
@@ -1134,7 +1138,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           href="/testA"
           tabindex="0"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -1146,7 +1150,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
                 optionA
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1157,7 +1161,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           href="/testB"
           tabindex="0"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -1169,7 +1173,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
                 optionB
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1180,7 +1184,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           href="/testC"
           tabindex="0"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -1192,7 +1196,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
                 optionC
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1204,7 +1208,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           href="/testD"
           tabindex="-1"
         >
-          <span
+          <div
             class="c9"
           >
             <div
@@ -1216,7 +1220,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
                 optionD
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
     </ul>

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -73,6 +73,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -117,6 +118,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -747,6 +749,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -791,6 +794,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
@@ -75,8 +75,10 @@ exports[`DropdownMenu Is hidden 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c7 {
@@ -251,7 +253,7 @@ exports[`DropdownMenu Is hidden 1`] = `
         href="/testA"
         tabindex="0"
       >
-        <span
+        <div
           class="c3"
         >
           <div
@@ -263,7 +265,7 @@ exports[`DropdownMenu Is hidden 1`] = `
               optionA
             </span>
           </div>
-        </span>
+        </div>
       </a>
     </li>
     <li>
@@ -274,7 +276,7 @@ exports[`DropdownMenu Is hidden 1`] = `
         href="/testB"
         tabindex="0"
       >
-        <span
+        <div
           class="c3"
         >
           <div
@@ -286,7 +288,7 @@ exports[`DropdownMenu Is hidden 1`] = `
               optionB
             </span>
           </div>
-        </span>
+        </div>
       </a>
     </li>
     <li>
@@ -297,7 +299,7 @@ exports[`DropdownMenu Is hidden 1`] = `
         href="/testC"
         tabindex="0"
       >
-        <span
+        <div
           class="c3"
         >
           <div
@@ -309,7 +311,7 @@ exports[`DropdownMenu Is hidden 1`] = `
               optionC
             </span>
           </div>
-        </span>
+        </div>
       </a>
     </li>
   </ul>
@@ -483,8 +485,10 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c7 {
@@ -658,7 +662,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
         href="/testA"
         tabindex="0"
       >
-        <span
+        <div
           class="c3"
         >
           <div
@@ -670,7 +674,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
               optionA
             </span>
           </div>
-        </span>
+        </div>
       </a>
     </li>
     <li>
@@ -681,7 +685,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
         href="/testB"
         tabindex="0"
       >
-        <span
+        <div
           class="c3"
         >
           <div
@@ -693,7 +697,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
               optionB
             </span>
           </div>
-        </span>
+        </div>
       </a>
     </li>
     <li>
@@ -704,7 +708,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
         href="/testC"
         tabindex="0"
       >
-        <span
+        <div
           class="c3"
         >
           <div
@@ -716,7 +720,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
               optionC
             </span>
           </div>
-        </span>
+        </div>
       </a>
     </li>
   </ul>

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
@@ -24,6 +24,7 @@ exports[`DropdownMenu Is hidden 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -434,6 +435,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/packages/react/src/components/dropdown-menu/list-items/item-content.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/item-content.tsx
@@ -61,7 +61,7 @@ const getFontSize = ({ $smallLabel, $device: { isTablet, isMobile } }: LabelCont
     return (isTablet || isMobile) ? '1rem' : '0.875rem';
 };
 
-const LabelContainer = styled.span<{ $smallLabel: boolean, $device: DeviceContextProps }>`
+const LabelContainer = styled.div<{ $smallLabel: boolean, $device: DeviceContextProps }>`
     align-items: center;
     display: flex;
     flex-flow: row wrap;

--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`External Link matches snapshot (disabled) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -121,6 +122,7 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -249,6 +251,7 @@ exports[`External Link matches snapshot (only icon) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -375,6 +378,7 @@ exports[`External Link matches snapshot (without href) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -503,6 +507,7 @@ exports[`External Link matches snapshot 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }

--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -56,8 +56,10 @@ exports[`External Link matches snapshot (disabled) 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1 {
@@ -174,8 +176,10 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1 {
@@ -300,8 +304,10 @@ exports[`External Link matches snapshot (only icon) 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1 {
@@ -424,8 +430,10 @@ exports[`External Link matches snapshot (without href) 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1 {
@@ -546,8 +554,10 @@ exports[`External Link matches snapshot 1`] = `
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
+  height: 1rem;
   margin-left: var(--spacing-half);
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1 {

--- a/packages/react/src/components/external-link/external-link.tsx
+++ b/packages/react/src/components/external-link/external-link.tsx
@@ -13,8 +13,10 @@ const LeftIcon = styled(Icon)`
 const ExternalIcon = styled(Icon)`
     align-self: center;
     flex-shrink: 0;
+    height: 1rem;
     margin-left: var(--spacing-half);
     margin-right: 0;
+    width: 1rem;
 `;
 
 const Link = styled(StyledLink)`

--- a/packages/react/src/components/global-banner/global-banner.test.tsx.snap
+++ b/packages/react/src/components/global-banner/global-banner.test.tsx.snap
@@ -127,7 +127,7 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
   -ms-letter-spacing: 0.0125rem;
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
-  padding: 0 var(--spacing-2x) var(--spacing-1x) var(--spacing-5x);
+  padding: var(--spacing-1x) var(--spacing-2x);
   position: relative;
 }
 
@@ -144,18 +144,23 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-top: var(--spacing-1x);
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
-  left: calc(var(--spacing-3x) * -1);
-  position: absolute;
-  top: var(--spacing-half);
+  height: var(--size-1x);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1x);
+}
+
+.c2 {
+  -webkit-align-self: initial;
+  -ms-flex-item-align: initial;
+  align-self: initial;
 }
 
 .c3 {
@@ -183,14 +188,11 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-top: var(--spacing-1x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: unset;
 }
 
-.c6 * + * {
+.c6 > button {
+  margin-top: 0;
   margin-left: var(--spacing-1x);
 }
 
@@ -401,7 +403,7 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
   -ms-letter-spacing: 0.0125rem;
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
-  padding: 0 var(--spacing-2x) var(--spacing-1x) var(--spacing-5x);
+  padding: var(--spacing-1x) var(--spacing-2x);
   position: relative;
 }
 
@@ -418,18 +420,23 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-top: var(--spacing-1x);
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
-  left: calc(var(--spacing-3x) * -1);
-  position: absolute;
-  top: var(--spacing-half);
+  height: var(--size-1x);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1x);
+}
+
+.c2 {
+  -webkit-align-self: initial;
+  -ms-flex-item-align: initial;
+  align-self: initial;
 }
 
 .c3 {
@@ -465,14 +472,11 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-top: var(--spacing-1x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: unset;
 }
 
-.c6 * + * {
+.c6 > button {
+  margin-top: 0;
   margin-left: var(--spacing-1x);
 }
 
@@ -690,7 +694,7 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
   -ms-letter-spacing: 0.0125rem;
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
-  padding: 0 var(--spacing-2x) var(--spacing-1x) var(--spacing-5x);
+  padding: var(--spacing-1x) var(--spacing-2x);
   position: relative;
 }
 
@@ -707,18 +711,23 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-top: var(--spacing-1x);
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
-  left: calc(var(--spacing-3x) * -1);
-  position: absolute;
-  top: var(--spacing-half);
+  height: var(--size-1x);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1x);
+}
+
+.c2 {
+  -webkit-align-self: initial;
+  -ms-flex-item-align: initial;
+  align-self: initial;
 }
 
 .c3 {
@@ -754,14 +763,11 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-top: var(--spacing-1x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: unset;
 }
 
-.c6 * + * {
+.c6 > button {
+  margin-top: 0;
   margin-left: var(--spacing-1x);
 }
 
@@ -979,7 +985,7 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
   -ms-letter-spacing: 0.0125rem;
   letter-spacing: 0.0125rem;
   line-height: 1.5rem;
-  padding: 0 var(--spacing-2x) var(--spacing-1x) var(--spacing-5x);
+  padding: var(--spacing-1x) var(--spacing-2x);
   position: relative;
 }
 
@@ -996,18 +1002,23 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  margin-top: var(--spacing-1x);
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
-  left: calc(var(--spacing-3x) * -1);
-  position: absolute;
-  top: var(--spacing-half);
+  height: var(--size-1x);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1x);
+}
+
+.c2 {
+  -webkit-align-self: initial;
+  -ms-flex-item-align: initial;
+  align-self: initial;
 }
 
 .c3 {
@@ -1055,14 +1066,11 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
-  margin-top: var(--spacing-1x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: unset;
 }
 
-.c6 * + * {
+.c6 > button {
+  margin-top: 0;
   margin-left: var(--spacing-1x);
 }
 
@@ -1247,7 +1255,7 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
-  padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  padding: var(--spacing-1halfx);
   position: relative;
 }
 
@@ -1267,15 +1275,20 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
   -webkit-justify-content: unset;
   -ms-flex-pack: unset;
   justify-content: unset;
-  margin-top: 0;
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
+  height: var(--size-1halfx);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1halfx);
+}
+
+.c2 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1306,15 +1319,12 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-top: var(--spacing-3x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: 100%;
 }
 
-.c6 * + * {
+.c6 > button {
   margin-top: var(--spacing-1x);
+  margin-left: 0;
 }
 
 <section
@@ -1524,7 +1534,7 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
-  padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  padding: var(--spacing-1halfx);
   position: relative;
 }
 
@@ -1544,15 +1554,20 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
   -webkit-justify-content: unset;
   -ms-flex-pack: unset;
   justify-content: unset;
-  margin-top: 0;
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
+  height: var(--size-1halfx);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1halfx);
+}
+
+.c2 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1591,15 +1606,12 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-top: var(--spacing-3x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: 100%;
 }
 
-.c6 * + * {
+.c6 > button {
   margin-top: var(--spacing-1x);
+  margin-left: 0;
 }
 
 <section
@@ -1816,7 +1828,7 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
-  padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  padding: var(--spacing-1halfx);
   position: relative;
 }
 
@@ -1836,15 +1848,20 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
   -webkit-justify-content: unset;
   -ms-flex-pack: unset;
   justify-content: unset;
-  margin-top: 0;
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
+  height: var(--size-1halfx);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1halfx);
+}
+
+.c2 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -1883,15 +1900,12 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-top: var(--spacing-3x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: 100%;
 }
 
-.c6 * + * {
+.c6 > button {
   margin-top: var(--spacing-1x);
+  margin-left: 0;
 }
 
 <section
@@ -2108,7 +2122,7 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
   line-height: 1.5rem;
-  padding: var(--spacing-3x) var(--spacing-2x) var(--spacing-2x);
+  padding: var(--spacing-1halfx);
   position: relative;
 }
 
@@ -2128,15 +2142,20 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
   -webkit-justify-content: unset;
   -ms-flex-pack: unset;
   justify-content: unset;
-  margin-top: 0;
+  padding-left: var(--spacing-4x);
   position: relative;
 }
 
-.c2 {
+.c1 > svg {
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  margin-right: var(--spacing-1x);
+  height: var(--size-1halfx);
+  margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+  width: var(--size-1halfx);
+}
+
+.c2 {
   -webkit-align-self: flex-start;
   -ms-flex-item-align: start;
   align-self: flex-start;
@@ -2187,15 +2206,12 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  margin-top: var(--spacing-3x);
-  min-width: -webkit-fit-content;
-  min-width: -moz-fit-content;
-  min-width: fit-content;
   width: 100%;
 }
 
-.c6 * + * {
+.c6 > button {
   margin-top: var(--spacing-1x);
+  margin-left: 0;
 }
 
 <section

--- a/packages/react/src/components/global-banner/global-banner.test.tsx.snap
+++ b/packages/react/src/components/global-banner/global-banner.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c8 {
@@ -296,6 +298,8 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c8 {
@@ -583,6 +587,8 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c8 {
@@ -870,6 +876,8 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c8 {
@@ -1169,6 +1177,8 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c8 {
@@ -1411,6 +1421,8 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c8 {
@@ -1701,6 +1713,8 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c8 {
@@ -1991,6 +2005,8 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
 
 .c7 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c8 {

--- a/packages/react/src/components/global-banner/global-banner.test.tsx.snap
+++ b/packages/react/src/components/global-banner/global-banner.test.tsx.snap
@@ -192,8 +192,8 @@ exports[`GlobalBanner matches snapshot (desktop, alert) 1`] = `
 }
 
 .c6 > button {
-  margin-top: 0;
   margin-left: var(--spacing-1x);
+  margin-top: 0;
 }
 
 <section
@@ -476,8 +476,8 @@ exports[`GlobalBanner matches snapshot (desktop, default) 1`] = `
 }
 
 .c6 > button {
-  margin-top: 0;
   margin-left: var(--spacing-1x);
+  margin-top: 0;
 }
 
 <section
@@ -767,8 +767,8 @@ exports[`GlobalBanner matches snapshot (desktop, info) 1`] = `
 }
 
 .c6 > button {
-  margin-top: 0;
   margin-left: var(--spacing-1x);
+  margin-top: 0;
 }
 
 <section
@@ -1070,8 +1070,8 @@ exports[`GlobalBanner matches snapshot (desktop, warning) 1`] = `
 }
 
 .c6 > button {
-  margin-top: 0;
   margin-left: var(--spacing-1x);
+  margin-top: 0;
 }
 
 <section
@@ -1323,8 +1323,8 @@ exports[`GlobalBanner matches snapshot (mobile, alert) 1`] = `
 }
 
 .c6 > button {
-  margin-top: var(--spacing-1x);
   margin-left: 0;
+  margin-top: var(--spacing-1x);
 }
 
 <section
@@ -1610,8 +1610,8 @@ exports[`GlobalBanner matches snapshot (mobile, default) 1`] = `
 }
 
 .c6 > button {
-  margin-top: var(--spacing-1x);
   margin-left: 0;
+  margin-top: var(--spacing-1x);
 }
 
 <section
@@ -1904,8 +1904,8 @@ exports[`GlobalBanner matches snapshot (mobile, info) 1`] = `
 }
 
 .c6 > button {
-  margin-top: var(--spacing-1x);
   margin-left: 0;
+  margin-top: var(--spacing-1x);
 }
 
 <section
@@ -2210,8 +2210,8 @@ exports[`GlobalBanner matches snapshot (mobile, warning) 1`] = `
 }
 
 .c6 > button {
-  margin-top: var(--spacing-1x);
   margin-left: 0;
+  margin-top: var(--spacing-1x);
 }
 
 <section

--- a/packages/react/src/components/global-banner/global-banner.tsx
+++ b/packages/react/src/components/global-banner/global-banner.tsx
@@ -51,12 +51,6 @@ function getContainerColor({ bannerType, theme }: StyledProps<ContainerProps>): 
     }
 }
 
-function getContainerPadding({ isMobile }: ContainerProps): string {
-    return isMobile
-        ? 'var(--spacing-3x) var(--spacing-2x) var(--spacing-2x)'
-        : ' 0 var(--spacing-2x) var(--spacing-1x) var(--spacing-5x)';
-}
-
 const Label = styled.b<{ isMobile: boolean }>`
     display: ${({ isMobile }) => (isMobile ? 'block' : 'inline')};
     font-weight: var(--font-semi-bold);
@@ -82,7 +76,7 @@ const Container = styled.section<ContainerProps>`
     justify-content: space-between;
     letter-spacing: ${({ isMobile }) => (isMobile ? 0.02875 : 0.0125)}rem;
     line-height: 1.5rem;
-    padding: ${getContainerPadding};
+    padding: ${({ isMobile }) => (isMobile ? 'var(--spacing-1halfx)' : 'var(--spacing-1x) var(--spacing-2x)')};
     position: relative;
 `;
 
@@ -91,8 +85,15 @@ const Content = styled.div<{ isMobile: boolean }>`
     align-self: ${({ isMobile }) => (isMobile ? 'flex-start' : null)};
     display: flex;
     justify-content: ${({ isMobile }) => (isMobile ? 'unset' : 'center')};
-    margin-top: ${({ isMobile }) => (isMobile ? '0' : 'var(--spacing-1x)')};
+    padding-left: var(--spacing-4x);
     position: relative;
+
+    > svg {
+        flex-shrink: 0;
+        height: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
+        margin: 0 var(--spacing-1x) 0 calc(-1 * var(--spacing-4x));
+        width: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
+    }
 `;
 
 function getIconPosition(props: IsMobileProps): SimpleInterpolation {
@@ -103,17 +104,14 @@ function getIconPosition(props: IsMobileProps): SimpleInterpolation {
     }
 
     return css`
-        left: calc(var(--spacing-3x) * -1);
-        position: absolute;
-        top: var(--spacing-half);
+        align-self: initial;
     `;
 }
 
 const StyledIcon = styled(Icon)<SVGProps<SVGSVGElement> & IsMobileProps>`
-    flex-shrink: 0;
-    margin-right: var(--spacing-1x);
 
     ${getIconPosition};
+
 `;
 
 const Text = styled.span`
@@ -190,16 +188,11 @@ const TertiaryButton = styled(Button).attrs({ buttonType: 'tertiary', inverted: 
 const ButtonContainer = styled.div<{ isMobile: boolean }>`
     display: flex;
     flex-direction: ${({ isMobile }) => (isMobile ? 'column' : 'row')};
-    margin-top: ${({ isMobile }) => (isMobile ? 'var(--spacing-3x)' : 'var(--spacing-1x)')};
-    min-width: fit-content;
     width: ${({ isMobile }) => (isMobile ? '100%' : 'unset')};
 
-    * + * {
-        ${({ isMobile }) => (isMobile ? css`
-            margin-top: var(--spacing-1x);
-        ` : css`
-            margin-left: var(--spacing-1x);
-        `)}
+    > button {
+        margin-top: ${({ isMobile }) => (isMobile ? 'var(--spacing-1x)' : '0')};
+        margin-left: ${({ isMobile }) => (isMobile ? '0' : 'var(--spacing-1x)')};
     }
 `;
 

--- a/packages/react/src/components/global-banner/global-banner.tsx
+++ b/packages/react/src/components/global-banner/global-banner.tsx
@@ -191,8 +191,8 @@ const ButtonContainer = styled.div<{ isMobile: boolean }>`
     width: ${({ isMobile }) => (isMobile ? '100%' : 'unset')};
 
     > button {
-        margin-top: ${({ isMobile }) => (isMobile ? 'var(--spacing-1x)' : '0')};
         margin-left: ${({ isMobile }) => (isMobile ? '0' : 'var(--spacing-1x)')};
+        margin-top: ${({ isMobile }) => (isMobile ? 'var(--spacing-1x)' : '0')};
     }
 `;
 

--- a/packages/react/src/components/global-banner/global-banner.tsx
+++ b/packages/react/src/components/global-banner/global-banner.tsx
@@ -111,7 +111,6 @@ function getIconPosition(props: IsMobileProps): SimpleInterpolation {
 const StyledIcon = styled(Icon)<SVGProps<SVGSVGElement> & IsMobileProps>`
 
     ${getIconPosition};
-
 `;
 
 const Text = styled.span`

--- a/packages/react/src/components/global-header/global-header.test.tsx.snap
+++ b/packages/react/src/components/global-header/global-header.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Global Header Matches the snapshot (desktop) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 48px;
+  height: var(--size-3x);
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -152,7 +152,7 @@ exports[`Global Header Matches the snapshot (mobile) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 56px;
+  height: var(--size-3halfx);
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
@@ -291,7 +291,7 @@ exports[`Global Header mobileDrawerContent prop adds a side drawer and burger bu
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 56px;
+  height: var(--size-3halfx);
   -webkit-box-pack: justify;
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;

--- a/packages/react/src/components/global-header/global-header.tsx
+++ b/packages/react/src/components/global-header/global-header.tsx
@@ -22,7 +22,7 @@ const Header = styled.header<{ device: DeviceType }>`
     background: ${(props) => props.theme.main['primary-2']};
     box-sizing: border-box;
     display: flex;
-    height: ${({ device }) => (device === 'desktop' ? 48 : 56)}px;
+    height: ${({ device }) => (device === 'desktop' ? 'var(--size-3x)' : 'var(--size-3halfx)')};
     justify-content: space-between;
     padding: ${({ device }) => getPadding(device)};
     position: relative;

--- a/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
+++ b/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Global Navigation matches snapshot 1`] = `
-.c1 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -41,27 +41,27 @@ exports[`Global Navigation matches snapshot 1`] = `
   user-select: none;
 }
 
-.c1:focus {
+.c2:focus {
   outline: none;
 }
 
-.c1:focus {
+.c2:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c1:not(:disabled) {
+.c2:not(:disabled) {
   cursor: pointer;
 }
 
-.c1 > svg {
+.c2 > svg {
   color: inherit;
   height: var(--size-1x);
   width: var(--size-1x);
 }
 
-.c2 {
+.c3 {
   background-color: #006296;
   border-color: #006296;
   color: #FFFFFF;
@@ -69,28 +69,28 @@ exports[`Global Navigation matches snapshot 1`] = `
   width: var(--size-2x);
 }
 
-.c2:focus {
+.c3:focus {
   outline: none;
 }
 
-.c2:focus {
+.c3:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c2:hover,
-.c2[aria-expanded="true"] {
+.c3:hover,
+.c3[aria-expanded="true"] {
   background-color: #003A5A;
   border-color: #003A5A;
 }
 
-.c2:disabled {
+.c3:disabled {
   background-color: #84C6EA;
   border-color: #84C6EA;
 }
 
-.c2 > svg {
+.c3 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
@@ -111,20 +111,20 @@ exports[`Global Navigation matches snapshot 1`] = `
   -webkit-justify-content: space-between;
   -ms-flex-pack: justify;
   justify-content: space-between;
-  width: 72px;
+  width: var(--size-4halfx);
 }
 
-.c4 {
+.c5 {
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.c4 > li:first-child > :first-child {
+.c5 > li:first-child > :first-child {
   padding-top: var(--spacing-1x);
 }
 
-.c6 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -141,31 +141,31 @@ exports[`Global Navigation matches snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  min-height: 56px;
+  min-height: var(--size-3halfx);
   padding: var(--spacing-half) var(--spacing-1x);
-  width: 72px;
+  width: var(--size-4halfx);
 }
 
-.c6:focus {
+.c7:focus {
   outline: none;
 }
 
-.c6:focus {
+.c7:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c6:hover {
+.c7:hover {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c5 {
+.c6 {
   position: relative;
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -185,18 +185,33 @@ exports[`Global Navigation matches snapshot 1`] = `
   text-decoration: none;
 }
 
-.c7.active {
+.c8.active {
   background-color: #E0F0F9;
   color: #000000;
 }
 
-.c8 {
-  font-size: 0.6875rem;
-  line-height: 1.25rem;
-  text-align: center;
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
 }
 
 .c9 {
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  text-align: center;
+  word-break: break-word;
+}
+
+.c10 {
   background-color: #D9DDE2;
   border: 0;
   height: 1px;
@@ -204,10 +219,10 @@ exports[`Global Navigation matches snapshot 1`] = `
   width: 40px;
 }
 
-.c3 {
-  height: 40px;
+.c4 {
+  height: var(--size-2halfx);
   margin: var(--spacing-2x);
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <div
@@ -216,10 +231,12 @@ exports[`Global Navigation matches snapshot 1`] = `
   <div
     class="c0"
   >
-    <div>
+    <div
+      class="c1"
+    >
       <button
         aria-label="add"
-        class="c1 c2 c3"
+        class="c2 c3 c4"
         data-testid="core-action-button"
         type="button"
       >
@@ -235,13 +252,13 @@ exports[`Global Navigation matches snapshot 1`] = `
         aria-label="App Navigation"
       >
         <ul
-          class="c4"
+          class="c5"
         >
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="home-home-link"
               href="/test1"
             >
@@ -253,17 +270,17 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 home
               </span>
             </a>
           </li>
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="edit-edit-link"
               href="/test2"
             >
@@ -275,17 +292,17 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 edit
               </span>
             </a>
           </li>
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="map-mapPin-link"
               href="/test3"
             >
@@ -297,17 +314,17 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 map
               </span>
             </a>
           </li>
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="mail-mail-link"
               href="/test4"
             >
@@ -319,17 +336,17 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 mail
               </span>
             </a>
           </li>
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="phone-phone-link"
               href="/test5"
             >
@@ -341,7 +358,7 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 phone
               </span>
@@ -352,19 +369,19 @@ exports[`Global Navigation matches snapshot 1`] = `
     </div>
     <div>
       <hr
-        class="c9"
+        class="c10"
       />
       <nav
         aria-label="App Navigation"
       >
         <ul
-          class="c4"
+          class="c5"
         >
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="info-info-link"
               href="/test6"
             >
@@ -376,17 +393,17 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 info
               </span>
             </a>
           </li>
           <li
-            class="c5"
+            class="c6"
           >
             <a
-              class="c6 c7"
+              class="c7 c8"
               data-testid="help-helpCircle-link"
               href="/test7"
             >
@@ -398,7 +415,7 @@ exports[`Global Navigation matches snapshot 1`] = `
                 width="20"
               />
               <span
-                class="c8"
+                class="c9"
               >
                 help
               </span>

--- a/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
+++ b/packages/react/src/components/global-navigation/global-navigation.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`Global Navigation matches snapshot 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c2 {
@@ -86,6 +88,11 @@ exports[`Global Navigation matches snapshot 1`] = `
 .c2:disabled {
   background-color: #84C6EA;
   border-color: #84C6EA;
+}
+
+.c2 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {

--- a/packages/react/src/components/global-navigation/global-navigation.tsx
+++ b/packages/react/src/components/global-navigation/global-navigation.tsx
@@ -122,8 +122,8 @@ const ItemLink = styled(ShowMore).attrs({ as: NavLink })<NavLinkProps>`
 `;
 
 const WrapperNav = styled.div`
-    align-items: center;    
-    display: flex; 
+    align-items: center;
+    display: flex;
     flex-direction: column;
 `
 

--- a/packages/react/src/components/global-navigation/global-navigation.tsx
+++ b/packages/react/src/components/global-navigation/global-navigation.tsx
@@ -18,7 +18,7 @@ const Wrapper = styled.div`
     flex-direction: column;
     height: 100%;
     justify-content: space-between;
-    width: 72px;
+    width: var(--size-4halfx);
 `;
 
 const NavList = styled.ul`
@@ -35,7 +35,7 @@ const MenuLink = styled(NavLink)`
     color: ${({ theme }) => theme.greys.black};
     display: flex;
     flex-grow: 1;
-    line-height: 24px;
+    line-height: 1.5rem;
     padding: var(--spacing-half) var(--spacing-2x);
     text-decoration: none;
     width: max-content;
@@ -57,7 +57,7 @@ const ShowMoreMenu = styled.ul<{ open?: boolean }>`
     box-shadow: 0 6px 10px 0 rgb(0 0 0 / 10%);
     display: ${({ open }) => (open ? 'flex' : 'none')};
     flex-wrap: wrap;
-    left: 72px;
+    left: 4.5rem;
     list-style: none;
     margin: 0;
     padding: 0;
@@ -86,9 +86,9 @@ const ShowMore = styled.button<{ active?: boolean }>`
     cursor: pointer;
     display: flex;
     justify-content: center;
-    min-height: 56px;
+    min-height: var(--size-3halfx);
     padding: var(--spacing-half) var(--spacing-1x);
-    width: 72px;
+    width: var(--size-4halfx);
 
     ${focus};
 
@@ -121,10 +121,17 @@ const ItemLink = styled(ShowMore).attrs({ as: NavLink })<NavLinkProps>`
     }
 `;
 
+const WrapperNav = styled.div`
+    align-items: center;    
+    display: flex; 
+    flex-direction: column;
+`
+
 const ItemSpan = styled.span`
-    font-size: 0.6875rem;
+    font-size: 0.75rem;
     line-height: 1.25rem;
     text-align: center;
+    word-break: break-word;
 `;
 
 const separatorHeight = 17;
@@ -138,11 +145,10 @@ const Separator = styled.hr`
 `;
 
 const coreActionButtonHeight = 72;
-const coreActionButtonMargins = 32;
 const CoreActionButton = styled(IconButton)`
-    height: ${coreActionButtonHeight - coreActionButtonMargins}px;
+    height: var(--size-2halfx);
     margin: var(--spacing-2x);
-    width: 40px;
+    width: var(--size-2halfx);
 `;
 
 export interface GlobalNavigationItem {
@@ -253,7 +259,7 @@ export const GlobalNavigation: VoidFunctionComponent<GlobalNavigationProps> = ({
 
     return (
         <Wrapper className={className} ref={wrapperRef}>
-            <div>
+            <WrapperNav>
                 {coreActionButton && (
                     <CoreActionButton
                         {...coreActionButton /* eslint-disable-line react/jsx-props-no-spreading */}
@@ -293,7 +299,7 @@ export const GlobalNavigation: VoidFunctionComponent<GlobalNavigationProps> = ({
                         )}
                     </NavList>
                 </nav>
-            </div>
+            </WrapperNav>
             <div>
                 <Separator />
                 <nav aria-label="App Navigation">

--- a/packages/react/src/components/global-navigation/global-navigation.tsx
+++ b/packages/react/src/components/global-navigation/global-navigation.tsx
@@ -125,7 +125,7 @@ const WrapperNav = styled.div`
     align-items: center;
     display: flex;
     flex-direction: column;
-`
+`;
 
 const ItemSpan = styled.span`
     font-size: 0.75rem;

--- a/packages/react/src/components/legend/legend.test.tsx.snap
+++ b/packages/react/src/components/legend/legend.test.tsx.snap
@@ -7,13 +7,17 @@ exports[`Legend Matches the snapshot 1`] = `
 }
 
 .c1 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin: 0 0 var(--spacing-1x);
-  padding: 0 var(--spacing-2x);
+  padding: 0;
 }
 
 .c1 p {
@@ -26,19 +30,23 @@ exports[`Legend Matches the snapshot 1`] = `
   background-color: #84C6EA;
   border-radius: 50%;
   content: "";
-  height: 8px;
-  margin: var(--spacing-1x) var(--spacing-1x) 0 calc(-1 * var(--spacing-2x));
-  width: 8px;
+  height: var(--size-half);
+  width: var(--size-half);
+  margin: 0 var(--spacing-1x) 0 0;
 }
 
 .c3 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin: 0 0 var(--spacing-1x);
-  padding: 0 var(--spacing-2x);
+  padding: 0;
 }
 
 .c3 p {
@@ -51,19 +59,23 @@ exports[`Legend Matches the snapshot 1`] = `
   background-color: #000014;
   border-radius: 50%;
   content: "";
-  height: 8px;
-  margin: var(--spacing-1x) var(--spacing-1x) 0 calc(-1 * var(--spacing-2x));
-  width: 8px;
+  height: var(--size-half);
+  width: var(--size-half);
+  margin: 0 var(--spacing-1x) 0 0;
 }
 
 .c4 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   list-style: none;
   margin: 0 0 var(--spacing-1x);
-  padding: 0 var(--spacing-2x);
+  padding: 0;
 }
 
 .c4 p {
@@ -76,9 +88,9 @@ exports[`Legend Matches the snapshot 1`] = `
   background-color: #304E63;
   border-radius: 50%;
   content: "";
-  height: 8px;
-  margin: var(--spacing-1x) var(--spacing-1x) 0 calc(-1 * var(--spacing-2x));
-  width: 8px;
+  height: var(--size-half);
+  width: var(--size-half);
+  margin: 0 var(--spacing-1x) 0 0;
 }
 
 .c2 {

--- a/packages/react/src/components/legend/legend.test.tsx.snap
+++ b/packages/react/src/components/legend/legend.test.tsx.snap
@@ -31,8 +31,8 @@ exports[`Legend Matches the snapshot 1`] = `
   border-radius: 50%;
   content: "";
   height: var(--size-half);
-  width: var(--size-half);
   margin: 0 var(--spacing-1x) 0 0;
+  width: var(--size-half);
 }
 
 .c3 {
@@ -60,8 +60,8 @@ exports[`Legend Matches the snapshot 1`] = `
   border-radius: 50%;
   content: "";
   height: var(--size-half);
-  width: var(--size-half);
   margin: 0 var(--spacing-1x) 0 0;
+  width: var(--size-half);
 }
 
 .c4 {
@@ -89,8 +89,8 @@ exports[`Legend Matches the snapshot 1`] = `
   border-radius: 50%;
   content: "";
   height: var(--size-half);
-  width: var(--size-half);
   margin: 0 var(--spacing-1x) 0 0;
+  width: var(--size-half);
 }
 
 .c2 {

--- a/packages/react/src/components/legend/legend.tsx
+++ b/packages/react/src/components/legend/legend.tsx
@@ -30,8 +30,8 @@ const Item = styled.li<Pick<LegendItem, 'color'>>`
         border-radius: 50%;
         content: "";
         height: var(--size-half);
-        width: var(--size-half);
         margin: 0 var(--spacing-1x) 0 0;
+        width: var(--size-half);
     }
 `;
 

--- a/packages/react/src/components/legend/legend.tsx
+++ b/packages/react/src/components/legend/legend.tsx
@@ -13,10 +13,11 @@ export interface LegendItem {
 }
 
 const Item = styled.li<Pick<LegendItem, 'color'>>`
+    align-items: baseline;
     display: flex;
     list-style: none;
     margin: 0 0 var(--spacing-1x);
-    padding: 0 var(--spacing-2x);
+    padding: 0;
 
     p {
         font-size: 0.875rem;
@@ -28,9 +29,9 @@ const Item = styled.li<Pick<LegendItem, 'color'>>`
         background-color: ${(props) => props.color || props.theme.main['primary-1.2']};
         border-radius: 50%;
         content: "";
-        height: 8px;
-        margin: var(--spacing-1x) var(--spacing-1x) 0 calc(-1 * var(--spacing-2x));
-        width: 8px;
+        height: var(--size-half);
+        width: var(--size-half);
+        margin: 0 var(--spacing-1x) 0 0;
     }
 `;
 

--- a/packages/react/src/components/lozenge/lozenge.test.tsx.snap
+++ b/packages/react/src/components/lozenge/lozenge.test.tsx.snap
@@ -19,21 +19,28 @@ exports[`Lozenge alert matches the snapshot 1`] = `
   font-weight: var(--font-normal);
   line-height: 0.875rem;
   max-width: 312px;
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-<span
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
   class="c0"
 >
-  alert
-</span>
+  <span
+    class="c1"
+  >
+    alert
+  </span>
+</div>
 `;
 
 exports[`Lozenge default matches the snapshot 1`] = `
@@ -55,21 +62,28 @@ exports[`Lozenge default matches the snapshot 1`] = `
   font-weight: var(--font-normal);
   line-height: 0.875rem;
   max-width: 312px;
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-<span
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
   class="c0"
 >
-  default
-</span>
+  <span
+    class="c1"
+  >
+    default
+  </span>
+</div>
 `;
 
 exports[`Lozenge info matches the snapshot 1`] = `
@@ -91,21 +105,28 @@ exports[`Lozenge info matches the snapshot 1`] = `
   font-weight: var(--font-normal);
   line-height: 0.875rem;
   max-width: 312px;
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-<span
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
   class="c0"
 >
-  info
-</span>
+  <span
+    class="c1"
+  >
+    info
+  </span>
+</div>
 `;
 
 exports[`Lozenge matches the snapshot 1`] = `
@@ -127,21 +148,28 @@ exports[`Lozenge matches the snapshot 1`] = `
   font-weight: var(--font-normal);
   line-height: 0.875rem;
   max-width: 312px;
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-<span
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
   class="c0"
 >
-  Hello World
-</span>
+  <span
+    class="c1"
+  >
+    Hello World
+  </span>
+</div>
 `;
 
 exports[`Lozenge success matches the snapshot 1`] = `
@@ -163,21 +191,28 @@ exports[`Lozenge success matches the snapshot 1`] = `
   font-weight: var(--font-normal);
   line-height: 0.875rem;
   max-width: 312px;
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-<span
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
   class="c0"
 >
-  success
-</span>
+  <span
+    class="c1"
+  >
+    success
+  </span>
+</div>
 `;
 
 exports[`Lozenge warning matches the snapshot 1`] = `
@@ -199,19 +234,26 @@ exports[`Lozenge warning matches the snapshot 1`] = `
   font-weight: var(--font-normal);
   line-height: 0.875rem;
   max-width: 312px;
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
   text-transform: uppercase;
-  white-space: nowrap;
   width: -webkit-fit-content;
   width: -moz-fit-content;
   width: fit-content;
 }
 
-<span
+.c1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
   class="c0"
 >
-  warning
-</span>
+  <span
+    class="c1"
+  >
+    warning
+  </span>
+</div>
 `;

--- a/packages/react/src/components/lozenge/lozenge.tsx
+++ b/packages/react/src/components/lozenge/lozenge.tsx
@@ -69,7 +69,7 @@ function getLozengeColor({ $type, theme }: StyledLozengeProps): string {
     }
 }
 
-const StyledLozenge = styled.span<StyledLozengeProps>`
+const StyledLozenge = styled.div<StyledLozengeProps>`
     align-items: center;
     background-color: ${getLozengeBackgroundColor};
     border: 1px solid ${getLozengeBorderColor};
@@ -81,16 +81,21 @@ const StyledLozenge = styled.span<StyledLozengeProps>`
     font-weight: var(--font-normal);
     line-height: ${({ $isMobile }) => ($isMobile ? '1.375rem' : '0.875rem')};
     max-width: ${MAXIMUM_LENGTH};
-    overflow: hidden;
     padding: 0 var(--spacing-half);
-    text-overflow: ellipsis;
     text-transform: uppercase;
-    white-space: nowrap;
     width: fit-content;
 `;
 
+const TagLabel = styled.span`
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+`
+
 const StyledIcon = styled(Icon)<{ $isMobile: boolean }>`
+    height: 0.75rem;
     margin-right: ${({ $isMobile }) => ($isMobile ? 'var(--spacing-1x)' : 'var(--spacing-half)')};
+    width: 0.75rem;
 `;
 
 interface Props {
@@ -120,7 +125,9 @@ export const Lozenge: FunctionComponent<PropsWithChildren<Props>> = ({
                     $isMobile={isMobile}
                 />
             )}
-            {children}
+            <TagLabel>
+                {children}
+            </TagLabel>
         </StyledLozenge>
     );
 };

--- a/packages/react/src/components/lozenge/lozenge.tsx
+++ b/packages/react/src/components/lozenge/lozenge.tsx
@@ -90,7 +90,7 @@ const TagLabel = styled.span`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-`
+`;
 
 const StyledIcon = styled(Icon)<{ $isMobile: boolean }>`
     height: 0.75rem;

--- a/packages/react/src/components/modal/modal-dialog.test.tsx.snap
+++ b/packages/react/src/components/modal/modal-dialog.test.tsx.snap
@@ -81,6 +81,8 @@ exports[`Modal-Dialog Matches snapshot (custom button labels) 1`] = `
 
 .c9 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c13 {
@@ -116,6 +118,11 @@ exports[`Modal-Dialog Matches snapshot (custom button labels) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c13 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -428,6 +435,8 @@ exports[`Modal-Dialog Matches snapshot (custom footer content) 1`] = `
 
 .c4 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c5 {
@@ -463,6 +472,11 @@ exports[`Modal-Dialog Matches snapshot (custom footer content) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c5 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -648,6 +662,8 @@ exports[`Modal-Dialog Matches snapshot (not titles) 1`] = `
 
 .c5 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c9 {
@@ -683,6 +699,11 @@ exports[`Modal-Dialog Matches snapshot (not titles) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c9 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -959,6 +980,8 @@ exports[`Modal-Dialog Matches snapshot (only subtitle) 1`] = `
 
 .c8 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c12 {
@@ -994,6 +1017,11 @@ exports[`Modal-Dialog Matches snapshot (only subtitle) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c12 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -1295,6 +1323,8 @@ exports[`Modal-Dialog Matches snapshot (only title) 1`] = `
 
 .c8 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c12 {
@@ -1330,6 +1360,11 @@ exports[`Modal-Dialog Matches snapshot (only title) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c12 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -1630,6 +1665,8 @@ exports[`Modal-Dialog Matches snapshot (opened, desktop) 1`] = `
 
 .c9 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c13 {
@@ -1665,6 +1702,11 @@ exports[`Modal-Dialog Matches snapshot (opened, desktop) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c13 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -1977,6 +2019,8 @@ exports[`Modal-Dialog Matches snapshot (opened, mobile) 1`] = `
 
 .c9 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c13 {
@@ -2012,6 +2056,11 @@ exports[`Modal-Dialog Matches snapshot (opened, mobile) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c13 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c0 {

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -43,14 +43,14 @@ const HeadingWrapper = styled.div`
     position: relative;
 `;
 
+const TitleIcon = styled(Icon)`
+    margin-right: var(--spacing-1x);
+`;
+
 const StyledHeadingWrapperComponent = styled(HeadingWrapper)`
     align-items: center;
     display: flex;
     margin-left: calc(-1 * var(--spacing-4x));
- `;
-
-const TitleIcon = styled(Icon)`
-    margin-right: var(--spacing-1x);
 `;
 
 export interface ModalDialogProps {

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -43,15 +43,15 @@ const HeadingWrapper = styled.div`
     position: relative;
 `;
 
-const TitleIcon = styled(Icon)`
-    margin-right: var(--spacing-1x);
-`;
-
 const StyledHeadingWrapperComponent = styled(HeadingWrapper)`
     align-items: center;
     display: flex;
     margin-left: calc(-1 * var(--spacing-4x));
  `;
+
+const TitleIcon = styled(Icon)`
+    margin-right: var(--spacing-1x);
+`;
 
 export interface ModalDialogProps {
     /** Takes a query selector targeting the app Element. */

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -44,12 +44,14 @@ const HeadingWrapper = styled.div`
 `;
 
 const TitleIcon = styled(Icon)`
-    // left: -32px;
-    // margin-top: calc(var(--spacing-half) * 1.5);
-    // position: absolute;
-    // top: 0;
     margin-right: var(--spacing-1x);
 `;
+
+const StyledHeadingWrapperComponent = styled(HeadingWrapper)`
+    align-items: center;
+    display: flex;
+    margin-left: calc(-1 * var(--spacing-4x));
+ `;
 
 export interface ModalDialogProps {
     /** Takes a query selector targeting the app Element. */
@@ -118,19 +120,13 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     }
 
     function getHeader(): ReactElement | undefined {
-        const HeadingWrapperComponent = hasTitleIcon ? HeadingWrapper : Fragment;
-
-        const StyledHeadingWrapperComponent = styled(HeadingWrapperComponent)`
-            align-items: center;
-            display: flex;
-            margin-left: calc(-1 * var(--spacing-4x));
-        `
+        const HeadingWrapperComponent = hasTitleIcon ? StyledHeadingWrapperComponent : Fragment;
 
         if (title || subtitle) {
             return (
                 <>
                     {title && (
-                        <StyledHeadingWrapperComponent>
+                        <HeadingWrapperComponent>
                             {titleIcon && (
                                 <TitleIcon name={titleIcon} size="24" data-testid="title-icon" />
                             )}
@@ -143,7 +139,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
                             >
                                 {title}
                             </Heading>
-                        </StyledHeadingWrapperComponent>
+                        </HeadingWrapperComponent>
                     )}
                     {subtitle && (
                         <Subtitle hasTitle={title !== undefined} isMobile={isMobile}>{subtitle}</Subtitle>

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -44,10 +44,11 @@ const HeadingWrapper = styled.div`
 `;
 
 const TitleIcon = styled(Icon)`
-    left: -32px;
-    margin-top: calc(var(--spacing-half) * 1.5);
-    position: absolute;
-    top: 0;
+    // left: -32px;
+    // margin-top: calc(var(--spacing-half) * 1.5);
+    // position: absolute;
+    // top: 0;
+    margin-right: var(--spacing-1x);
 `;
 
 export interface ModalDialogProps {
@@ -119,11 +120,17 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     function getHeader(): ReactElement | undefined {
         const HeadingWrapperComponent = hasTitleIcon ? HeadingWrapper : Fragment;
 
+        const StyledHeadingWrapperComponent = styled(HeadingWrapperComponent)`
+            align-items: center;
+            display: flex;
+            margin-left: calc(-1 * var(--spacing-4x));
+        `
+
         if (title || subtitle) {
             return (
                 <>
                     {title && (
-                        <HeadingWrapperComponent>
+                        <StyledHeadingWrapperComponent>
                             {titleIcon && (
                                 <TitleIcon name={titleIcon} size="24" data-testid="title-icon" />
                             )}
@@ -136,7 +143,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
                             >
                                 {title}
                             </Heading>
-                        </HeadingWrapperComponent>
+                        </StyledHeadingWrapperComponent>
                     )}
                     {subtitle && (
                         <Subtitle hasTitle={title !== undefined} isMobile={isMobile}>{subtitle}</Subtitle>

--- a/packages/react/src/components/modal/modal.test.tsx.snap
+++ b/packages/react/src/components/modal/modal.test.tsx.snap
@@ -273,6 +273,8 @@ exports[`Modal Matches snapshot (noPadding) 1`] = `
 
 .c3 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -308,6 +310,11 @@ exports[`Modal Matches snapshot (noPadding) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -482,6 +489,8 @@ exports[`Modal Matches snapshot (opened, desktop) 1`] = `
 
 .c3 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -517,6 +526,11 @@ exports[`Modal Matches snapshot (opened, desktop) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -691,6 +705,8 @@ exports[`Modal Matches snapshot (opened, mobile) 1`] = `
 
 .c3 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c4 {
@@ -726,6 +742,11 @@ exports[`Modal Matches snapshot (opened, mobile) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c0 {

--- a/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx.snap
+++ b/packages/react/src/components/nav-menu-button/nav-menu-button.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`NavMenuButton Matches Snapshot (defaultOpen) 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c2 {
@@ -319,6 +321,8 @@ exports[`NavMenuButton Matches Snapshot (tag="nav") 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c2 {
@@ -582,6 +586,8 @@ exports[`NavMenuButton Matches Snapshot 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c2 {

--- a/packages/react/src/components/pagination/pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/pagination.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #006296;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #FFFFFF;
   display: -webkit-inline-box;
@@ -125,14 +125,14 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   display: inline-flex;
   font-size: 0.9rem;
   font-weight: var(--font-normal);
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0 var(--spacing-half);
-  min-width: 24px;
+  min-width: var(--size-1halfx);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -158,7 +158,7 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFFFFF;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #000000;
   display: -webkit-inline-box;
@@ -167,14 +167,14 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   display: inline-flex;
   font-size: 0.9rem;
   font-weight: var(--font-normal);
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0 var(--spacing-half);
-  min-width: 24px;
+  min-width: var(--size-1halfx);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -446,7 +446,7 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   -ms-flex-align: center;
   align-items: center;
   background-color: #006296;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #FFFFFF;
   display: -webkit-inline-box;
@@ -455,14 +455,14 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   display: inline-flex;
   font-size: 0.9rem;
   font-weight: var(--font-normal);
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0 var(--spacing-half);
-  min-width: 24px;
+  min-width: var(--size-1halfx);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -488,7 +488,7 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFFFFF;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #000000;
   display: -webkit-inline-box;
@@ -497,14 +497,14 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   display: inline-flex;
   font-size: 0.9rem;
   font-weight: var(--font-normal);
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0 var(--spacing-half);
-  min-width: 24px;
+  min-width: var(--size-1halfx);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -776,7 +776,7 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #006296;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #FFFFFF;
   display: -webkit-inline-box;
@@ -785,14 +785,14 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   display: inline-flex;
   font-size: 1rem;
   font-weight: var(--font-normal);
-  height: 32px;
+  height: var(--size-2x);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 32px;
+  line-height: 2rem;
   margin: 0 var(--spacing-half);
-  min-width: 32px;
+  min-width: var(--size-2x);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -818,7 +818,7 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFFFFF;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #000000;
   display: -webkit-inline-box;
@@ -827,14 +827,14 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   display: inline-flex;
   font-size: 1rem;
   font-weight: var(--font-normal);
-  height: 32px;
+  height: var(--size-2x);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 32px;
+  line-height: 2rem;
   margin: 0 var(--spacing-half);
-  min-width: 32px;
+  min-width: var(--size-2x);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -1106,7 +1106,7 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   -ms-flex-align: center;
   align-items: center;
   background-color: #006296;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #FFFFFF;
   display: -webkit-inline-box;
@@ -1115,14 +1115,14 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   display: inline-flex;
   font-size: 1rem;
   font-weight: var(--font-normal);
-  height: 32px;
+  height: var(--size-2x);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 32px;
+  line-height: 2rem;
   margin: 0 var(--spacing-half);
-  min-width: 32px;
+  min-width: var(--size-2x);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }
@@ -1148,7 +1148,7 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   -ms-flex-align: center;
   align-items: center;
   background-color: #FFFFFF;
-  border-radius: 16px;
+  border-radius: 1rem;
   box-sizing: border-box;
   color: #000000;
   display: -webkit-inline-box;
@@ -1157,14 +1157,14 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   display: inline-flex;
   font-size: 1rem;
   font-weight: var(--font-normal);
-  height: 32px;
+  height: var(--size-2x);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  line-height: 32px;
+  line-height: 2rem;
   margin: 0 var(--spacing-half);
-  min-width: 32px;
+  min-width: var(--size-2x);
   padding: 0 var(--spacing-1x);
   text-align: center;
 }

--- a/packages/react/src/components/pagination/pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/pagination.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {
@@ -92,6 +94,11 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c3 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -380,6 +387,8 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {
@@ -415,6 +424,11 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c3 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -703,6 +717,8 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c3 {
@@ -738,6 +754,11 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c3 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c4 {
@@ -1026,6 +1047,8 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c3 {
@@ -1061,6 +1084,11 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c3 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c4 {

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -18,17 +18,17 @@ const Pages = styled.ol`
 const Page = styled.li<{ isSelected: boolean, isMobile: boolean }>`
     align-items: center;
     background-color: ${(props) => (props.isSelected ? props.theme.main['primary-1.1'] : props.theme.greys.white)};
-    border-radius: 16px;
+    border-radius: 1rem;
     box-sizing: border-box;
     color: ${(props) => (props.isSelected ? props.theme.greys.white : props.theme.greys.black)};
     display: inline-flex;
     font-size: ${(props) => (props.isMobile ? 1 : 0.9)}rem;
     font-weight: var(--font-normal);
-    height: ${(props) => (props.isMobile ? 32 : 24)}px;
+    height: ${(props) => (props.isMobile ? 'var(--size-2x)' : 'var(--size-1halfx)')};
     justify-content: center;
-    line-height: ${(props) => (props.isMobile ? 32 : 24)}px;
+    line-height: ${(props) => (props.isMobile ? 2 : 1.5)}rem;
     margin: 0 var(--spacing-half);
-    min-width: ${(props) => (props.isMobile ? 32 : 24)}px;
+    min-width: ${(props) => (props.isMobile ? 'var(--size-2x)' : 'var(--size-1halfx)')};
     padding: 0 var(--spacing-1x);
     text-align: center;
 
@@ -74,9 +74,9 @@ const Container = styled.div<{ isMobile: boolean }>`
 
 const ResultsLabel = styled.div<{ isMobile: boolean }>`
     font-size: ${(props) => (props.isMobile ? 1 : 0.9)}rem;
-    line-height: ${(props) => (props.isMobile ? 32 : 24)}px;
-    margin-bottom: ${(props) => (props.isMobile ? '12px' : 0)};
-    margin-right: ${(props) => (props.isMobile ? 0 : '24px')};
+    line-height: ${(props) => (props.isMobile ? 2 : 1.5)}rem;
+    margin-bottom: ${(props) => (props.isMobile ? 'var(--spacing-1halfx)' : 0)};
+    margin-right: ${(props) => (props.isMobile ? 0 : 'var(--spacing-3x)')};
     white-space: nowrap;
 `;
 

--- a/packages/react/src/components/progress/progress.test.tsx.snap
+++ b/packages/react/src/components/progress/progress.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Progress Component Snapshots with labels 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -83,7 +83,7 @@ exports[`Progress Component Snapshots with labels 1`] = `
   line-height: 2rem;
   margin: 0 auto 0.625rem;
   text-align: center;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 .c3 > span {
@@ -242,7 +242,7 @@ exports[`Progress Component Snapshots without labels 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-box-pack: center;
   -webkit-justify-content: center;
   -ms-flex-pack: center;
@@ -250,7 +250,7 @@ exports[`Progress Component Snapshots without labels 1`] = `
   line-height: 2rem;
   margin: 0 auto 0.625rem;
   text-align: center;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 .c3 > span {

--- a/packages/react/src/components/progress/progress.tsx
+++ b/packages/react/src/components/progress/progress.tsx
@@ -65,12 +65,12 @@ const Step = styled.li`
         content: counter(step);
         counter-increment: step;
         display: flex;
-        height: 32px;
+        height: var(--size-2x);
         justify-content: center;
         line-height: 2rem;
         margin: 0 auto 0.625rem;
         text-align: center;
-        width: 32px;
+        width: var(--size-2x);
     }
 
     > span {

--- a/packages/react/src/components/radio-button-group/radio-button-group.test.tsx.snap
+++ b/packages/react/src/components/radio-button-group/radio-button-group.test.tsx.snap
@@ -27,10 +27,16 @@ input + .c1 {
 
 .c3 {
   cursor: pointer;
-  display: block;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 0.875rem;
   line-height: 1.5rem;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -43,13 +49,13 @@ input + .c1 {
 }
 
 .c3 input {
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   margin: 0;
   opacity: 0;
   position: absolute;
   top: 2px;
-  width: 16px;
+  width: var(--size-1x);
 }
 
 .c3 input:checked + .radioInput {
@@ -61,14 +67,14 @@ input + .c1 {
   background-color: #FFFFFF;
   border-radius: 50%;
   content: "";
-  height: 8px;
+  height: var(--size-half);
   left: 50%;
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 8px;
+  width: var(--size-half);
 }
 
 .c3 input:focus + .radioInput {
@@ -83,12 +89,10 @@ input + .c1 {
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
-  left: 0;
-  margin-top: var(--spacing-half);
-  position: absolute;
-  top: 0;
-  width: 16px;
+  height: var(--size-1x);
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c3:hover .radioInput {
@@ -96,10 +100,16 @@ input + .c1 {
 }
 
 .c4 {
-  display: block;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   font-size: 0.875rem;
   line-height: 1.5rem;
-  padding-left: var(--spacing-3x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -112,13 +122,13 @@ input + .c1 {
 }
 
 .c4 input {
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
   margin: 0;
   opacity: 0;
   position: absolute;
   top: 2px;
-  width: 16px;
+  width: var(--size-1x);
 }
 
 .c4 input:checked + .radioInput {
@@ -130,14 +140,14 @@ input + .c1 {
   background-color: #FFFFFF;
   border-radius: 50%;
   content: "";
-  height: 8px;
+  height: var(--size-half);
   left: 50%;
   position: absolute;
   top: 50%;
   -webkit-transform: translate(-50%,-50%);
   -ms-transform: translate(-50%,-50%);
   transform: translate(-50%,-50%);
-  width: 8px;
+  width: var(--size-half);
 }
 
 .c4 input:focus + .radioInput {
@@ -152,12 +162,10 @@ input + .c1 {
   border-radius: 50%;
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
-  left: 0;
-  margin-top: var(--spacing-half);
-  position: absolute;
-  top: 0;
-  width: 16px;
+  height: var(--size-1x);
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c4:hover .radioInput {
@@ -176,7 +184,7 @@ input + .c1 {
   <label
     class="c3"
   >
-     Earth
+     
     <input
       data-testid="radio-button-group-earth"
       name="planets"
@@ -186,11 +194,12 @@ input + .c1 {
     <span
       class="radioInput"
     />
+    Earth
   </label>
   <label
     class="c3"
   >
-     Mars
+     
     <input
       checked=""
       data-testid="radio-button-group-mars"
@@ -201,12 +210,13 @@ input + .c1 {
     <span
       class="radioInput"
     />
+    Mars
   </label>
   <label
     class="c4"
     disabled=""
   >
-     Pluto
+     
     <input
       data-testid="radio-button-group-pluto"
       disabled=""
@@ -217,11 +227,12 @@ input + .c1 {
     <span
       class="radioInput"
     />
+    Pluto
   </label>
   <label
     class="c3"
   >
-     Saturn
+     
     <input
       data-testid="radio-button-group-saturn"
       name="planets"
@@ -231,6 +242,7 @@ input + .c1 {
     <span
       class="radioInput"
     />
+    Saturn
   </label>
 </div>
 `;

--- a/packages/react/src/components/radio-button-group/radio-button-group.test.tsx.snap
+++ b/packages/react/src/components/radio-button-group/radio-button-group.test.tsx.snap
@@ -54,7 +54,6 @@ input + .c1 {
   margin: 0;
   opacity: 0;
   position: absolute;
-  top: 2px;
   width: var(--size-1x);
 }
 
@@ -127,7 +126,6 @@ input + .c1 {
   margin: 0;
   opacity: 0;
   position: absolute;
-  top: 2px;
   width: var(--size-1x);
 }
 

--- a/packages/react/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/react/src/components/radio-button-group/radio-button-group.tsx
@@ -16,10 +16,10 @@ const StyledDiv = styled.div`
 const StyledLabel = styled.label`
     ${(props: { theme: Theme, disabled?: boolean }) => `
             ${props.disabled ? '' : 'cursor: pointer;'};
-            display: block;
+            align-items: center;
+            display: flex;
             font-size: 0.875rem;
             line-height: 1.5rem;
-            padding-left: var(--spacing-3x);
             position: relative;
             user-select: none;
 
@@ -28,13 +28,13 @@ const StyledLabel = styled.label`
             }
 
             input {
-                height: 16px;
+                height: var(--size-1x);
                 left: 0;
                 margin: 0;
                 opacity: 0;
                 position: absolute;
                 top: 2px;
-                width: 16px;
+                width: var(--size-1x);
 
                 &:checked + .radioInput {
                     background-color: ${props.theme.main['primary-1.1']};
@@ -44,12 +44,12 @@ const StyledLabel = styled.label`
                         background-color: ${props.theme.greys.white};
                         border-radius: 50%;
                         content: "";
-                        height: 8px;
+                        height: var(--size-half);
                         left: 50%;
                         position: absolute;
                         top: 50%;
                         transform: translate(-50%, -50%);
-                        width: 8px;
+                        width: var(--size-half);
                     }
                 }
 
@@ -62,12 +62,10 @@ const StyledLabel = styled.label`
                 border-radius: 50%;
                 box-sizing: border-box;
                 display: inline-block;
-                height: 16px;
-                left: 0;
-                margin-top: var(--spacing-half);
-                position: absolute;
-                top: 0;
-                width: 16px;
+                height: var(--size-1x);
+                margin-right: var(--spacing-1x);
+                position: relative;
+                width: var(--size-1x);
             }
 
             &:hover .radioInput {
@@ -116,7 +114,6 @@ export const RadioButtonGroup: VoidFunctionComponent<RadioButtonGroupProps> = ({
                     key={`${groupName}-${button.value}`}
                 >
                     {' '}
-                    {button.label}
                     <input
                         data-testid={`${dataTestId}-${button.value}`}
                         type="radio"
@@ -128,6 +125,7 @@ export const RadioButtonGroup: VoidFunctionComponent<RadioButtonGroupProps> = ({
                         onChange={onChange}
                     />
                     <span className="radioInput" />
+                    {button.label}
                 </StyledLabel>
             ))}
         </StyledDiv>

--- a/packages/react/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/react/src/components/radio-button-group/radio-button-group.tsx
@@ -33,7 +33,6 @@ const StyledLabel = styled.label`
                 margin: 0;
                 opacity: 0;
                 position: absolute;
-                top: 2px;
                 width: var(--size-1x);
 
                 &:checked + .radioInput {

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -37,15 +38,6 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #84C6EA;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -80,6 +72,7 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -112,15 +105,6 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -164,6 +148,7 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -196,15 +181,6 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: 0;
@@ -247,6 +223,7 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -279,15 +256,6 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -324,6 +292,7 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -348,15 +317,6 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #84C6EA;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -391,6 +351,7 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -423,15 +384,6 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);
@@ -475,6 +427,7 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -507,15 +460,6 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: 0;
@@ -558,6 +502,7 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   display: -ms-inline-flexbox;
   display: inline-flex;
   font-size: 0.875rem;
+  line-height: 1.5rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -590,15 +535,6 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-<<<<<<< HEAD
-=======
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-
->>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
   height: 1rem;
   margin-right: var(--spacing-1x);

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -37,8 +37,19 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #84C6EA;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c1[disabled] {
@@ -101,8 +112,19 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c1:visited svg {
@@ -174,8 +196,19 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1:visited svg {
@@ -246,8 +279,19 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c1:visited svg {
@@ -304,8 +348,19 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #84C6EA;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c1[disabled] {
@@ -368,8 +423,19 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c1:visited svg {
@@ -441,8 +507,19 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: 0;
+  width: 1rem;
 }
 
 .c1:visited svg {
@@ -513,8 +590,19 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
+<<<<<<< HEAD
+=======
+.c1 {
+  color: #006296;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+}
+
+>>>>>>> a0c9b68a (fix(a11y): fix zoom navigation)
 .c1 svg {
+  height: 1rem;
   margin-right: var(--spacing-1x);
+  width: 1rem;
 }
 
 .c1:visited svg {

--- a/packages/react/src/components/route-link/route-link.tsx
+++ b/packages/react/src/components/route-link/route-link.tsx
@@ -7,7 +7,9 @@ import { StyledLink } from './styles/styled-link';
 
 const Link = styled(StyledLink)`
     svg {
+        height: 1rem;
         margin-right: ${({ $hasLabel }) => ($hasLabel ? 'var(--spacing-1x)' : '0')};
+        width: 1rem;
     }
 
     &:visited {

--- a/packages/react/src/components/route-link/styles/styled-link.tsx
+++ b/packages/react/src/components/route-link/styles/styled-link.tsx
@@ -13,6 +13,7 @@ export const StyledLink = styled.a<ContainerProps>`
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
     display: inline-flex;
     font-size: ${({ $isMobile }) => ($isMobile ? '1rem' : '0.875rem')};
+    line-height: 1.5rem;
     text-decoration: underline;
 
     &:hover {

--- a/packages/react/src/components/search/search-input.test.tsx.snap
+++ b/packages/react/src/components/search/search-input.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`SearchInput should match the snapshot 1`] = `
 
 .c13 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c12 {

--- a/packages/react/src/components/sectional-banner/sectional-banner.test.tsx.snap
+++ b/packages/react/src/components/sectional-banner/sectional-banner.test.tsx.snap
@@ -25,6 +25,8 @@ exports[`SectionalBanner should match snapshot (custom message) 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  height: 1rem;
+  width: 1rem;
 }
 
 .c5 {
@@ -106,6 +108,8 @@ exports[`SectionalBanner should match snapshot (desktop) 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  height: 1rem;
+  width: 1rem;
 }
 
 .c5 {
@@ -179,6 +183,8 @@ exports[`SectionalBanner should match snapshot (mobile) 1`] = `
   -webkit-flex: 0 0 auto;
   -ms-flex: 0 0 auto;
   flex: 0 0 auto;
+  height: 1rem;
+  width: 1rem;
 }
 
 .c5 {

--- a/packages/react/src/components/sectional-banner/sectional-banner.tsx
+++ b/packages/react/src/components/sectional-banner/sectional-banner.tsx
@@ -68,6 +68,8 @@ function abstractContainer(
         ${BannerIcon} {
             color: ${(props) => (iconColor ? props.theme.notifications[iconColor] : props.theme.main['primary-3'])};
             flex: 0 0 auto;
+            height: 1rem;
+            width: 1rem;
         }
     `;
 }

--- a/packages/react/src/components/select/select.test.tsx.snap
+++ b/packages/react/src/components/select/select.test.tsx.snap
@@ -183,6 +183,11 @@ input + .c2 {
   display: flex;
 }
 
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 <div
   class="c0 c1"
 >
@@ -585,6 +590,11 @@ input + .c2 {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c9 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div
@@ -1076,6 +1086,11 @@ input + .c2 {
   display: flex;
 }
 
+.c6 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 <div
     class="c0 c1"
   >
@@ -1520,6 +1535,11 @@ exports[`Select mobile select has a different style 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <div

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -126,6 +126,11 @@ const Arrow = styled.button<{ disabled?: boolean }>`
     align-items: center;
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
     display: flex;
+
+    > svg {
+        height: var(--size-1x);
+        width: var(--size-1x);
+    }
 `;
 
 interface SelectProps {

--- a/packages/react/src/components/skip-link/skip-link.test.tsx.snap
+++ b/packages/react/src/components/skip-link/skip-link.test.tsx.snap
@@ -68,6 +68,8 @@ exports[`SkipLink Matches Snapshot (Desktop) 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0:not(:focus) {
@@ -158,6 +160,8 @@ exports[`SkipLink Matches Snapshot (Mobile) 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c0:not(:focus) {

--- a/packages/react/src/components/status/status.test.tsx.snap
+++ b/packages/react/src/components/status/status.test.tsx.snap
@@ -17,9 +17,9 @@ exports[`Status matches snapshot (blocked) 1`] = `
   border: none;
   border-radius: 50%;
   box-sizing: border-box;
-  height: .625rem;
+  height: 0.625rem;
   margin-right: var(--spacing-1halfx);
-  width: .625rem;
+  width: 0.625rem;
 }
 
 <Status
@@ -67,9 +67,9 @@ exports[`Status matches snapshot (disabled) 1`] = `
   border: 1px solid #60666E;
   border-radius: 50%;
   box-sizing: border-box;
-  height: .625rem;
+  height: 0.625rem;
   margin-right: var(--spacing-1halfx);
-  width: .625rem;
+  width: 0.625rem;
 }
 
 <Status
@@ -116,9 +116,9 @@ exports[`Status matches snapshot (enabled) 1`] = `
   border: none;
   border-radius: 50%;
   box-sizing: border-box;
-  height: .625rem;
+  height: 0.625rem;
   margin-right: var(--spacing-1halfx);
-  width: .625rem;
+  width: 0.625rem;
 }
 
 <Status

--- a/packages/react/src/components/status/status.test.tsx.snap
+++ b/packages/react/src/components/status/status.test.tsx.snap
@@ -17,9 +17,9 @@ exports[`Status matches snapshot (blocked) 1`] = `
   border: none;
   border-radius: 50%;
   box-sizing: border-box;
-  height: 10px;
-  margin-right: calc(var(--spacing-base) * 1.5);
-  width: 10px;
+  height: .625rem;
+  margin-right: var(--spacing-1halfx);
+  width: .625rem;
 }
 
 <Status
@@ -67,9 +67,9 @@ exports[`Status matches snapshot (disabled) 1`] = `
   border: 1px solid #60666E;
   border-radius: 50%;
   box-sizing: border-box;
-  height: 10px;
-  margin-right: calc(var(--spacing-base) * 1.5);
-  width: 10px;
+  height: .625rem;
+  margin-right: var(--spacing-1halfx);
+  width: .625rem;
 }
 
 <Status
@@ -116,9 +116,9 @@ exports[`Status matches snapshot (enabled) 1`] = `
   border: none;
   border-radius: 50%;
   box-sizing: border-box;
-  height: 10px;
-  margin-right: calc(var(--spacing-base) * 1.5);
-  width: 10px;
+  height: .625rem;
+  margin-right: var(--spacing-1halfx);
+  width: .625rem;
 }
 
 <Status

--- a/packages/react/src/components/status/status.tsx
+++ b/packages/react/src/components/status/status.tsx
@@ -27,9 +27,9 @@ const Circle = styled.div<{ type: StatusType }>`
     border: ${({ type, theme }) => (type === 'disabled' ? `1px solid ${theme.greys['dark-grey']}` : 'none')};
     border-radius: 50%;
     box-sizing: border-box;
-    height: 10px;
-    margin-right: calc(var(--spacing-base) * 1.5);
-    width: 10px;
+    height: .625rem;
+    margin-right: var(--spacing-1halfx);
+    width: .625rem;
 `;
 
 interface Props {

--- a/packages/react/src/components/status/status.tsx
+++ b/packages/react/src/components/status/status.tsx
@@ -27,9 +27,9 @@ const Circle = styled.div<{ type: StatusType }>`
     border: ${({ type, theme }) => (type === 'disabled' ? `1px solid ${theme.greys['dark-grey']}` : 'none')};
     border-radius: 50%;
     box-sizing: border-box;
-    height: .625rem;
+    height: 0.625rem;
     margin-right: var(--spacing-1halfx);
-    width: .625rem;
+    width: 0.625rem;
 `;
 
 interface Props {

--- a/packages/react/src/components/stepper-input/stepper-buttons.tsx
+++ b/packages/react/src/components/stepper-input/stepper-buttons.tsx
@@ -44,6 +44,12 @@ const IncrementButton = styled.button`
     border-bottom: none;
     border-radius: 0 var(--border-radius) 0 0;
     height: calc(50% - 1px);
+
+    > svg {
+        color: inherit;
+        height: var(--size-1x);
+        width: var(--size-1x);
+    }
 `;
 
 const DecrementButton = styled.button`
@@ -51,6 +57,11 @@ const DecrementButton = styled.button`
 
     border-radius: 0 0 var(--border-radius) 0;
     height: calc(50% + 1px);
+
+    > svg {
+        height: var(--size-1x);
+        width: var(--size-1x);
+    }
 `;
 
 interface StepperButtonsProps {

--- a/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
+++ b/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
@@ -90,6 +90,12 @@ input + .c1 {
   cursor: default;
 }
 
+.c6 > svg {
+  color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 .c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -126,6 +132,11 @@ input + .c1 {
   border-color: #DBDEE1;
   color: #B7BBC2;
   cursor: default;
+}
+
+.c7 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {
@@ -400,6 +411,12 @@ input + .c1 {
   cursor: default;
 }
 
+.c9 > svg {
+  color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 .c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -436,6 +453,11 @@ input + .c1 {
   border-color: #DBDEE1;
   color: #B7BBC2;
   cursor: default;
+}
+
+.c10 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c6 {
@@ -853,6 +875,12 @@ input + .c1 {
   cursor: default;
 }
 
+.c6 > svg {
+  color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
 .c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -889,6 +917,11 @@ input + .c1 {
   border-color: #DBDEE1;
   color: #B7BBC2;
   cursor: default;
+}
+
+.c7 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c3 {

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Table has clickable rows styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -65,9 +65,9 @@ exports[`Table has clickable rows styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -187,7 +187,7 @@ exports[`Table has custom text alignment 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -201,9 +201,9 @@ exports[`Table has custom text alignment 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -328,7 +328,7 @@ exports[`Table has desktop styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -342,9 +342,9 @@ exports[`Table has desktop styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -492,7 +492,7 @@ exports[`Table has error rows styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -506,9 +506,9 @@ exports[`Table has error rows styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -625,7 +625,7 @@ exports[`Table has mobile styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 1rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -639,9 +639,9 @@ exports[`Table has mobile styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -758,7 +758,7 @@ exports[`Table has rowNumbers styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -772,9 +772,9 @@ exports[`Table has rowNumbers styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -1006,7 +1006,7 @@ exports[`Table has selectable rows styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -1020,9 +1020,9 @@ exports[`Table has selectable rows styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -1269,7 +1269,7 @@ exports[`Table has small rowSize styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -1283,9 +1283,9 @@ exports[`Table has small rowSize styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -1422,7 +1422,7 @@ exports[`Table has sorting styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -1436,9 +1436,9 @@ exports[`Table has sorting styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -1592,7 +1592,7 @@ exports[`Table has sticky column styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -1606,9 +1606,9 @@ exports[`Table has sticky column styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -1757,7 +1757,7 @@ exports[`Table has sticky header styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -1771,9 +1771,9 @@ exports[`Table has sticky header styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -1894,7 +1894,7 @@ exports[`Table has striped styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 0.875rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -1908,9 +1908,9 @@ exports[`Table has striped styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table
@@ -2027,7 +2027,7 @@ exports[`Table has tablet styles 1`] = `
 .c0 th,
 .c0 td {
   font-size: 1rem;
-  line-height: 24px;
+  line-height: 1.5rem;
   margin: 0;
   text-align: left;
 }
@@ -2041,9 +2041,9 @@ exports[`Table has tablet styles 1`] = `
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
-  min-width: 40px;
+  min-width: var(--size-2halfx);
   text-align: center;
-  width: 40px;
+  width: var(--size-2halfx);
 }
 
 <table

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -916,11 +916,11 @@ exports[`Table has selectable rows styles 1`] = `
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
-  height: 16px;
+  height: var(--size-1x);
   left: 0;
-  position: absolute;
-  top: 4px;
-  width: 16px;
+  margin-right: var(--spacing-1x);
+  position: relative;
+  width: var(--size-1x);
 }
 
 .c4:hover {
@@ -959,11 +959,16 @@ exports[`Table has selectable rows styles 1`] = `
 }
 
 .c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   cursor: pointer;
-  display: block;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   line-height: 1.5rem;
-  min-height: 24px;
-  padding-left: 16px;
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -145,7 +145,7 @@ const StyledTable = styled.table<StyledTableProps>`
     th,
     td {
         font-size: ${({ device }) => (device === 'desktop' ? 0.875 : 1)}rem;
-        line-height: 24px;
+        line-height: 1.5rem;
         margin: 0;
         text-align: left;
 
@@ -158,9 +158,9 @@ const StyledTable = styled.table<StyledTableProps>`
         box-sizing: border-box;
         color: ${({ theme }) => theme.greys['dark-grey']};
         font-size: 0.75rem;
-        min-width: 40px;
+        min-width: var(--size-2halfx);
         text-align: center;
-        width: 40px;
+        width: var(--size-2halfx);
     }
 `;
 

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -22,7 +22,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     display: flex;
     justify-content: center;
     line-height: 1.5rem;
-    min-height: ${({ $isMobile }) => ($isMobile ? 56 : 48)}px;
+    min-height: ${({ $isMobile }) => ($isMobile ? 'var(--size-3halfx)' : 'var(--size-3x)')};
     min-width: 82px;
     padding: 0 var(--spacing-2x);
     position: relative;
@@ -74,14 +74,18 @@ const StyledButtonText = styled.span<IsSelected & { $isMobile: boolean; }>`
 
 const LeftIcon = styled(Icon)<IsSelected>`
     color: ${({ theme }) => theme.greys.black};
+    height: 1rem;
     min-width: fit-content;
     padding-right: var(--spacing-half);
+    width: 1rem;
 `;
 
 const RightIcon = styled(Icon)<IsSelected>`
     color: ${({ theme }) => theme.greys.black};
+    height: 1rem;
     min-width: fit-content;
     padding-left: var(--spacing-half);
+    width: 1rem;
 `;
 
 interface TabButtonProps {

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.5rem;
-  min-height: 48px;
+  min-height: var(--size-3x);
   min-width: 82px;
   padding: 0 var(--spacing-2x);
   position: relative;
@@ -83,7 +83,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.5rem;
-  min-height: 48px;
+  min-height: var(--size-3x);
   min-width: 82px;
   padding: 0 var(--spacing-2x);
   position: relative;
@@ -256,7 +256,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.5rem;
-  min-height: 56px;
+  min-height: var(--size-3halfx);
   min-width: 82px;
   padding: 0 var(--spacing-2x);
   position: relative;
@@ -314,7 +314,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.5rem;
-  min-height: 56px;
+  min-height: var(--size-3halfx);
   min-width: 82px;
   padding: 0 var(--spacing-2x);
   position: relative;
@@ -487,7 +487,7 @@ exports[`Tabs matches snapshot 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.5rem;
-  min-height: 48px;
+  min-height: var(--size-3x);
   min-width: 82px;
   padding: 0 var(--spacing-2x);
   position: relative;
@@ -545,7 +545,7 @@ exports[`Tabs matches snapshot 1`] = `
   -ms-flex-pack: center;
   justify-content: center;
   line-height: 1.5rem;
-  min-height: 48px;
+  min-height: var(--size-3x);
   min-width: 82px;
   padding: 0 var(--spacing-2x);
   position: relative;

--- a/packages/react/src/components/tag/tag.test.tsx.snap
+++ b/packages/react/src/components/tag/tag.test.tsx.snap
@@ -6,8 +6,8 @@ exports[`Tag Tag medium matches snapshot (desktop clickable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -76,8 +76,8 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -194,8 +194,8 @@ exports[`Tag Tag medium matches snapshot (desktop with icons) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -257,8 +257,8 @@ exports[`Tag Tag medium matches snapshot (desktop) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -310,8 +310,8 @@ exports[`Tag Tag medium matches snapshot (desktop) 2`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -363,8 +363,8 @@ exports[`Tag Tag medium matches snapshot (mobile clickable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -433,8 +433,8 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -551,8 +551,8 @@ exports[`Tag Tag medium matches snapshot (mobile with icons) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -614,8 +614,8 @@ exports[`Tag Tag medium matches snapshot (mobile) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -667,8 +667,8 @@ exports[`Tag Tag medium matches snapshot (mobile) 2`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -720,8 +720,8 @@ exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -790,8 +790,8 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -908,8 +908,8 @@ exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -971,8 +971,8 @@ exports[`Tag Tag small matches snapshot (desktop) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -1024,8 +1024,8 @@ exports[`Tag Tag small matches snapshot (desktop) 2`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -1077,8 +1077,8 @@ exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -1147,8 +1147,8 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -1265,8 +1265,8 @@ exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -1328,8 +1328,8 @@ exports[`Tag Tag small matches snapshot (mobile) 1`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
@@ -1381,8 +1381,8 @@ exports[`Tag Tag small matches snapshot (mobile) 2`] = `
   font-size: 0.75rem;
   line-height: 1.5rem;
   max-width: 312px;
-  text-overflow: ellipsis;
   overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 

--- a/packages/react/src/components/tag/tag.test.tsx.snap
+++ b/packages/react/src/components/tag/tag.test.tsx.snap
@@ -23,8 +23,6 @@ exports[`Tag Tag medium matches snapshot (desktop clickable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -131,8 +129,6 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -211,8 +207,6 @@ exports[`Tag Tag medium matches snapshot (desktop with icons) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -274,8 +268,6 @@ exports[`Tag Tag medium matches snapshot (desktop) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -307,8 +299,8 @@ exports[`Tag Tag medium matches snapshot (desktop) 1`] = `
 exports[`Tag Tag medium matches snapshot (desktop) 2`] = `
 .c2 {
   display: inline-block;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.875rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -327,8 +319,6 @@ exports[`Tag Tag medium matches snapshot (desktop) 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.875rem;
-  line-height: 1.875rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -380,8 +370,6 @@ exports[`Tag Tag medium matches snapshot (mobile clickable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -488,8 +476,6 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -568,8 +554,6 @@ exports[`Tag Tag medium matches snapshot (mobile with icons) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -631,8 +615,6 @@ exports[`Tag Tag medium matches snapshot (mobile) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -664,8 +646,8 @@ exports[`Tag Tag medium matches snapshot (mobile) 1`] = `
 exports[`Tag Tag medium matches snapshot (mobile) 2`] = `
 .c2 {
   display: inline-block;
-  font-size: 0.75rem;
-  line-height: 1.5rem;
+  font-size: 0.875rem;
+  line-height: 1.875rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -684,8 +666,6 @@ exports[`Tag Tag medium matches snapshot (mobile) 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.875rem;
-  line-height: 1.875rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -718,7 +698,7 @@ exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
 .c2 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -737,8 +717,6 @@ exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -788,7 +766,7 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
 .c2 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -845,8 +823,6 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -906,7 +882,7 @@ exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
 .c3 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -925,8 +901,6 @@ exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -969,7 +943,7 @@ exports[`Tag Tag small matches snapshot (desktop) 1`] = `
 .c2 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -988,8 +962,6 @@ exports[`Tag Tag small matches snapshot (desktop) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -1021,7 +993,7 @@ exports[`Tag Tag small matches snapshot (desktop) 1`] = `
 exports[`Tag Tag small matches snapshot (desktop) 2`] = `
 .c2 {
   display: inline-block;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   line-height: 1.5rem;
   max-width: 312px;
   overflow: hidden;
@@ -1041,8 +1013,6 @@ exports[`Tag Tag small matches snapshot (desktop) 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 
@@ -1075,7 +1045,7 @@ exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
 .c2 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1094,8 +1064,6 @@ exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -1145,7 +1113,7 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
 .c2 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1202,8 +1170,6 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -1263,7 +1229,7 @@ exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
 .c3 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1282,8 +1248,6 @@ exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -1326,7 +1290,7 @@ exports[`Tag Tag small matches snapshot (mobile) 1`] = `
 .c2 {
   display: inline-block;
   font-size: 0.75rem;
-  line-height: 1.5rem;
+  line-height: 1rem;
   max-width: 312px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1345,8 +1309,6 @@ exports[`Tag Tag small matches snapshot (mobile) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.75rem;
-  line-height: 0.875rem;
   padding: 0 var(--spacing-half);
 }
 
@@ -1378,7 +1340,7 @@ exports[`Tag Tag small matches snapshot (mobile) 1`] = `
 exports[`Tag Tag small matches snapshot (mobile) 2`] = `
 .c2 {
   display: inline-block;
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   line-height: 1.5rem;
   max-width: 312px;
   overflow: hidden;
@@ -1398,8 +1360,6 @@ exports[`Tag Tag small matches snapshot (mobile) 2`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  font-size: 0.875rem;
-  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
 }
 

--- a/packages/react/src/components/tag/tag.test.tsx.snap
+++ b/packages/react/src/components/tag/tag.test.tsx.snap
@@ -1,23 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag Tag medium matches snapshot (desktop clickable) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-3x);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -54,31 +62,58 @@ exports[`Tag Tag medium matches snapshot (desktop clickable) 1`] = `
   class="c0 c1"
   type="button"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </button>
 `;
 
 exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
-.c3 {
-  border-radius: 50%;
-  cursor: pointer;
+.c2 {
   display: inline-block;
-  height: calc(24px - var(--spacing-1x) / 2);
-  margin-bottom: 1px;
-  margin-left: var(--spacing-1x);
-  padding: var(--spacing-half);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.c3:hover {
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: var(--size-1halfx);
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: var(--spacing-half);
+  width: var(--size-1halfx);
+}
+
+.c4 > svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.c4:hover {
   background-color: #dbdee1;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
@@ -90,24 +125,22 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 12px+var(--spacing-1x));
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
   margin-left: var(--spacing-1x);
 }
 
-.c1 .c2 {
+.c1 .c3 {
   margin-right: calc(-1 * var(--spacing-half));
 }
 
@@ -124,10 +157,14 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
   <button
     aria-label="deleteButtonAriaLabel"
-    class="c2 c3"
+    class="c3 c4"
     data-testid="Test-delete-button"
     type="button"
   >
@@ -146,10 +183,20 @@ exports[`Tag Tag medium matches snapshot (desktop deletable) 1`] = `
 exports[`Tag Tag medium matches snapshot (desktop with icons) 1`] = `
 .c2 {
   color: #60666e;
+  height: var(--size-1x);
+  margin-right: var(--spacing-half);
+  vertical-align: text-bottom;
+  width: var(--size-1x);
+}
+
+.c3 {
   display: inline-block;
-  height: calc(24px - var(--spacing-1x) / 2);
-  margin-right: var(--spacing-1x);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c1 {
@@ -158,17 +205,15 @@ exports[`Tag Tag medium matches snapshot (desktop with icons) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 12px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -198,28 +243,40 @@ exports[`Tag Tag medium matches snapshot (desktop with icons) 1`] = `
     role="img"
     width="12"
   />
-  Test
+  <span
+    class="c3"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag medium matches snapshot (desktop) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -239,28 +296,40 @@ exports[`Tag Tag medium matches snapshot (desktop) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag medium matches snapshot (desktop) 2`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.875rem;
   line-height: 1.875rem;
-  max-width: calc(312px / 0.875 + 0px);
-  overflow: hidden;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -280,28 +349,40 @@ exports[`Tag Tag medium matches snapshot (desktop) 2`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag medium matches snapshot (mobile clickable) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-3x);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -338,31 +419,58 @@ exports[`Tag Tag medium matches snapshot (mobile clickable) 1`] = `
   class="c0 c1"
   type="button"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </button>
 `;
 
 exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
-.c3 {
-  border-radius: 50%;
-  cursor: pointer;
+.c2 {
   display: inline-block;
-  height: calc(24px - var(--spacing-1x) / 2);
-  margin-bottom: 1px;
-  margin-left: var(--spacing-1x);
-  padding: var(--spacing-half);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.c3:hover {
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: var(--size-1halfx);
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: var(--spacing-half);
+  width: var(--size-1halfx);
+}
+
+.c4 > svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.c4:hover {
   background-color: #dbdee1;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
@@ -374,24 +482,22 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 12px+var(--spacing-1x));
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
   margin-left: var(--spacing-1x);
 }
 
-.c1 .c2 {
+.c1 .c3 {
   margin-right: calc(-1 * var(--spacing-half));
 }
 
@@ -408,10 +514,14 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
   <button
     aria-label="deleteButtonAriaLabel"
-    class="c2 c3"
+    class="c3 c4"
     data-testid="Test-delete-button"
     type="button"
   >
@@ -430,10 +540,20 @@ exports[`Tag Tag medium matches snapshot (mobile deletable) 1`] = `
 exports[`Tag Tag medium matches snapshot (mobile with icons) 1`] = `
 .c2 {
   color: #60666e;
+  height: var(--size-1x);
+  margin-right: var(--spacing-half);
+  vertical-align: text-bottom;
+  width: var(--size-1x);
+}
+
+.c3 {
   display: inline-block;
-  height: calc(24px - var(--spacing-1x) / 2);
-  margin-right: var(--spacing-1x);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c1 {
@@ -442,17 +562,15 @@ exports[`Tag Tag medium matches snapshot (mobile with icons) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 12px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -482,28 +600,40 @@ exports[`Tag Tag medium matches snapshot (mobile with icons) 1`] = `
     role="img"
     width="12"
   />
-  Test
+  <span
+    class="c3"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag medium matches snapshot (mobile) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -523,28 +653,40 @@ exports[`Tag Tag medium matches snapshot (mobile) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag medium matches snapshot (mobile) 2`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.875rem;
   line-height: 1.875rem;
-  max-width: calc(312px / 0.875 + 0px);
-  overflow: hidden;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -564,28 +706,40 @@ exports[`Tag Tag medium matches snapshot (mobile) 2`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -622,31 +776,58 @@ exports[`Tag Tag small matches snapshot (desktop clickable) 1`] = `
   class="c0 c1"
   type="button"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </button>
 `;
 
 exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
-.c3 {
-  border-radius: 50%;
-  cursor: pointer;
+.c2 {
   display: inline-block;
-  height: calc(16px - var(--spacing-half) / 2);
-  margin-bottom: 1px;
-  margin-left: var(--spacing-1x);
-  padding: var(--spacing-half);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.c3:hover {
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: var(--size-1halfx);
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: var(--spacing-half);
+  width: var(--size-1halfx);
+}
+
+.c4 > svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.c4:hover {
   background-color: #dbdee1;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
@@ -658,24 +839,22 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-half);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 12px+var(--spacing-1x));
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
   margin-left: var(--spacing-1x);
 }
 
-.c1 .c2 {
+.c1 .c3 {
   margin-right: calc(-1 * var(--spacing-half));
 }
 
@@ -692,10 +871,14 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
   <button
     aria-label="deleteButtonAriaLabel"
-    class="c2 c3"
+    class="c3 c4"
     data-testid="Test-delete-button"
     type="button"
   >
@@ -714,10 +897,20 @@ exports[`Tag Tag small matches snapshot (desktop deletable) 1`] = `
 exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
 .c2 {
   color: #60666e;
+  height: var(--size-1x);
+  margin-right: var(--spacing-half);
+  vertical-align: text-bottom;
+  width: var(--size-1x);
+}
+
+.c3 {
   display: inline-block;
-  height: calc(16px - var(--spacing-half) / 2);
-  margin-right: var(--spacing-1x);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c1 {
@@ -726,17 +919,15 @@ exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-half);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 12px);
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -766,28 +957,40 @@ exports[`Tag Tag small matches snapshot (desktop with icons) 1`] = `
     role="img"
     width="12"
   />
-  Test
+  <span
+    class="c3"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag small matches snapshot (desktop) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-half);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -807,28 +1010,40 @@ exports[`Tag Tag small matches snapshot (desktop) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag small matches snapshot (desktop) 2`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.875rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.875 + 0px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -848,28 +1063,40 @@ exports[`Tag Tag small matches snapshot (desktop) 2`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -906,31 +1133,58 @@ exports[`Tag Tag small matches snapshot (mobile clickable) 1`] = `
   class="c0 c1"
   type="button"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </button>
 `;
 
 exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
-.c3 {
-  border-radius: 50%;
-  cursor: pointer;
+.c2 {
   display: inline-block;
-  height: calc(16px - var(--spacing-half) / 2);
-  margin-bottom: 1px;
-  margin-left: var(--spacing-1x);
-  padding: var(--spacing-half);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
-.c3:hover {
+.c4 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 50%;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  height: var(--size-1halfx);
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  margin-left: var(--spacing-half);
+  width: var(--size-1halfx);
+}
+
+.c4 > svg {
+  height: 1rem;
+  width: 1rem;
+}
+
+.c4:hover {
   background-color: #dbdee1;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
 }
 
-.c3:focus {
+.c4:focus {
   outline: none;
   box-shadow: 0 0 0 2px #84C6EA;
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
@@ -942,24 +1196,22 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-half);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 12px+var(--spacing-1x));
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
   margin-left: var(--spacing-1x);
 }
 
-.c1 .c2 {
+.c1 .c3 {
   margin-right: calc(-1 * var(--spacing-half));
 }
 
@@ -976,10 +1228,14 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
   <button
     aria-label="deleteButtonAriaLabel"
-    class="c2 c3"
+    class="c3 c4"
     data-testid="Test-delete-button"
     type="button"
   >
@@ -998,10 +1254,20 @@ exports[`Tag Tag small matches snapshot (mobile deletable) 1`] = `
 exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
 .c2 {
   color: #60666e;
+  height: var(--size-1x);
+  margin-right: var(--spacing-half);
+  vertical-align: text-bottom;
+  width: var(--size-1x);
+}
+
+.c3 {
   display: inline-block;
-  height: calc(16px - var(--spacing-half) / 2);
-  margin-right: var(--spacing-1x);
-  vertical-align: middle;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .c1 {
@@ -1010,17 +1276,15 @@ exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-half);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 12px);
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -1050,28 +1314,40 @@ exports[`Tag Tag small matches snapshot (mobile with icons) 1`] = `
     role="img"
     width="12"
   />
-  Test
+  <span
+    class="c3"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag small matches snapshot (mobile) 1`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius-half);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.75rem;
   line-height: 0.875rem;
-  max-width: calc(312px / 0.75 + 0px);
-  overflow: hidden;
   padding: 0 var(--spacing-half);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -1091,28 +1367,40 @@ exports[`Tag Tag small matches snapshot (mobile) 1`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;
 
 exports[`Tag Tag small matches snapshot (mobile) 2`] = `
+.c2 {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1.5rem;
+  max-width: 312px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #878f9a;
   border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: inline-block;
+  box-shadow: inset 0 0 0 1px #878f9a;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
   font-size: 0.875rem;
-  line-height: 1.375rem;
-  max-width: calc(312px / 0.875 + 0px);
-  overflow: hidden;
+  line-height: 1.5rem;
   padding: 0 var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 + .c0 {
@@ -1132,6 +1420,10 @@ exports[`Tag Tag small matches snapshot (mobile) 2`] = `
 <span
   class="c0 c1"
 >
-  Test
+  <span
+    class="c2"
+  >
+    Test
+  </span>
 </span>
 `;

--- a/packages/react/src/components/tag/tag.tsx
+++ b/packages/react/src/components/tag/tag.tsx
@@ -51,18 +51,6 @@ function getIconSize(isMobile: boolean): string {
     return isMobile ? '20' : '12';
 }
 
-function getIconAndButtonWidth({ $deletable, $hasIcon, $isMobile }: ContainerProps): string {
-    const sizes = [];
-    if ($deletable) {
-        sizes.push(`${getIconSize($isMobile)}px`, 'var(--spacing-1x)');
-    }
-    if ($hasIcon) {
-        sizes.push(`${getIconSize($isMobile)}px`);
-    }
-
-    return sizes.length > 0 ? sizes.join('+') : '0px';
-}
-
 interface IconOrButtonProps {
     $isMobile: boolean;
     $tagSize: TagSize;
@@ -80,23 +68,11 @@ function isSmall(tagSize: TagSize): tagSize is 'small' {
     return tagSize === 'small';
 }
 
-function getTagHeight(props: IconOrButtonProps): string {
-    let height: string;
-    const isSmallTag = isSmall(props.$tagSize);
-    if (props.$isMobile) {
-        height = isSmallTag ? '24px' : '32px';
-    } else {
-        height = isSmallTag ? '16px' : '24px';
-    }
-
-    return `calc(${height} - ${getPadding(props)} / 2)`;
-}
-
 function getLineHeight({ $isMobile, $tagSize }: ContainerProps): number {
     if (isSmall($tagSize)) {
-        return $isMobile ? 1.375 : 0.875;
+        return $isMobile ? 1.5 : 0.875;
     }
-    return $isMobile ? 1.875 : 1.375;
+    return $isMobile ? 1.875 : 1.5;
 }
 
 function getBorderRadius({ $clickable, $isMobile, $tagSize }: ContainerProps): string {
@@ -113,10 +89,10 @@ function getBorderRadius({ $clickable, $isMobile, $tagSize }: ContainerProps): s
 const StyledIcon = styled(Icon)<SVGProps<SVGSVGElement> & IconOrButtonProps>`
     /* TODO change when updating thematization */
     color: #60666e;
-    display: inline-block;
-    height: ${getTagHeight};
-    margin-right: var(--spacing-1x);
-    vertical-align: middle;
+    height: var(--size-1x);
+    margin-right: var(--spacing-half);
+    vertical-align: text-bottom;
+    width: var(--size-1x);
 `;
 
 const DeleteIcon = styled(Icon).attrs({
@@ -142,15 +118,29 @@ function getClickableStyle({ $clickable }: ContainerProps): FlattenInterpolation
     `;
 }
 
-const DeleteButton = styled.button<IconOrButtonProps>`
-    border-radius: 50%;
-    cursor: pointer;
+const TagLabel = styled.span`
     display: inline-block;
-    height: ${getTagHeight};
-    margin-bottom: 1px;
-    margin-left: var(--spacing-1x);
-    padding: var(--spacing-half);
-    vertical-align: middle;
+    font-size: 0.75rem;
+    line-height: 1.5rem;
+    max-width: 312px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`
+
+const DeleteButton = styled.button<IconOrButtonProps>`
+    align-items: center;
+    border-radius: 50%;
+    display: inline-flex;
+    height: var(--size-1halfx);
+    justify-content: center;
+    margin-left: var(--spacing-half);
+    width: var(--size-1halfx);
+
+    > svg {
+        height: 1rem;
+        width: 1rem;
+    }
 
     &:hover {
         /* TODO fix with next thematization gray65 */
@@ -164,23 +154,17 @@ const DeleteButton = styled.button<IconOrButtonProps>`
     ${focus};
 `;
 
-const MAXIMUM_LENGTH = '312px';
 const Container = styled.span<ContainerProps>`
     align-items: center;
     background-color: ${({ theme }) => theme.greys['light-grey']};
 
     /* TODO fix with next thematization gray50 */
-    border: 1px solid #878f9a;
     border-radius: ${getBorderRadius};
-    box-sizing: border-box;
-    display: inline-block;
+    box-shadow: inset 0 0 0 1px #878f9a;
+    display: inline-flex;
     font-size: ${getFontSize}rem;
     line-height: ${getLineHeight}rem;
-    max-width: calc(${MAXIMUM_LENGTH} / ${getFontSize} + ${getIconAndButtonWidth});
-    overflow: hidden;
     padding: 0 ${getPadding};
-    text-overflow: ellipsis;
-    white-space: nowrap;
 
     & + & {
         margin-left: var(--spacing-1x);
@@ -247,7 +231,9 @@ export const Tag = forwardRef(({
                 />
             )}
 
-            {value.label}
+            <TagLabel>
+                {value.label}
+            </TagLabel>
 
             {onDelete && (
                 <DeleteButton

--- a/packages/react/src/components/tag/tag.tsx
+++ b/packages/react/src/components/tag/tag.tsx
@@ -43,7 +43,12 @@ interface ContainerProps {
     type?: DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>['type'];
 }
 
-function getFontSize({ $isMobile }: ContainerProps): number {
+interface TagLabelProps {
+    $isMobile: boolean;
+    $tagSize: TagSize;
+}
+
+function getFontSize({ $isMobile }: TagLabelProps): number {
     return $isMobile ? 0.875 : 0.75;
 }
 
@@ -61,16 +66,16 @@ function isMedium(tagSize: TagSize): tagSize is 'medium' {
 }
 
 function getPadding({ $isMobile, $tagSize }: IconOrButtonProps): string {
-    return $isMobile || isMedium($tagSize) ? 'var(--spacing-1x)' : 'var(--spacing-half)';
+    return $isMobile || isMedium($tagSize) ? '0 var(--spacing-1x)' : '0 var(--spacing-half)';
 }
 
 function isSmall(tagSize: TagSize): tagSize is 'small' {
     return tagSize === 'small';
 }
 
-function getLineHeight({ $isMobile, $tagSize }: ContainerProps): number {
+function getLineHeight({ $isMobile, $tagSize }: TagLabelProps): number {
     if (isSmall($tagSize)) {
-        return $isMobile ? 1.5 : 0.875;
+        return $isMobile ? 1.5 : 1;
     }
     return $isMobile ? 1.875 : 1.5;
 }
@@ -118,15 +123,15 @@ function getClickableStyle({ $clickable }: ContainerProps): FlattenInterpolation
     `;
 }
 
-const TagLabel = styled.span`
+const TagLabel = styled.span<TagLabelProps>`
     display: inline-block;
-    font-size: 0.75rem;
-    line-height: 1.5rem;
+    font-size: ${getFontSize}rem;
+    line-height: ${getLineHeight}rem;
     max-width: 312px;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-`
+`;
 
 const DeleteButton = styled.button<IconOrButtonProps>`
     align-items: center;
@@ -162,9 +167,7 @@ const Container = styled.span<ContainerProps>`
     border-radius: ${getBorderRadius};
     box-shadow: inset 0 0 0 1px #878f9a;
     display: inline-flex;
-    font-size: ${getFontSize}rem;
-    line-height: ${getLineHeight}rem;
-    padding: 0 ${getPadding};
+    padding: ${getPadding};
 
     & + & {
         margin-left: var(--spacing-1x);
@@ -231,7 +234,10 @@ export const Tag = forwardRef(({
                 />
             )}
 
-            <TagLabel>
+            <TagLabel
+                $isMobile={isMobile}
+                $tagSize={size}
+            >
                 {value.label}
             </TagLabel>
 

--- a/packages/react/src/components/tag/tag.tsx
+++ b/packages/react/src/components/tag/tag.tsx
@@ -123,8 +123,8 @@ const TagLabel = styled.span`
     font-size: 0.75rem;
     line-height: 1.5rem;
     max-width: 312px;
-    text-overflow: ellipsis;
     overflow: hidden;
+    text-overflow: ellipsis;
     white-space: nowrap;
 `
 

--- a/packages/react/src/components/theme-wrapper/theme-wrapper.test.tsx.snap
+++ b/packages/react/src/components/theme-wrapper/theme-wrapper.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`Theme Wrapper Returns component with default theme 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {
@@ -149,6 +151,8 @@ exports[`Theme Wrapper Returns component with test theme 1`] = `
 
 .c0 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c1 {

--- a/packages/react/src/components/toast/toast-container.test.tsx.snap
+++ b/packages/react/src/components/toast/toast-container.test.tsx.snap
@@ -102,10 +102,10 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: var(--border-radius);
   box-shadow: 0 16px 32px 0 rgb(0 0 0 / 5%);
   box-sizing: border-box;
@@ -113,10 +113,6 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  min-height: 56px;
   padding: var(--spacing-2x);
   -webkit-transition: 0.3s ease;
   transition: 0.3s ease;
@@ -133,10 +129,7 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   flex: 1;
   font-size: 1rem;
   line-height: 1.5rem;
-  margin: 0;
-  padding-left: var(--spacing-2x);
-  padding-right: var(--spacing-4x);
-  position: relative;
+  margin: 0 var(--spacing-1halfx);
 }
 
 .c3 {
@@ -144,10 +137,7 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   -ms-flex-item-align: start;
   align-self: flex-start;
   color: #FFFFFF;
-  margin-top: calc(-1 * var(--spacing-half));
-  position: absolute;
-  right: 0;
-  top: 0;
+  margin: calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) 0;
 }
 
 .c3:focus {
@@ -160,7 +150,12 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
 }
 
 .c1 {
-  height: 24px;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  height: var(--size-1x);
+  margin-top: 0.25rem;
+  width: var(--size-1x);
 }
 
 <ToastContainer
@@ -184,7 +179,7 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
         color="#FFFFFF"
         isMobile={false}
         name="alertOctagon"
-        size="20"
+        size="16"
         type="error"
       >
         <Icon
@@ -194,7 +189,7 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
           focusable={true}
           isMobile={false}
           name="alertOctagon"
-          size="20"
+          size="16"
           type="error"
         >
           <svg
@@ -202,10 +197,10 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
             className="c1"
             color="#FFFFFF"
             focusable={true}
-            height="20"
+            height="16"
             isMobile={false}
             type="error"
-            width="20"
+            width="16"
           />
         </Icon>
       </Styled(Icon)>
@@ -218,78 +213,78 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
           color="#FFFFFF"
         >
           a message
-          <Styled(IconButton)
-            $color="#FFFFFF"
-            $isMobile={false}
-            $type="error"
+        </p>
+      </styled.p>
+      <Styled(IconButton)
+        $color="#FFFFFF"
+        $isMobile={false}
+        $type="error"
+        data-testid="dismiss"
+        label="Dismiss notification"
+        onClick={[Function]}
+      >
+        <IconButton
+          buttonType="tertiary"
+          className="c3"
+          data-testid="dismiss"
+          iconName="x"
+          label="Dismiss notification"
+          onClick={[Function]}
+        >
+          <Styled(AbstractButton)
+            aria-label="Dismiss notification"
+            buttonType="tertiary"
+            className="c3"
             data-testid="dismiss"
-            label="Dismiss notification"
+            isMobile={false}
             onClick={[Function]}
+            type="submit"
           >
-            <IconButton
+            <AbstractButton
+              aria-label="Dismiss notification"
               buttonType="tertiary"
-              className="c3"
+              className="c4 c3"
               data-testid="dismiss"
-              iconName="x"
-              label="Dismiss notification"
+              isMobile={false}
               onClick={[Function]}
+              type="submit"
             >
-              <Styled(AbstractButton)
+              <styled.button
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
-                className="c3"
+                className="c4 c3"
                 data-testid="dismiss"
                 isMobile={false}
                 onClick={[Function]}
                 type="submit"
               >
-                <AbstractButton
+                <button
                   aria-label="Dismiss notification"
-                  buttonType="tertiary"
-                  className="c4 c3"
+                  className="c5 c4 c3"
                   data-testid="dismiss"
-                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <styled.button
-                    aria-label="Dismiss notification"
-                    buttonType="tertiary"
-                    className="c4 c3"
-                    data-testid="dismiss"
-                    isMobile={false}
-                    onClick={[Function]}
-                    type="submit"
+                  <Icon
+                    aria-hidden="true"
+                    color="currentColor"
+                    name="x"
+                    size="16"
                   >
-                    <button
-                      aria-label="Dismiss notification"
-                      className="c5 c4 c3"
-                      data-testid="dismiss"
-                      onClick={[Function]}
-                      type="submit"
-                    >
-                      <Icon
-                        aria-hidden="true"
-                        color="currentColor"
-                        name="x"
-                        size="16"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable={false}
-                          height="16"
-                          width="16"
-                        />
-                      </Icon>
-                    </button>
-                  </styled.button>
-                </AbstractButton>
-              </Styled(AbstractButton)>
-            </IconButton>
-          </Styled(IconButton)>
-        </p>
-      </styled.p>
+                    <svg
+                      aria-hidden="true"
+                      color="currentColor"
+                      focusable={false}
+                      height="16"
+                      width="16"
+                    />
+                  </Icon>
+                </button>
+              </styled.button>
+            </AbstractButton>
+          </Styled(AbstractButton)>
+        </IconButton>
+      </Styled(IconButton)>
     </div>
   </styled.div>
 </ToastContainer>
@@ -397,10 +392,10 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: var(--border-radius);
   box-shadow: 0 16px 32px 0 rgb(0 0 0 / 5%);
   box-sizing: border-box;
@@ -408,10 +403,6 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  min-height: 56px;
   padding: var(--spacing-2x);
   -webkit-transition: 0.3s ease;
   transition: 0.3s ease;
@@ -428,10 +419,7 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   flex: 1;
   font-size: 1rem;
   line-height: 1.5rem;
-  margin: 0;
-  padding-left: var(--spacing-2x);
-  padding-right: var(--spacing-4x);
-  position: relative;
+  margin: 0 var(--spacing-1halfx);
 }
 
 .c3 {
@@ -439,10 +427,7 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   -ms-flex-item-align: start;
   align-self: flex-start;
   color: #FFFFFF;
-  margin-top: calc(-1 * var(--spacing-half));
-  position: absolute;
-  right: 0;
-  top: 0;
+  margin: calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) 0;
 }
 
 .c3:focus {
@@ -455,7 +440,12 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
 }
 
 .c1 {
-  height: 24px;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  height: var(--size-1x);
+  margin-top: 0.25rem;
+  width: var(--size-1x);
 }
 
 <ToastContainer
@@ -479,7 +469,7 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
         color="#FFFFFF"
         isMobile={false}
         name="info"
-        size="20"
+        size="16"
         type="information"
       >
         <Icon
@@ -489,7 +479,7 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
           focusable={true}
           isMobile={false}
           name="info"
-          size="20"
+          size="16"
           type="information"
         >
           <svg
@@ -497,10 +487,10 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
             className="c1"
             color="#FFFFFF"
             focusable={true}
-            height="20"
+            height="16"
             isMobile={false}
             type="information"
-            width="20"
+            width="16"
           />
         </Icon>
       </Styled(Icon)>
@@ -513,78 +503,78 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
           color="#FFFFFF"
         >
           a message
-          <Styled(IconButton)
-            $color="#FFFFFF"
-            $isMobile={false}
-            $type="information"
+        </p>
+      </styled.p>
+      <Styled(IconButton)
+        $color="#FFFFFF"
+        $isMobile={false}
+        $type="information"
+        data-testid="dismiss"
+        label="Dismiss notification"
+        onClick={[Function]}
+      >
+        <IconButton
+          buttonType="tertiary"
+          className="c3"
+          data-testid="dismiss"
+          iconName="x"
+          label="Dismiss notification"
+          onClick={[Function]}
+        >
+          <Styled(AbstractButton)
+            aria-label="Dismiss notification"
+            buttonType="tertiary"
+            className="c3"
             data-testid="dismiss"
-            label="Dismiss notification"
+            isMobile={false}
             onClick={[Function]}
+            type="submit"
           >
-            <IconButton
+            <AbstractButton
+              aria-label="Dismiss notification"
               buttonType="tertiary"
-              className="c3"
+              className="c4 c3"
               data-testid="dismiss"
-              iconName="x"
-              label="Dismiss notification"
+              isMobile={false}
               onClick={[Function]}
+              type="submit"
             >
-              <Styled(AbstractButton)
+              <styled.button
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
-                className="c3"
+                className="c4 c3"
                 data-testid="dismiss"
                 isMobile={false}
                 onClick={[Function]}
                 type="submit"
               >
-                <AbstractButton
+                <button
                   aria-label="Dismiss notification"
-                  buttonType="tertiary"
-                  className="c4 c3"
+                  className="c5 c4 c3"
                   data-testid="dismiss"
-                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <styled.button
-                    aria-label="Dismiss notification"
-                    buttonType="tertiary"
-                    className="c4 c3"
-                    data-testid="dismiss"
-                    isMobile={false}
-                    onClick={[Function]}
-                    type="submit"
+                  <Icon
+                    aria-hidden="true"
+                    color="currentColor"
+                    name="x"
+                    size="16"
                   >
-                    <button
-                      aria-label="Dismiss notification"
-                      className="c5 c4 c3"
-                      data-testid="dismiss"
-                      onClick={[Function]}
-                      type="submit"
-                    >
-                      <Icon
-                        aria-hidden="true"
-                        color="currentColor"
-                        name="x"
-                        size="16"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable={false}
-                          height="16"
-                          width="16"
-                        />
-                      </Icon>
-                    </button>
-                  </styled.button>
-                </AbstractButton>
-              </Styled(AbstractButton)>
-            </IconButton>
-          </Styled(IconButton)>
-        </p>
-      </styled.p>
+                    <svg
+                      aria-hidden="true"
+                      color="currentColor"
+                      focusable={false}
+                      height="16"
+                      width="16"
+                    />
+                  </Icon>
+                </button>
+              </styled.button>
+            </AbstractButton>
+          </Styled(AbstractButton)>
+        </IconButton>
+      </Styled(IconButton)>
     </div>
   </styled.div>
 </ToastContainer>
@@ -692,10 +682,10 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: var(--border-radius);
   box-shadow: 0 16px 32px 0 rgb(0 0 0 / 5%);
   box-sizing: border-box;
@@ -703,10 +693,6 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  min-height: 56px;
   padding: var(--spacing-2x);
   -webkit-transition: 0.3s ease;
   transition: 0.3s ease;
@@ -723,10 +709,7 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   flex: 1;
   font-size: 1rem;
   line-height: 1.5rem;
-  margin: 0;
-  padding-left: var(--spacing-2x);
-  padding-right: var(--spacing-4x);
-  position: relative;
+  margin: 0 var(--spacing-1halfx);
 }
 
 .c3 {
@@ -734,10 +717,7 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   -ms-flex-item-align: start;
   align-self: flex-start;
   color: #FFFFFF;
-  margin-top: calc(-1 * var(--spacing-half));
-  position: absolute;
-  right: 0;
-  top: 0;
+  margin: calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) 0;
 }
 
 .c3:focus {
@@ -750,7 +730,12 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
 }
 
 .c1 {
-  height: 24px;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  height: var(--size-1x);
+  margin-top: 0.25rem;
+  width: var(--size-1x);
 }
 
 <ToastContainer
@@ -774,7 +759,7 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
         color="#FFFFFF"
         isMobile={false}
         name="check"
-        size="20"
+        size="16"
         type="success"
       >
         <Icon
@@ -784,7 +769,7 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
           focusable={true}
           isMobile={false}
           name="check"
-          size="20"
+          size="16"
           type="success"
         >
           <svg
@@ -792,10 +777,10 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
             className="c1"
             color="#FFFFFF"
             focusable={true}
-            height="20"
+            height="16"
             isMobile={false}
             type="success"
-            width="20"
+            width="16"
           />
         </Icon>
       </Styled(Icon)>
@@ -808,78 +793,78 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
           color="#FFFFFF"
         >
           a message
-          <Styled(IconButton)
-            $color="#FFFFFF"
-            $isMobile={false}
-            $type="success"
+        </p>
+      </styled.p>
+      <Styled(IconButton)
+        $color="#FFFFFF"
+        $isMobile={false}
+        $type="success"
+        data-testid="dismiss"
+        label="Dismiss notification"
+        onClick={[Function]}
+      >
+        <IconButton
+          buttonType="tertiary"
+          className="c3"
+          data-testid="dismiss"
+          iconName="x"
+          label="Dismiss notification"
+          onClick={[Function]}
+        >
+          <Styled(AbstractButton)
+            aria-label="Dismiss notification"
+            buttonType="tertiary"
+            className="c3"
             data-testid="dismiss"
-            label="Dismiss notification"
+            isMobile={false}
             onClick={[Function]}
+            type="submit"
           >
-            <IconButton
+            <AbstractButton
+              aria-label="Dismiss notification"
               buttonType="tertiary"
-              className="c3"
+              className="c4 c3"
               data-testid="dismiss"
-              iconName="x"
-              label="Dismiss notification"
+              isMobile={false}
               onClick={[Function]}
+              type="submit"
             >
-              <Styled(AbstractButton)
+              <styled.button
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
-                className="c3"
+                className="c4 c3"
                 data-testid="dismiss"
                 isMobile={false}
                 onClick={[Function]}
                 type="submit"
               >
-                <AbstractButton
+                <button
                   aria-label="Dismiss notification"
-                  buttonType="tertiary"
-                  className="c4 c3"
+                  className="c5 c4 c3"
                   data-testid="dismiss"
-                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <styled.button
-                    aria-label="Dismiss notification"
-                    buttonType="tertiary"
-                    className="c4 c3"
-                    data-testid="dismiss"
-                    isMobile={false}
-                    onClick={[Function]}
-                    type="submit"
+                  <Icon
+                    aria-hidden="true"
+                    color="currentColor"
+                    name="x"
+                    size="16"
                   >
-                    <button
-                      aria-label="Dismiss notification"
-                      className="c5 c4 c3"
-                      data-testid="dismiss"
-                      onClick={[Function]}
-                      type="submit"
-                    >
-                      <Icon
-                        aria-hidden="true"
-                        color="currentColor"
-                        name="x"
-                        size="16"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable={false}
-                          height="16"
-                          width="16"
-                        />
-                      </Icon>
-                    </button>
-                  </styled.button>
-                </AbstractButton>
-              </Styled(AbstractButton)>
-            </IconButton>
-          </Styled(IconButton)>
-        </p>
-      </styled.p>
+                    <svg
+                      aria-hidden="true"
+                      color="currentColor"
+                      focusable={false}
+                      height="16"
+                      width="16"
+                    />
+                  </Icon>
+                </button>
+              </styled.button>
+            </AbstractButton>
+          </Styled(AbstractButton)>
+        </IconButton>
+      </Styled(IconButton)>
     </div>
   </styled.div>
 </ToastContainer>
@@ -987,10 +972,10 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   border-radius: var(--border-radius);
   box-shadow: 0 16px 32px 0 rgb(0 0 0 / 5%);
   box-sizing: border-box;
@@ -998,10 +983,6 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
-  min-height: 56px;
   padding: var(--spacing-2x);
   -webkit-transition: 0.3s ease;
   transition: 0.3s ease;
@@ -1018,10 +999,7 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   flex: 1;
   font-size: 1rem;
   line-height: 1.5rem;
-  margin: 0;
-  padding-left: var(--spacing-2x);
-  padding-right: var(--spacing-4x);
-  position: relative;
+  margin: 0 var(--spacing-1halfx);
 }
 
 .c3 {
@@ -1029,10 +1007,7 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   -ms-flex-item-align: start;
   align-self: flex-start;
   color: #000000;
-  margin-top: calc(-1 * var(--spacing-half));
-  position: absolute;
-  right: 0;
-  top: 0;
+  margin: calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) calc(-1 * var(--spacing-half)) 0;
 }
 
 .c3:focus {
@@ -1045,7 +1020,12 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
 }
 
 .c1 {
-  height: 24px;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+  height: var(--size-1x);
+  margin-top: 0.25rem;
+  width: var(--size-1x);
 }
 
 <ToastContainer
@@ -1069,7 +1049,7 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
         color="#000000"
         isMobile={false}
         name="alertTriangle"
-        size="20"
+        size="16"
         type="warning"
       >
         <Icon
@@ -1079,7 +1059,7 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
           focusable={true}
           isMobile={false}
           name="alertTriangle"
-          size="20"
+          size="16"
           type="warning"
         >
           <svg
@@ -1087,10 +1067,10 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
             className="c1"
             color="#000000"
             focusable={true}
-            height="20"
+            height="16"
             isMobile={false}
             type="warning"
-            width="20"
+            width="16"
           />
         </Icon>
       </Styled(Icon)>
@@ -1103,78 +1083,78 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
           color="#000000"
         >
           a message
-          <Styled(IconButton)
-            $color="#000000"
-            $isMobile={false}
-            $type="warning"
+        </p>
+      </styled.p>
+      <Styled(IconButton)
+        $color="#000000"
+        $isMobile={false}
+        $type="warning"
+        data-testid="dismiss"
+        label="Dismiss notification"
+        onClick={[Function]}
+      >
+        <IconButton
+          buttonType="tertiary"
+          className="c3"
+          data-testid="dismiss"
+          iconName="x"
+          label="Dismiss notification"
+          onClick={[Function]}
+        >
+          <Styled(AbstractButton)
+            aria-label="Dismiss notification"
+            buttonType="tertiary"
+            className="c3"
             data-testid="dismiss"
-            label="Dismiss notification"
+            isMobile={false}
             onClick={[Function]}
+            type="submit"
           >
-            <IconButton
+            <AbstractButton
+              aria-label="Dismiss notification"
               buttonType="tertiary"
-              className="c3"
+              className="c4 c3"
               data-testid="dismiss"
-              iconName="x"
-              label="Dismiss notification"
+              isMobile={false}
               onClick={[Function]}
+              type="submit"
             >
-              <Styled(AbstractButton)
+              <styled.button
                 aria-label="Dismiss notification"
                 buttonType="tertiary"
-                className="c3"
+                className="c4 c3"
                 data-testid="dismiss"
                 isMobile={false}
                 onClick={[Function]}
                 type="submit"
               >
-                <AbstractButton
+                <button
                   aria-label="Dismiss notification"
-                  buttonType="tertiary"
-                  className="c4 c3"
+                  className="c5 c4 c3"
                   data-testid="dismiss"
-                  isMobile={false}
                   onClick={[Function]}
                   type="submit"
                 >
-                  <styled.button
-                    aria-label="Dismiss notification"
-                    buttonType="tertiary"
-                    className="c4 c3"
-                    data-testid="dismiss"
-                    isMobile={false}
-                    onClick={[Function]}
-                    type="submit"
+                  <Icon
+                    aria-hidden="true"
+                    color="currentColor"
+                    name="x"
+                    size="16"
                   >
-                    <button
-                      aria-label="Dismiss notification"
-                      className="c5 c4 c3"
-                      data-testid="dismiss"
-                      onClick={[Function]}
-                      type="submit"
-                    >
-                      <Icon
-                        aria-hidden="true"
-                        color="currentColor"
-                        name="x"
-                        size="16"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable={false}
-                          height="16"
-                          width="16"
-                        />
-                      </Icon>
-                    </button>
-                  </styled.button>
-                </AbstractButton>
-              </Styled(AbstractButton)>
-            </IconButton>
-          </Styled(IconButton)>
-        </p>
-      </styled.p>
+                    <svg
+                      aria-hidden="true"
+                      color="currentColor"
+                      focusable={false}
+                      height="16"
+                      width="16"
+                    />
+                  </Icon>
+                </button>
+              </styled.button>
+            </AbstractButton>
+          </Styled(AbstractButton)>
+        </IconButton>
+      </Styled(IconButton)>
     </div>
   </styled.div>
 </ToastContainer>

--- a/packages/react/src/components/toast/toast-container.test.tsx.snap
+++ b/packages/react/src/components/toast/toast-container.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
 
 .c5 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -92,6 +94,11 @@ exports[`ToastContainer should match snapshot (error) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -345,6 +352,8 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
 
 .c5 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -380,6 +389,11 @@ exports[`ToastContainer should match snapshot (information) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -633,6 +647,8 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
 
 .c5 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -668,6 +684,11 @@ exports[`ToastContainer should match snapshot (success) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -921,6 +942,8 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
 
 .c5 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -956,6 +979,11 @@ exports[`ToastContainer should match snapshot (warning) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c4 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {

--- a/packages/react/src/components/toast/toast-container.tsx
+++ b/packages/react/src/components/toast/toast-container.tsx
@@ -230,13 +230,13 @@ export const ToastContainer: VoidFunctionComponent<ToastContainerProps> = ({
                 {message}
             </StyledMessage>
             <DismissIcon
-                    label={t('dismissButtonLabel')}
-                    $color={toastTextColor}
-                    $isMobile={isMobile}
-                    $type={type}
-                    onClick={() => removeToast(id)}
-                    data-testid="dismiss"
-                />
+                label={t('dismissButtonLabel')}
+                $color={toastTextColor}
+                $isMobile={isMobile}
+                $type={type}
+                onClick={() => removeToast(id)}
+                data-testid="dismiss"
+            />
         </ToastWrapper>
     );
 };

--- a/packages/react/src/components/toast/toast-container.tsx
+++ b/packages/react/src/components/toast/toast-container.tsx
@@ -87,14 +87,12 @@ function getToastPosition({ position }: ToastWrapperProps): FlattenInterpolation
 }
 
 const ToastWrapper = styled.div<ToastWrapperProps>`
-    align-items: flex-start;
+    align-items: center;
     border-radius: var(--border-radius);
     box-shadow: 0 16px 32px 0 rgb(0 0 0 / 5%);
     box-sizing: border-box;
     display: flex;
-    flex: 1;
-    min-height: ${({ isMobile }) => (isMobile ? '72px' : '56px')};
-    padding: ${({ isMobile }) => (isMobile ? 'calc(2.5 * var(--spacing-1x))' : 'var(--spacing-2x)')};
+    padding: ${({ isMobile }) => (isMobile ? 'var(--spacing-2halfx)' : 'var(--spacing-2x)')};
     transition: 0.3s ease;
     width: ${({ isMobile }) => (isMobile ? '100vw' : '400px')};
 
@@ -107,10 +105,7 @@ const StyledMessage = styled.p<{ color: string, $isMobile: boolean }>`
     flex: 1;
     font-size: ${({ $isMobile }) => ($isMobile ? 1.125 : 1)}rem;
     line-height: ${({ $isMobile }) => ($isMobile ? 1.75 : 1.5)}rem;
-    margin: 0;
-    padding-left: var(--spacing-2x);
-    padding-right: var(--spacing-4x);
-    position: relative;
+    margin: 0 var(--spacing-1halfx);
 `;
 
 type DismissIconProps = ThemedStyledProps<Pick<IconButtonProps, 'label' | 'onClick'>, Theme> & {
@@ -145,11 +140,7 @@ function getDismissHoverCss({ $type, theme }: DismissIconProps): FlattenSimpleIn
 }
 
 function getDismissIconMarginTop({ $isMobile }: DismissIconProps): string {
-    return $isMobile ? 'calc(-1.5 * var(--spacing-1x))' : 'calc(-1 * var(--spacing-half))';
-}
-
-function getDismissIconRight({ $isMobile }: DismissIconProps): string {
-    return $isMobile ? 'calc(-1.5 * var(--spacing-1x))' : '0';
+    return $isMobile ? 'calc(-1 * var(--spacing-1x))' : 'calc(-1 * var(--spacing-half))';
 }
 
 const DismissIcon = styled(IconButton).attrs<DismissIconProps, Partial<IconButtonProps>>({
@@ -158,10 +149,7 @@ const DismissIcon = styled(IconButton).attrs<DismissIconProps, Partial<IconButto
 })<DismissIconProps>`
     align-self: flex-start;
     color: ${({ $color }) => $color};
-    margin-top: ${getDismissIconMarginTop};
-    position: absolute;
-    right: ${getDismissIconRight};
-    top: ${({ $isMobile }) => ($isMobile ? '3px' : '0')};
+    margin: ${getDismissIconMarginTop} calc(-1 * var(--spacing-half)) ${getDismissIconMarginTop} 0;
 
     &:focus {
         box-shadow: 0 0 0 2px ${({ theme }) => theme.main['primary-1.2']};
@@ -190,7 +178,10 @@ const MessageIcon = styled(Icon).attrs(({ type }: MessageIconProps) => ({
     focusable: true,
     'aria-label': getMessageLabel(type),
 }))<MessageIconProps>`
-    height: ${({ isMobile }) => (isMobile ? '28px' : '24px')};
+    align-self: flex-start;
+    height: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
+    margin-top: 0.25rem;
+    width: ${({ isMobile }) => (isMobile ? 'var(--size-1halfx)' : 'var(--size-1x)')};
 `;
 
 function getToastIconName(type: ToastType): IconName {
@@ -234,10 +225,11 @@ export const ToastContainer: VoidFunctionComponent<ToastContainerProps> = ({
 
     return (
         <ToastWrapper isMobile={isMobile} className={className} type={type} position={position} role="status">
-            <MessageIcon name={toastIconName} color={toastTextColor} size="20" type={type} isMobile={isMobile} />
+            <MessageIcon name={toastIconName} color={toastTextColor} size="16" type={type} isMobile={isMobile} />
             <StyledMessage color={toastTextColor} $isMobile={isMobile}>
                 {message}
-                <DismissIcon
+            </StyledMessage>
+            <DismissIcon
                     label={t('dismissButtonLabel')}
                     $color={toastTextColor}
                     $isMobile={isMobile}
@@ -245,7 +237,6 @@ export const ToastContainer: VoidFunctionComponent<ToastContainerProps> = ({
                     onClick={() => removeToast(id)}
                     data-testid="dismiss"
                 />
-            </StyledMessage>
         </ToastWrapper>
     );
 };

--- a/packages/react/src/components/toggle-button-group/toggle-button-group.test.tsx.snap
+++ b/packages/react/src/components/toggle-button-group/toggle-button-group.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`ToggleButtonGroup Matches snapshot (desktop) 1`] = `
   -moz-letter-spacing: 0.02875rem;
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
-  min-height: 32px;
+  min-height: var(--size-2x);
   padding: 0 var(--spacing-2x);
 }
 
@@ -83,7 +83,7 @@ exports[`ToggleButtonGroup Matches snapshot (desktop) 1`] = `
   -moz-letter-spacing: 0.02875rem;
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
-  min-height: 32px;
+  min-height: var(--size-2x);
   padding: 0 var(--spacing-2x);
 }
 
@@ -191,7 +191,7 @@ exports[`ToggleButtonGroup Matches snapshot (mobile) 1`] = `
   -moz-letter-spacing: 0.02875rem;
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
-  min-height: 48px;
+  min-height: var(--size-3x);
   padding: 0 var(--spacing-2x);
 }
 
@@ -241,7 +241,7 @@ exports[`ToggleButtonGroup Matches snapshot (mobile) 1`] = `
   -moz-letter-spacing: 0.02875rem;
   -ms-letter-spacing: 0.02875rem;
   letter-spacing: 0.02875rem;
-  min-height: 48px;
+  min-height: var(--size-3x);
   padding: 0 var(--spacing-2x);
 }
 

--- a/packages/react/src/components/toggle-button-group/toggle-button-group.tsx
+++ b/packages/react/src/components/toggle-button-group/toggle-button-group.tsx
@@ -34,7 +34,7 @@ const ToggleButton = styled.button<ToggleButtonProps>`
     cursor: pointer;
     font-size: ${(props) => (props.isMobile ? '1rem' : '0.875rem')};
     letter-spacing: 0.02875rem;
-    min-height: ${(props) => (props.isMobile ? '48px' : '32px')};
+    min-height: ${(props) => (props.isMobile ? 'var(--size-3x)' : 'var(--size-2x)')};
     padding: 0 var(--spacing-2x);
 
     ${(props) => props.pressed && css`

--- a/packages/react/src/components/toggle-switch/toggle-switch.test.tsx.snap
+++ b/packages/react/src/components/toggle-switch/toggle-switch.test.tsx.snap
@@ -6,24 +6,24 @@ exports[`ToggleSwitch Matches snapshot (desktop) 1`] = `
   background: #FFFFFF;
   border-radius: 100%;
   box-sizing: border-box;
-  height: 16px;
+  height: 1rem;
   position: absolute;
-  right: calc(100% - 19px);
+  right: calc(100% - 1.1875rem);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 16px;
+  width: 1rem;
 }
 
 .c0 {
   background: #008533;
   border: 1px solid #008533;
-  border-radius: 12px;
-  height: 24px;
+  border-radius: 0.75rem;
+  height: var(--size-1halfx);
   position: relative;
   vertical-align: middle;
-  width: 36px;
+  width: var(--size-2halfx);
 }
 
 .c0:not([disabled]) {
@@ -104,24 +104,24 @@ exports[`ToggleSwitch Matches snapshot (mobile) 1`] = `
   background: #FFFFFF;
   border-radius: 100%;
   box-sizing: border-box;
-  height: 22px;
+  height: 1.375rem;
   position: absolute;
-  right: calc(100% - 26px);
+  right: calc(100% - 1.625rem);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 22px;
+  width: 1.375rem;
 }
 
 .c0 {
   background: #008533;
   border: 1px solid #008533;
-  border-radius: 16px;
-  height: 32px;
+  border-radius: 1rem;
+  height: var(--size-2x);
   position: relative;
   vertical-align: middle;
-  width: 48px;
+  width: var(--size-3x);
 }
 
 .c0:not([disabled]) {
@@ -202,24 +202,24 @@ exports[`ToggleSwitch has disabled styles 1`] = `
   background: #FFFFFF;
   border-radius: 100%;
   box-sizing: border-box;
-  height: 16px;
+  height: 1rem;
   position: absolute;
-  right: calc(100% - 19px);
+  right: calc(100% - 1.1875rem);
   top: 50%;
   -webkit-transform: translateY(-50%);
   -ms-transform: translateY(-50%);
   transform: translateY(-50%);
-  width: 16px;
+  width: 1rem;
 }
 
 .c0 {
   background: #008533;
   border: 1px solid #008533;
-  border-radius: 12px;
-  height: 24px;
+  border-radius: 0.75rem;
+  height: var(--size-1halfx);
   position: relative;
   vertical-align: middle;
-  width: 36px;
+  width: var(--size-2halfx);
 }
 
 .c0:not([disabled]) {

--- a/packages/react/src/components/toggle-switch/toggle-switch.tsx
+++ b/packages/react/src/components/toggle-switch/toggle-switch.tsx
@@ -30,12 +30,12 @@ const StyledButtonSpan = styled.span<StyledButtonSpanProps>`
     background: ${({ theme }) => theme.greys.white};
     border-radius: 100%;
     box-sizing: border-box;
-    height: ${({ isMobile }) => (isMobile ? 22 : 16)}px;
+    height: ${({ isMobile }) => (isMobile ? 1.375 : 1)}rem;
     position: absolute;
-    right: calc(100% - ${({ isMobile }) => (isMobile ? 26 : 19)}px);
+    right: calc(100% - ${({ isMobile }) => (isMobile ? 1.625 : 1.1875)}rem);
     top: 50%;
     transform: translateY(-50%);
-    width: ${({ isMobile }) => (isMobile ? 22 : 16)}px;
+    width: ${({ isMobile }) => (isMobile ? 1.375 : 1)}rem;
 `;
 
 interface StyledButtonProps {
@@ -50,11 +50,11 @@ const StyledButton = styled.button<StyledButtonProps>`
 
     background: ${({ theme }) => theme.notifications['success-1.1']};
     border: 1px solid ${({ theme }) => theme.notifications['success-1.1']};
-    border-radius: ${({ isMobile }) => (isMobile ? 16 : 12)}px;
-    height: ${({ isMobile }) => (isMobile ? 32 : 24)}px;
+    border-radius: ${({ isMobile }) => (isMobile ? 1 : .75)}rem;
+    height: ${({ isMobile }) => (isMobile ? 'var(--size-2x)' : 'var(--size-1halfx)')};
     position: relative;
     vertical-align: middle;
-    width: ${({ isMobile }) => (isMobile ? 48 : 36)}px;
+    width: ${({ isMobile }) => (isMobile ? 'var(--size-3x)' : 'var(--size-2halfx)')};
 
     &[aria-checked="false"] {
         background: ${({ theme }) => theme.greys['mid-grey']};

--- a/packages/react/src/components/toggle-switch/toggle-switch.tsx
+++ b/packages/react/src/components/toggle-switch/toggle-switch.tsx
@@ -50,7 +50,7 @@ const StyledButton = styled.button<StyledButtonProps>`
 
     background: ${({ theme }) => theme.notifications['success-1.1']};
     border: 1px solid ${({ theme }) => theme.notifications['success-1.1']};
-    border-radius: ${({ isMobile }) => (isMobile ? 1 : .75)}rem;
+    border-radius: ${({ isMobile }) => (isMobile ? 1 : 0.75)}rem;
     height: ${({ isMobile }) => (isMobile ? 'var(--size-2x)' : 'var(--size-1halfx)')};
     position: relative;
     vertical-align: middle;

--- a/packages/react/src/components/toggletip/toggletip.test.tsx.snap
+++ b/packages/react/src/components/toggletip/toggletip.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`Toggletip Has default desktop styles (defaultOpen) 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -92,6 +94,11 @@ exports[`Toggletip Has default desktop styles (defaultOpen) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c0 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -399,6 +406,8 @@ exports[`Toggletip Has default desktop styles 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c0 {
@@ -434,6 +443,11 @@ exports[`Toggletip Has default desktop styles 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c0 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 <Toggletip>
@@ -562,6 +576,8 @@ exports[`Toggletip Has mobile styles (defaultOpen) 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c0 {
@@ -597,6 +613,11 @@ exports[`Toggletip Has mobile styles (defaultOpen) 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c0 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c4 {
@@ -904,6 +925,8 @@ exports[`Toggletip Has mobile styles 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c0 {
@@ -939,6 +962,11 @@ exports[`Toggletip Has mobile styles 1`] = `
   background-color: #FFFFFF;
   border-color: #006296;
   color: #60666E;
+}
+
+.c0 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 <Toggletip>

--- a/packages/react/src/components/toggletip/toggletip.test.tsx.snap
+++ b/packages/react/src/components/toggletip/toggletip.test.tsx.snap
@@ -158,7 +158,7 @@ exports[`Toggletip Has default desktop styles (defaultOpen) 1`] = `
 .c2[data-popper-placement*="bottom"] > .c3 {
   height: 1rem;
   left: 0;
-  margin-top: -0.4rem;
+  margin-top: -0.35rem;
   top: 0;
   width: 1rem;
 }
@@ -210,7 +210,7 @@ exports[`Toggletip Has default desktop styles (defaultOpen) 1`] = `
 .c2[data-popper-placement*="right"] > .c3::after {
   border-color: transparent #FFFFFF transparent transparent;
   border-width: 0.5rem 0.4rem 0.5rem 0;
-  left: 6px;
+  left: 0.375rem;
   top: 0;
 }
 
@@ -223,13 +223,13 @@ exports[`Toggletip Has default desktop styles (defaultOpen) 1`] = `
 
 .c2[data-popper-placement*="left"] > .c3::before {
   border-color: transparent transparent transparent #60666E;
-  border-width: 0.5rem 0 0.5rem 0.4em;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
 }
 
 .c2[data-popper-placement*="left"] > .c3::after {
   border-color: transparent transparent transparent #FFFFFF;
-  border-width: 0.5rem 0 0.5rem 0.4em;
-  left: 3px;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
+  left: 0.25rem;
   top: 0;
 }
 
@@ -677,7 +677,7 @@ exports[`Toggletip Has mobile styles (defaultOpen) 1`] = `
 .c2[data-popper-placement*="bottom"] > .c3 {
   height: 1rem;
   left: 0;
-  margin-top: -0.4rem;
+  margin-top: -0.35rem;
   top: 0;
   width: 1rem;
 }
@@ -729,7 +729,7 @@ exports[`Toggletip Has mobile styles (defaultOpen) 1`] = `
 .c2[data-popper-placement*="right"] > .c3::after {
   border-color: transparent #FFFFFF transparent transparent;
   border-width: 0.5rem 0.4rem 0.5rem 0;
-  left: 6px;
+  left: 0.375rem;
   top: 0;
 }
 
@@ -742,13 +742,13 @@ exports[`Toggletip Has mobile styles (defaultOpen) 1`] = `
 
 .c2[data-popper-placement*="left"] > .c3::before {
   border-color: transparent transparent transparent #60666E;
-  border-width: 0.5rem 0 0.5rem 0.4em;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
 }
 
 .c2[data-popper-placement*="left"] > .c3::after {
   border-color: transparent transparent transparent #FFFFFF;
-  border-width: 0.5rem 0 0.5rem 0.4em;
-  left: 3px;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
+  left: 0.25rem;
   top: 0;
 }
 

--- a/packages/react/src/components/toggletip/toggletip.tsx
+++ b/packages/react/src/components/toggletip/toggletip.tsx
@@ -57,7 +57,7 @@ const ToggletipContainer = styled.div<{ isMobile?: boolean }>`
     &[data-popper-placement*="bottom"] > ${ToggletipArrow} {
         height: 1rem;
         left: 0;
-        margin-top: -0.4rem;
+        margin-top: -0.35rem;
         top: 0;
         width: 1rem;
     }
@@ -109,7 +109,7 @@ const ToggletipContainer = styled.div<{ isMobile?: boolean }>`
     &[data-popper-placement*="right"] > ${ToggletipArrow}::after {
         border-color: transparent ${({ theme }) => theme.greys.white} transparent transparent;
         border-width: 0.5rem 0.4rem 0.5rem 0;
-        left: 6px;
+        left: 0.375rem;
         top: 0;
     }
 
@@ -122,13 +122,13 @@ const ToggletipContainer = styled.div<{ isMobile?: boolean }>`
 
     &[data-popper-placement*="left"] > ${ToggletipArrow}::before {
         border-color: transparent transparent transparent ${({ theme }) => theme.greys['dark-grey']};
-        border-width: 0.5rem 0 0.5rem 0.4em;
+        border-width: 0.5rem 0 0.5rem 0.4rem;
     }
 
     &[data-popper-placement*="left"] > ${ToggletipArrow}::after {
         border-color: transparent transparent transparent ${({ theme }) => theme.greys.white};
-        border-width: 0.5rem 0 0.5rem 0.4em;
-        left: 3px;
+        border-width: 0.5rem 0 0.5rem 0.4rem;
+        left: 0.25rem;
         top: 0;
     }
 `;

--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 .c1[data-popper-placement*="bottom"] > .c2 {
   height: 1rem;
   left: 0;
-  margin-top: -0.4rem;
+  margin-top: -0.35rem;
   top: 0;
   width: 1rem;
 }
@@ -110,7 +110,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 .c1[data-popper-placement*="right"] > .c2::after {
   border-color: transparent #FFFFFF transparent transparent;
   border-width: 0.5rem 0.4rem 0.5rem 0;
-  left: 6px;
+  left: 0.375rem;
   top: 0;
 }
 
@@ -123,13 +123,13 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 
 .c1[data-popper-placement*="left"] > .c2::before {
   border-color: transparent transparent transparent #60666E;
-  border-width: 0.5rem 0 0.5rem 0.4em;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
 }
 
 .c1[data-popper-placement*="left"] > .c2::after {
   border-color: transparent transparent transparent #FFFFFF;
-  border-width: 0.5rem 0 0.5rem 0.4em;
-  left: 3px;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
+  left: 0.25rem;
   top: 0;
 }
 
@@ -306,7 +306,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 .c1[data-popper-placement*="bottom"] > .c2 {
   height: 1rem;
   left: 0;
-  margin-top: -0.4rem;
+  margin-top: -0.35rem;
   top: 0;
   width: 1rem;
 }
@@ -358,7 +358,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 .c1[data-popper-placement*="right"] > .c2::after {
   border-color: transparent #FFFFFF transparent transparent;
   border-width: 0.5rem 0.4rem 0.5rem 0;
-  left: 6px;
+  left: 0.375rem;
   top: 0;
 }
 
@@ -371,13 +371,13 @@ exports[`Tooltip Has default desktop styles 1`] = `
 
 .c1[data-popper-placement*="left"] > .c2::before {
   border-color: transparent transparent transparent #60666E;
-  border-width: 0.5rem 0 0.5rem 0.4em;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
 }
 
 .c1[data-popper-placement*="left"] > .c2::after {
   border-color: transparent transparent transparent #FFFFFF;
-  border-width: 0.5rem 0 0.5rem 0.4em;
-  left: 3px;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
+  left: 0.25rem;
   top: 0;
 }
 
@@ -556,7 +556,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 .c1[data-popper-placement*="bottom"] > .c2 {
   height: 1rem;
   left: 0;
-  margin-top: -0.4rem;
+  margin-top: -0.35rem;
   top: 0;
   width: 1rem;
 }
@@ -608,7 +608,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 .c1[data-popper-placement*="right"] > .c2::after {
   border-color: transparent #FFFFFF transparent transparent;
   border-width: 0.5rem 0.4rem 0.5rem 0;
-  left: 6px;
+  left: 0.375rem;
   top: 0;
 }
 
@@ -621,13 +621,13 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 
 .c1[data-popper-placement*="left"] > .c2::before {
   border-color: transparent transparent transparent #60666E;
-  border-width: 0.5rem 0 0.5rem 0.4em;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
 }
 
 .c1[data-popper-placement*="left"] > .c2::after {
   border-color: transparent transparent transparent #FFFFFF;
-  border-width: 0.5rem 0 0.5rem 0.4em;
-  left: 3px;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
+  left: 0.25rem;
   top: 0;
 }
 
@@ -804,7 +804,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 .c1[data-popper-placement*="bottom"] > .c2 {
   height: 1rem;
   left: 0;
-  margin-top: -0.4rem;
+  margin-top: -0.35rem;
   top: 0;
   width: 1rem;
 }
@@ -856,7 +856,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 .c1[data-popper-placement*="right"] > .c2::after {
   border-color: transparent #FFFFFF transparent transparent;
   border-width: 0.5rem 0.4rem 0.5rem 0;
-  left: 6px;
+  left: 0.375rem;
   top: 0;
 }
 
@@ -869,13 +869,13 @@ exports[`Tooltip Has mobile styles 1`] = `
 
 .c1[data-popper-placement*="left"] > .c2::before {
   border-color: transparent transparent transparent #60666E;
-  border-width: 0.5rem 0 0.5rem 0.4em;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
 }
 
 .c1[data-popper-placement*="left"] > .c2::after {
   border-color: transparent transparent transparent #FFFFFF;
-  border-width: 0.5rem 0 0.5rem 0.4em;
-  left: 3px;
+  border-width: 0.5rem 0 0.5rem 0.4rem;
+  left: 0.25rem;
   top: 0;
 }
 

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -63,7 +63,7 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
     &[data-popper-placement*="bottom"] > ${TooltipArrow} {
         height: 1rem;
         left: 0;
-        margin-top: -0.4rem;
+        margin-top: -0.35rem;
         top: 0;
         width: 1rem;
     }
@@ -115,7 +115,7 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
     &[data-popper-placement*="right"] > ${TooltipArrow}::after {
         border-color: transparent ${({ theme }) => theme.greys.white} transparent transparent;
         border-width: 0.5rem 0.4rem 0.5rem 0;
-        left: 6px;
+        left: 0.375rem;
         top: 0;
     }
 
@@ -128,13 +128,13 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
 
     &[data-popper-placement*="left"] > ${TooltipArrow}::before {
         border-color: transparent transparent transparent ${({ theme }) => theme.greys['dark-grey']};
-        border-width: 0.5rem 0 0.5rem 0.4em;
+        border-width: 0.5rem 0 0.5rem 0.4rem;
     }
 
     &[data-popper-placement*="left"] > ${TooltipArrow}::after {
         border-color: transparent transparent transparent ${({ theme }) => theme.greys.white};
-        border-width: 0.5rem 0 0.5rem 0.4em;
-        left: 3px;
+        border-width: 0.5rem 0 0.5rem 0.4rem;
+        left: 0.25rem;
         top: 0;
     }
 `;

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -57,6 +57,8 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -537,6 +539,8 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {
@@ -1018,6 +1022,8 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 
 .c2 > svg {
   color: inherit;
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c3 {
@@ -1053,6 +1059,11 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   background-color: #012639;
   border-color: #006296;
   color: #FFFFFF;
+}
+
+.c3 > svg {
+  height: var(--size-1halfx);
+  width: var(--size-1halfx);
 }
 
 .c4 {
@@ -1489,6 +1500,8 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
 
 .c1 > svg {
   color: inherit;
+  height: var(--size-1x);
+  width: var(--size-1x);
 }
 
 .c4 {

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -78,12 +78,12 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.625rem;
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-letter-spacing: 0.011rem;
   -moz-letter-spacing: 0.011rem;
   -ms-letter-spacing: 0.011rem;
   letter-spacing: 0.011rem;
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 .c2 {
@@ -558,12 +558,12 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.625rem;
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-letter-spacing: 0.011rem;
   -moz-letter-spacing: 0.011rem;
   -ms-letter-spacing: 0.011rem;
   letter-spacing: 0.011rem;
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 .c2 {
@@ -1074,12 +1074,12 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.75rem;
-  height: 32px;
+  height: var(--size-2x);
   -webkit-letter-spacing: 0.013rem;
   -moz-letter-spacing: 0.013rem;
   -ms-letter-spacing: 0.013rem;
   letter-spacing: 0.013rem;
-  width: 32px;
+  width: var(--size-2x);
 }
 
 .c6 {
@@ -1510,12 +1510,12 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
   justify-content: center;
   text-transform: capitalize;
   font-size: 0.625rem;
-  height: 24px;
+  height: var(--size-1halfx);
   -webkit-letter-spacing: 0.011rem;
   -moz-letter-spacing: 0.011rem;
   -ms-letter-spacing: 0.011rem;
   letter-spacing: 0.011rem;
-  width: 24px;
+  width: var(--size-1halfx);
 }
 
 .c2 {

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -365,7 +365,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
       <li
         class="c10"
       >
-        <span
+        <div
           class="c11"
         >
           <div
@@ -377,7 +377,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
               Test Button
             </span>
           </div>
-        </span>
+        </div>
       </li>
     </ul>
     <ul
@@ -392,7 +392,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
           href="/testa"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -404,7 +404,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
                 Option A
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -416,7 +416,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
           href="/testb"
           tabindex="-1"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -428,7 +428,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
                 Option B
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -439,7 +439,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
           href="/testc"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -451,7 +451,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
                 Option C
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -462,7 +462,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
           href="/testd"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -474,7 +474,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
                 Option D
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
     </ul>
@@ -848,7 +848,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
       <li
         class="c10"
       >
-        <span
+        <div
           class="c11"
         >
           <div
@@ -860,7 +860,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
               Test Button
             </span>
           </div>
-        </span>
+        </div>
       </li>
     </ul>
     <ul
@@ -875,7 +875,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
           href="/testa"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -887,7 +887,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
                 Option A
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -899,7 +899,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
           href="/testb"
           tabindex="-1"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -911,7 +911,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
                 Option B
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -922,7 +922,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
           href="/testc"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -934,7 +934,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
                 Option C
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -945,7 +945,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
           href="/testd"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -957,7 +957,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
                 Option D
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
     </ul>
@@ -1326,7 +1326,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
       <li
         class="c9"
       >
-        <span
+        <div
           class="c10"
         >
           <div
@@ -1338,7 +1338,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
               Test Button
             </span>
           </div>
-        </span>
+        </div>
       </li>
     </ul>
     <ul
@@ -1353,7 +1353,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
           href="/testa"
           tabindex="0"
         >
-          <span
+          <div
             class="c14"
           >
             <div
@@ -1365,7 +1365,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
                 Option A
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1377,7 +1377,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
           href="/testb"
           tabindex="-1"
         >
-          <span
+          <div
             class="c14"
           >
             <div
@@ -1389,7 +1389,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
                 Option B
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1400,7 +1400,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
           href="/testc"
           tabindex="0"
         >
-          <span
+          <div
             class="c14"
           >
             <div
@@ -1412,7 +1412,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
                 Option C
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1423,7 +1423,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
           href="/testd"
           tabindex="0"
         >
-          <span
+          <div
             class="c14"
           >
             <div
@@ -1435,7 +1435,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
                 Option D
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
     </ul>
@@ -1809,7 +1809,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
       <li
         class="c10"
       >
-        <span
+        <div
           class="c11"
         >
           <div
@@ -1821,7 +1821,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
               Test Button
             </span>
           </div>
-        </span>
+        </div>
       </li>
     </ul>
     <ul
@@ -1836,7 +1836,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
           href="/testa"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -1848,7 +1848,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
                 Option A
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1860,7 +1860,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
           href="/testb"
           tabindex="-1"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -1872,7 +1872,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
                 Option B
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1883,7 +1883,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
           href="/testc"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -1895,7 +1895,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
                 Option C
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
       <li>
@@ -1906,7 +1906,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
           href="/testd"
           tabindex="0"
         >
-          <span
+          <div
             class="c15"
           >
             <div
@@ -1918,7 +1918,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
                 Option D
               </span>
             </div>
-          </span>
+          </div>
         </a>
       </li>
     </ul>

--- a/packages/react/src/styles/_variables.scss
+++ b/packages/react/src/styles/_variables.scss
@@ -10,6 +10,7 @@
   --spacing-1x: var(--spacing-base);
   --spacing-1halfx: calc(1.5 * var(--spacing-base));
   --spacing-2x: calc(2 * var(--spacing-base));
+  --spacing-2halfx: calc(2.5 * var(--spacing-base));
   --spacing-3x: calc(3 * var(--spacing-base));
   --spacing-4x: calc(4 * var(--spacing-base));
   --spacing-5x: calc(5 * var(--spacing-base));
@@ -29,6 +30,7 @@
   --size-2x: calc(2 * var(--size-base));
   --size-2halfx: calc(2.5 * var(--size-base));
   --size-3x: calc(3 * var(--size-base));
+  --size-3halfx: calc(3.5 * var(--size-base));
   --size-4x: calc(4 * var(--size-base));
   --size-4halfx: calc(4.5 * var(--size-base));
   --size-5x: calc(5 * var(--size-base));

--- a/packages/react/src/styles/_variables.scss
+++ b/packages/react/src/styles/_variables.scss
@@ -23,9 +23,13 @@
   --border-radius-4x: calc(4 * var(--border-radius));
     // var for heights 
   --size-base: 1rem;
+  --size-half: calc(0.5 * var(--size-base));
   --size-1x: var(--size-base);
   --size-1halfx: calc(1.5 * var(--size-base));
   --size-2x: calc(2 * var(--size-base));
   --size-2halfx: calc(2.5 * var(--size-base));
   --size-3x: calc(3 * var(--size-base));
+  --size-4x: calc(4 * var(--size-base));
+  --size-4halfx: calc(4.5 * var(--size-base));
+  --size-5x: calc(5 * var(--size-base));
 }


### PR DESCRIPTION
## PR Description
### A11y success criteria
Si un utilisateur augmente la taille de la typo à 200%, il ne doit pas y avoir de perte de contenu.

### fix
J'ai changé les px pour des rem et adapté les composants en conséquence.

### To test
Chrome: Preferences... --> Appearance --> Font size (sélectionner "Very large" dans le dropdown-list)

## GitHub issues resolved by PR
...

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] All GitHub checks are successful.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] All GitHub checks are successful.
