### PR TITLE
chore: Redirect to latest without specific path

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <html>
 <head>
-<meta http-equiv="refresh" content="0;url=./latest/?path=/docs/introduction--page" />
+<meta http-equiv="refresh" content="0;url=./latest/" />
 <title>Equisoft Design System</title>
 </head>
 <body>
-Redirecting to the latest version. Click <a href="./latest/?path=/docs/introduction--page">here</a> if you are not redirected automatically.
+Redirecting to the latest version. Click <a href="./latest/">here</a> if you are not redirected automatically.
 </body>
 </html>


### PR DESCRIPTION
Le path de la page d'introduction a changé depuis l'update à Storybook 7. En redirigeant simplement vers la version _latest_ sans spécifier de path, on laisse Storybook ouvrir la première page disponible.