### PR TITLE
refactor(Link): remove unused attributes and duplicated code

### DIFF
--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -127,8 +127,17 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c18:hover {
+  color: #003A5A;
+}
+
+.c18:visited {
+  color: #62a;
 }
 
 .c18:focus {
@@ -162,6 +171,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -210,40 +220,13 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
 }
 
 .c19 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c19:hover {
-  color: #003A5A;
-}
-
-.c19:visited {
-  color: #62a;
 }
 
 .c19:visited svg {
-  color: #62a;
-}
-
-.c25 {
-  color: #84C6EA;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-}
-
-.c25:visited {
-  color: #62a;
-}
-
-.c25:visited svg {
   color: #62a;
 }
 
@@ -780,7 +763,6 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
           class="c18 c19 c20 c21"
           href="/testa"
           target="_blank"
-          type="external"
         >
           <span
             class="c22"
@@ -807,10 +789,9 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
       <li>
         <a
           aria-disabled="true"
-          class="c24 c25 c20 c21"
+          class="c24 c19 c20 c21"
           disabled=""
           target="_blank"
-          type="external"
         >
           <span
             class="c22"
@@ -966,8 +947,17 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c18:hover {
+  color: #003A5A;
+}
+
+.c18:visited {
+  color: #62a;
 }
 
 .c18:focus {
@@ -1001,6 +991,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -1049,40 +1040,13 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
 }
 
 .c19 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c19:hover {
-  color: #003A5A;
-}
-
-.c19:visited {
-  color: #62a;
 }
 
 .c19:visited svg {
-  color: #62a;
-}
-
-.c25 {
-  color: #84C6EA;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-}
-
-.c25:visited {
-  color: #62a;
-}
-
-.c25:visited svg {
   color: #62a;
 }
 
@@ -1531,7 +1495,6 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
           class="c18 c19 c20 c21"
           href="/testa"
           target="_blank"
-          type="external"
         >
           <span
             class="c22"
@@ -1558,10 +1521,9 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
       <li>
         <a
           aria-disabled="true"
-          class="c24 c25 c20 c21"
+          class="c24 c19 c20 c21"
           disabled=""
           target="_blank"
-          type="external"
         >
           <span
             class="c22"
@@ -1717,8 +1679,17 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c18:hover {
+  color: #003A5A;
+}
+
+.c18:visited {
+  color: #62a;
 }
 
 .c18:focus {
@@ -1752,6 +1723,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -1800,40 +1772,13 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
 }
 
 .c19 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c19:hover {
-  color: #003A5A;
-}
-
-.c19:visited {
-  color: #62a;
 }
 
 .c19:visited svg {
-  color: #62a;
-}
-
-.c25 {
-  color: #84C6EA;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-}
-
-.c25:visited {
-  color: #62a;
-}
-
-.c25:visited svg {
   color: #62a;
 }
 
@@ -2282,7 +2227,6 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
           class="c18 c19 c20 c21"
           href="/testa"
           target="_blank"
-          type="external"
         >
           <span
             class="c22"
@@ -2309,10 +2253,9 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
       <li>
         <a
           aria-disabled="true"
-          class="c24 c25 c20 c21"
+          class="c24 c19 c20 c21"
           disabled=""
           target="_blank"
-          type="external"
         >
           <span
             class="c22"

--- a/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
@@ -22,8 +22,17 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c2:hover {
+  color: #003A5A;
+}
+
+.c2:visited {
+  color: #62a;
 }
 
 .c2:focus {
@@ -46,21 +55,8 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c3 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c3:hover {
-  color: #003A5A;
-}
-
-.c3:visited {
-  color: #62a;
 }
 
 .c3:visited svg {
@@ -108,7 +104,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
               class="c2 c3"
               href="/index"
               tabindex="0"
-              type="route"
             >
               HOME
             </a>
@@ -120,7 +115,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
               class="c2 c3"
               href="/route"
               tabindex="0"
-              type="route"
             >
               ROUTE
             </a>
@@ -149,8 +143,17 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c2:hover {
+  color: #003A5A;
+}
+
+.c2:visited {
+  color: #62a;
 }
 
 .c2:focus {
@@ -173,21 +176,8 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c3 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c3:hover {
-  color: #003A5A;
-}
-
-.c3:visited {
-  color: #62a;
 }
 
 .c3:visited svg {
@@ -234,7 +224,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
             class="c2 c3"
             href="/index"
             tabindex="0"
-            type="route"
           >
             HOME
           </a>
@@ -246,7 +235,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
             class="c2 c3"
             href="/route"
             tabindex="0"
-            type="route"
           >
             ROUTE
           </a>
@@ -335,8 +323,17 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c2:hover {
+  color: #003A5A;
+}
+
+.c2:visited {
+  color: #62a;
 }
 
 .c2:focus {
@@ -359,21 +356,8 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c3 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c3:hover {
-  color: #003A5A;
-}
-
-.c3:visited {
-  color: #62a;
 }
 
 .c3:visited svg {
@@ -421,7 +405,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
               class="c2 c3"
               href="/index"
               tabindex="0"
-              type="route"
             >
               HOME
             </a>
@@ -450,8 +433,17 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c2:hover {
+  color: #003A5A;
+}
+
+.c2:visited {
+  color: #62a;
 }
 
 .c2:focus {
@@ -474,21 +466,8 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c3 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c3 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c3:hover {
-  color: #003A5A;
-}
-
-.c3:visited {
-  color: #62a;
 }
 
 .c3:visited svg {
@@ -535,7 +514,6 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
             class="c2 c3"
             href="/index"
             tabindex="0"
-            type="route"
           >
             HOME
           </a>

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -70,8 +70,17 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c13:hover {
+  color: #003A5A;
+}
+
+.c13:visited {
+  color: #62a;
 }
 
 .c13:focus {
@@ -105,6 +114,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -153,40 +163,13 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c14 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c14:hover {
-  color: #003A5A;
-}
-
-.c14:visited {
-  color: #62a;
 }
 
 .c14:visited svg {
-  color: #62a;
-}
-
-.c20 {
-  color: #84C6EA;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-}
-
-.c20:visited {
-  color: #62a;
-}
-
-.c20:visited svg {
   color: #62a;
 }
 
@@ -572,7 +555,6 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           class="c13 c14 c15"
           href="https://external-link.com/a"
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -602,7 +584,6 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           class="c13 c14 c15"
           href="https://external-link.com/b"
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -632,7 +613,6 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
           class="c13 c14 c15"
           href="https://external-link.com/c"
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -659,10 +639,9 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
       <li>
         <a
           aria-disabled="true"
-          class="c19 c20 c15"
+          class="c19 c14 c15"
           disabled=""
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -761,8 +740,17 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c13:hover {
+  color: #003A5A;
+}
+
+.c13:visited {
+  color: #62a;
 }
 
 .c13:focus {
@@ -796,6 +784,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -844,40 +833,13 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c14 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c14:hover {
-  color: #003A5A;
-}
-
-.c14:visited {
-  color: #62a;
 }
 
 .c14:visited svg {
-  color: #62a;
-}
-
-.c20 {
-  color: #84C6EA;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 0.875rem;
-}
-
-.c20:visited {
-  color: #62a;
-}
-
-.c20:visited svg {
   color: #62a;
 }
 
@@ -1264,7 +1226,6 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           class="c13 c14 c15"
           href="https://external-link.com/a"
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -1294,7 +1255,6 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           class="c13 c14 c15"
           href="https://external-link.com/b"
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -1324,7 +1284,6 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
           class="c13 c14 c15"
           href="https://external-link.com/c"
           target="_blank"
-          type="external"
         >
           <span
             class="c16"
@@ -1351,10 +1310,9 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
       <li>
         <a
           aria-disabled="true"
-          class="c19 c20 c15"
+          class="c19 c14 c15"
           disabled=""
           target="_blank"
-          type="external"
         >
           <span
             class="c16"

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
@@ -23,8 +23,17 @@ exports[`DropdownMenu Is hidden 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c6:hover {
+  color: #003A5A;
+}
+
+.c6:visited {
+  color: #62a;
 }
 
 .c6:focus {
@@ -71,20 +80,10 @@ exports[`DropdownMenu Is hidden 1`] = `
 }
 
 .c7 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c7:hover {
-  color: #003A5A;
-}
-
-.c7:visited {
-  color: #62a;
 }
 
 .c7:visited svg {
@@ -324,7 +323,6 @@ exports[`DropdownMenu Is hidden 1`] = `
         class="c6 c7 c8"
         href="https://external-link.com/a"
         target="_blank"
-        type="external"
       >
         <span
           class="c9"
@@ -354,7 +352,6 @@ exports[`DropdownMenu Is hidden 1`] = `
         class="c6 c7 c8"
         href="https://external-link.com/b"
         target="_blank"
-        type="external"
       >
         <span
           class="c9"
@@ -384,7 +381,6 @@ exports[`DropdownMenu Is hidden 1`] = `
         class="c6 c7 c8"
         href="https://external-link.com/c"
         target="_blank"
-        type="external"
       >
         <span
           class="c9"
@@ -435,8 +431,17 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c6:hover {
+  color: #003A5A;
+}
+
+.c6:visited {
+  color: #62a;
 }
 
 .c6:focus {
@@ -483,20 +488,10 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 }
 
 .c7 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c7:hover {
-  color: #003A5A;
-}
-
-.c7:visited {
-  color: #62a;
 }
 
 .c7:visited svg {
@@ -735,7 +730,6 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
         class="c6 c7 c8"
         href="https://external-link.com/a"
         target="_blank"
-        type="external"
       >
         <span
           class="c9"
@@ -765,7 +759,6 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
         class="c6 c7 c8"
         href="https://external-link.com/b"
         target="_blank"
-        type="external"
       >
         <span
           class="c9"
@@ -795,7 +788,6 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
         class="c6 c7 c8"
         href="https://external-link.com/c"
         target="_blank"
-        type="external"
       >
         <span
           class="c9"

--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`External Link matches snapshot (disabled) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -60,16 +61,10 @@ exports[`External Link matches snapshot (disabled) 1`] = `
 }
 
 .c1 {
-  color: #84C6EA;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -87,7 +82,6 @@ exports[`External Link matches snapshot (disabled) 1`] = `
   class="c0 c1"
   disabled=""
   target="_blank"
-  type="external"
 >
   <span
     class="c2"
@@ -124,8 +118,17 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -176,20 +179,10 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
 }
 
 .c1 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -207,7 +200,6 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
   class="c0 c1"
   href="#"
   target="_blank"
-  type="external"
 >
   <svg
     aria-hidden="true"
@@ -252,8 +244,17 @@ exports[`External Link matches snapshot (only icon) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -304,20 +305,10 @@ exports[`External Link matches snapshot (only icon) 1`] = `
 }
 
 .c1 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -335,7 +326,6 @@ exports[`External Link matches snapshot (only icon) 1`] = `
   class="c0 c1"
   href="#"
   target="_blank"
-  type="external"
 >
   <svg
     aria-hidden="true"
@@ -378,8 +368,17 @@ exports[`External Link matches snapshot (without href) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -430,20 +429,10 @@ exports[`External Link matches snapshot (without href) 1`] = `
 }
 
 .c1 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -461,7 +450,6 @@ exports[`External Link matches snapshot (without href) 1`] = `
   class="c0 c1"
   href=""
   target="_blank"
-  type="external"
 >
   <svg
     aria-hidden="true"
@@ -506,8 +494,17 @@ exports[`External Link matches snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -554,20 +551,10 @@ exports[`External Link matches snapshot 1`] = `
 }
 
 .c1 {
-  color: #006296;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  font-size: 0.875rem;
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -585,7 +572,6 @@ exports[`External Link matches snapshot 1`] = `
   class="c0 c1"
   href="https://www.google.ca/"
   target="_blank"
-  type="external"
 >
   <span
     class="c2"

--- a/packages/react/src/components/external-link/external-link.tsx
+++ b/packages/react/src/components/external-link/external-link.tsx
@@ -17,18 +17,10 @@ const ExternalIcon = styled(Icon)`
     margin-right: 0;
 `;
 
-const Link = styled(StyledLink)<{isMobile: boolean}>`
-    color: ${({ disabled, theme }) => (disabled ? theme.main['primary-1.2'] : theme.main['primary-1.1'])};
+const Link = styled(StyledLink)`
     display: flex;
-    font-size: ${({ isMobile }) => (isMobile ? '1rem' : '0.875rem')};
-
-    &:hover {
-        ${({ disabled, theme }) => (disabled ? '' : `color: ${theme.main['primary-1.3']};`)}
-    }
 
     &:visited {
-        color: #62a; /* TODO change colors when updating thematization */
-
         svg {
             color: #62a; /* TODO change colors when updating thematization */
         }
@@ -53,7 +45,13 @@ export interface ExternalLinkProps {
 }
 
 export const ExternalLink: VoidFunctionComponent<ExternalLinkProps> = ({
-    className, disabled, href = '', iconName, label, onClick, target = '_blank',
+    className,
+    disabled,
+    href = '',
+    iconName,
+    label,
+    onClick,
+    target = '_blank',
 }) => {
     const { isMobile } = useDeviceContext();
     const { t } = useTranslation('common');
@@ -72,10 +70,9 @@ export const ExternalLink: VoidFunctionComponent<ExternalLinkProps> = ({
             disabled={disabled}
             $hasLabel={!!label}
             href={disabled ? undefined : href}
-            isMobile={isMobile}
+            $isMobile={isMobile}
             onClick={disabled ? undefined : handleClick}
             target={target}
-            type="external"
         >
             {iconName && <LeftIcon aria-hidden="true" name={iconName} size="16" />}
             <StyledLabel>{label}</StyledLabel>

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -36,11 +37,6 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #84C6EA;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: var(--spacing-1x);
 }
@@ -55,7 +51,6 @@ exports[`Route Link matches snapshot (Link | disabled) 1`] = `
   disabled=""
   href="/test"
   tabindex="-1"
-  type="route"
 >
   Navigation Link
 </a>
@@ -73,8 +68,17 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -97,21 +101,8 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -126,7 +117,6 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
   class="c0 c1"
   href="/test"
   tabindex="0"
-  type="route"
 >
   <svg
     aria-hidden="true"
@@ -151,8 +141,17 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -175,21 +174,8 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: 0;
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -204,7 +190,6 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
   class="c0 c1"
   href="/test"
   tabindex="0"
-  type="route"
 >
   <svg
     aria-hidden="true"
@@ -228,8 +213,17 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -252,21 +246,8 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -281,7 +262,6 @@ exports[`Route Link matches snapshot (Link) 1`] = `
   class="c0 c1"
   href="/test"
   tabindex="0"
-  type="route"
 >
   Navigation Link
 </a>
@@ -299,6 +279,7 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -323,11 +304,6 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #84C6EA;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: var(--spacing-1x);
 }
@@ -342,7 +318,6 @@ exports[`Route Link matches snapshot (NavLink | disabled) 1`] = `
   disabled=""
   href="/test"
   tabindex="-1"
-  type="route"
 >
   Navigation Link
 </a>
@@ -360,8 +335,17 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -384,21 +368,8 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -413,7 +384,6 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
   class="c0 c1"
   href="/test"
   tabindex="0"
-  type="route"
 >
   <svg
     aria-hidden="true"
@@ -438,8 +408,17 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -462,21 +441,8 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: 0;
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -491,7 +457,6 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
   class="c0 c1"
   href="/test"
   tabindex="0"
-  type="route"
 >
   <svg
     aria-hidden="true"
@@ -515,8 +480,17 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  font-size: 0.875rem;
   -webkit-text-decoration: underline;
   text-decoration: underline;
+}
+
+.c0:hover {
+  color: #003A5A;
+}
+
+.c0:visited {
+  color: #62a;
 }
 
 .c0:focus {
@@ -539,21 +513,8 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
-.c1 {
-  color: #006296;
-  font-size: 0.875rem;
-}
-
 .c1 svg {
   margin-right: var(--spacing-1x);
-}
-
-.c1:hover {
-  color: #003A5A;
-}
-
-.c1:visited {
-  color: #62a;
 }
 
 .c1:visited svg {
@@ -568,7 +529,6 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
   class="c0 c1"
   href="/test"
   tabindex="0"
-  type="route"
 >
   Navigation Link
 </a>

--- a/packages/react/src/components/route-link/route-link.tsx
+++ b/packages/react/src/components/route-link/route-link.tsx
@@ -1,26 +1,16 @@
-import { MouseEvent, VoidFunctionComponent } from 'react';
-
+import { ComponentPropsWithoutRef, MouseEvent, VoidFunctionComponent } from 'react';
 import { NavLink, Link as ReactRouterLink } from 'react-router-dom';
 import styled from 'styled-components';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
 import { Icon, IconName } from '../icon/icon';
 import { StyledLink } from './styles/styled-link';
 
-const Link = styled(StyledLink)<{ $isMobile: boolean, $hasLabel: boolean }>`
-    color: ${({ disabled, theme }) => (disabled ? theme.main['primary-1.2'] : theme.main['primary-1.1'])};
-    font-size: ${({ $isMobile }) => ($isMobile ? '1rem' : '0.875rem')};
-
+const Link = styled(StyledLink)`
     svg {
         margin-right: ${({ $hasLabel }) => ($hasLabel ? 'var(--spacing-1x)' : '0')};
     }
 
-    &:hover {
-        ${({ disabled, theme }) => (disabled ? '' : `color: ${theme.main['primary-1.3']};`)};
-    }
-
     &:visited {
-        ${({ disabled }) => (disabled ? '' : 'color: #62a;')};
-
         svg {
             ${({ disabled }) => (disabled ? '' : 'color: #62a;')}
         }
@@ -31,10 +21,14 @@ const Link = styled(StyledLink)<{ $isMobile: boolean, $hasLabel: boolean }>`
     }
 `;
 
-interface LinkProps {
+type RouterLinkProps = Pick<
+    ComponentPropsWithoutRef<typeof NavLink>,
+    'end'
+>;
+
+interface LinkProps extends RouterLinkProps {
     className?: string;
     disabled?: boolean;
-    end?: boolean;
     href: string;
     iconName?: IconName;
     label?: string;
@@ -66,7 +60,6 @@ export const RouteLink: VoidFunctionComponent<LinkProps> = ({
             $isMobile={isMobile}
             tabIndex={disabled ? -1 : 0}
             to={href}
-            type="route"
             onClick={onClick}
         >
             {iconName && <Icon aria-hidden="true" name={iconName} size="16" />}

--- a/packages/react/src/components/route-link/styles/styled-link.tsx
+++ b/packages/react/src/components/route-link/styles/styled-link.tsx
@@ -1,15 +1,10 @@
 import styled from 'styled-components';
-import { focus } from '../../../utils/css-state';
-
-type Type = 'external' | 'route';
+import { focus, focusVisibleReset } from '../../../utils/css-state';
 
 interface ContainerProps {
-    activeClassName?: string;
     disabled?: boolean;
-    end?: boolean;
     $hasLabel: boolean;
-    to?: string;
-    type: Type;
+    $isMobile: boolean;
 }
 
 export const StyledLink = styled.a<ContainerProps>`
@@ -17,13 +12,20 @@ export const StyledLink = styled.a<ContainerProps>`
     color: ${({ disabled, theme }) => (disabled ? theme.main['primary-1.2'] : theme.main['primary-1.1'])};
     cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
     display: inline-flex;
+    font-size: ${({ $isMobile }) => ($isMobile ? '1rem' : '0.875rem')};
     text-decoration: underline;
+
+    &:hover {
+        ${({ disabled, theme }) => (disabled ? '' : `color: ${theme.main['primary-1.3']};`)};
+    }
+
+    &:visited {
+        ${({ disabled }) => (disabled ? '' : 'color: #62a;')}; /* TODO change colors when updating thematization */
+    }
 
     ${focus};
 
-    &:focus:not(:focus-visible) {
-        box-shadow: none;
-    }
+    ${focusVisibleReset};
 
     ${({ theme }) => focus({ theme }, false, '&:focus-visible')}
 `;


### PR DESCRIPTION
DS-714

L'élément `<a>` généré par les composants `<RouteLink>` et `<ExternalLink>` contiennent un attribut `type` erroné. Cet attribut existe dans la spec mais devrait contenir un mimetype s'il est utilisé. L'attribut en question a été retiré car il n'était pas utilisé.

De plus, certains attributs sont désuets depuis la migration à react-router v6 (`activeClassName`).

Finalement, certaines déclarations de style étaient dupliquées dans plusieurs types de liens. Elles ont été ramenées dans le composant abstrait `<StyledLink>`.

**Tests fonctionnels**
- Tous les composants dont le snapshot a changé sont visuellement identiques dans le storybook