### PR TITLE
fix(MenuButton): remove auto-focus from first menu item (ABF-6488)

### DIFF
--- a/packages/react/src/components/menu-button/menu-button.test.tsx
+++ b/packages/react/src/components/menu-button/menu-button.test.tsx
@@ -52,6 +52,30 @@ describe('MenuButton', () => {
         expect(getByTestId(wrapper, 'menu').exists()).toBe(true);
     });
 
+    it('should open menu when Space key is pressed', () => {
+        const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options}>Test</MenuButton>);
+        getByTestId(wrapper, 'menu-button').simulate('keydown', { key: 'Space' });
+        setTimeout(() => {
+            expect(getByTestId(wrapper, 'menu').exists()).toBe(true);
+        }, 0);
+    });
+
+    it('should open menu when Enter key is pressed', () => {
+        const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options}>Test</MenuButton>);
+        getByTestId(wrapper, 'menu-button').simulate('keydown', { key: 'Enter' });
+        setTimeout(() => {
+            expect(getByTestId(wrapper, 'menu').exists()).toBe(true);
+        });
+    });
+
+    it('should select menu child #0 if Enter is pressed', () => {
+        const wrapper = mountWithTheme(<MenuButton buttonType="primary" options={options}>Test</MenuButton>);
+        getByTestId(wrapper, 'menu-button').simulate('keydown', { key: 'Enter' });
+        setTimeout(() => {
+            expect(document.activeElement).toBe(getByTestId(wrapper, 'menu').getNodes()[0]);
+        });
+    });
+
     it('should be default open when defaultOpen prop is set to true', () => {
         const wrapper = mountWithTheme(
             <MenuButton buttonType="primary" defaultOpen options={options}>

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -44,7 +44,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
     onMenuVisibilityChanged,
 }) => {
     const [visible, setVisible] = useState(!!defaultOpen);
-    const initialFocusIndex = 0;
+    const [initialFocusIndex, setInitialFocusIndex] = useState(0);
     const buttonRef = useRef<HTMLButtonElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
 
@@ -73,11 +73,15 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
 
     /**
      * Set focus on first menu item conditionally
-     * irrespective of whether it's a keypress, or a mouse event
+     * depending on whether it's a keypress, or a mouse event
      * @type {() => void}
      */
-    const handleClickInside = useCallback(() => {
+    const handleClickInside = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
         setVisible(!visible);
+        // event.detail returns an integer, indicating how many clicks there were
+        // If it's 0, no click was made and onClick was fired by a keypress
+        const focusIndex = event.detail === 0 ? 0 : -1;
+        setInitialFocusIndex(focusIndex);
     }, [visible]);
 
     /**

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -55,13 +55,21 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
         }
     }, [containerRef, visible, setVisible]);
 
+    const handleClickWithin: () => void = useCallback(() => {
+        setVisible(!visible);
+        if (!visible) {
+            buttonRef.current?.focus();
+        } else {
+            buttonRef.current?.blur();
+        }
+    }, [buttonRef, visible, setVisible]);
+
     useEffect(() => {
         onMenuVisibilityChanged?.(visible);
     }, [visible, onMenuVisibilityChanged]);
 
     useEffect(() => {
         document.addEventListener('mouseup', handleClickOutside);
-
         return () => document.removeEventListener('mouseup', handleClickOutside);
     }, [handleClickOutside]);
 
@@ -102,7 +110,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
                     aria-expanded={visible}
                     buttonType={buttonType}
                     inverted={inverted}
-                    onClick={() => setVisible(!visible)}
+                    onClick={() => handleClickWithin()}
                 >
                     {children}
                     <StyledIcon
@@ -115,10 +123,9 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
             )}
             {visible && (
                 <StyledMenu
-                    initialFocusIndex={0}
                     options={options}
                     onKeyDown={handleMenuKeyDown}
-                    onOptionSelect={() => setVisible(false)}
+                    onOptionSelect={() => handleClickWithin()}
                 />
             )}
         </StyledContainer>

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -1,4 +1,4 @@
-import { MenuButton } from '@equisoft/design-elements-react';
+import { MenuButton, Tooltip } from '@equisoft/design-elements-react';
 import { StoryFn as Story } from '@storybook/react';
 import styled from 'styled-components';
 import { decorateWith } from './utils/decorator';
@@ -106,4 +106,27 @@ export const VisibilityChangeEvent: Story = () => (
     >
         Button
     </MenuButton>
+);
+
+export const TooltipWrapperWithClickableItems: Story = () => (
+    <Tooltip label="Label" desktopPlacement="right">
+        <MenuButton
+            options={[
+                {
+                    label: 'Option 1',
+                    // eslint-disable-next-line no-console
+                    onClick: () => console.log('option 1 clicked'),
+                },
+                {
+                    label: 'Option 2',
+                    // eslint-disable-next-line no-console
+                    onClick: () => console.log('option 2 clicked'),
+                },
+            ]}
+            buttonType="primary"
+            onMenuVisibilityChanged={(visibility) => console.info(visibility)}
+        >
+            Menu
+        </MenuButton>
+    </Tooltip>
 );


### PR DESCRIPTION
Remove auto-focus from first menu item at the DS-level, as requested on [ABF-6488](https://jira.equisoft.com/browse/ABF-6488).

## Bug fix checklist
- [ ] Units tests have been adjusted to account for bug.
- [ ] The fix has been tested in multiple Storybook stories.
- [ ] All GitHub checks are successful.

## New component checklist
- [ ] The new component and its tests are in the same component folder.
- [ ] The component is unit tested and/or snapshot tested.
- [ ] All of the relevant Storybook stories have been added to the `storybook` package.
- [ ] There are no linting errors or warnings in the modified/new code.
- [ ] All GitHub checks are successful.
