### PR TITLE
DS-708: Adds destructive & information modal variant

### DIFF
--- a/packages/react/src/components/modal/modal-dialog.test.tsx
+++ b/packages/react/src/components/modal/modal-dialog.test.tsx
@@ -3,7 +3,8 @@ import { doNothing } from '../../test-utils/callbacks';
 import { getByTestId as enzymeGetByTestId } from '../../test-utils/enzyme-selectors';
 import { mountWithProviders, renderPortalWithProviders } from '../../test-utils/renderer';
 import { DeviceType } from '../device-context-provider/device-context-provider';
-import { ModalDialog, ModalDialogProps } from './modal-dialog';
+import { ModalDialog, ModalDialogProps, ModalType } from './modal-dialog';
+import { IconName } from '../icon/icon';
 
 jest.mock('../../utils/uuid');
 
@@ -151,4 +152,39 @@ describe('Modal-Dialog', () => {
 
         expect(baseElement).toMatchSnapshot();
     });
+
+    test.each([
+        ['information-modal', 'alertFilled', 'primary', false],
+        ['action-modal', 'home', 'primary', true],
+        ['destructive-modal', 'alertFilled', 'destructive', true],
+    ])(
+        'should respect %s modalType with proper titleIcon and buttons',
+        (modalType, expectedIcon, expectedButtonType, hasCancelButton) => {
+            const wrapper = mountWithProviders(
+                <ModalDialog
+                    ariaHideApp={false}
+                    title="test"
+                    titleIcon={expectedIcon as IconName}
+                    isOpen
+                    modalType={modalType as ModalType}
+                    onRequestClose={jest.fn()}
+                >
+                    <p id="modal-description">Test Content</p>
+                </ModalDialog>,
+                { attachTo: document.body },
+            );
+
+            const titleIcon = enzymeGetByTestId(wrapper, 'title-icon');
+            expect(titleIcon.exists()).toBe(true);
+            expect(titleIcon.prop('name')).toBe(expectedIcon);
+
+            const confirmButton = enzymeGetByTestId(wrapper, 'confirm-button');
+            expect(confirmButton.prop('buttonType')).toBe(expectedButtonType);
+
+            const cancelButton = enzymeGetByTestId(wrapper, 'cancel-button');
+            expect(cancelButton.exists()).toBe(hasCancelButton);
+
+            wrapper.detach();
+        },
+    );
 });

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -10,6 +10,14 @@ import { Modal } from './modal';
 
 type MobileDeviceContextProps = Pick<DeviceContextProps, 'isMobile'>
 
+type ModalType = 'information-modal' | 'action-modal' | 'destructive-modal';
+
+const MODAL_ROLES: Record<ModalType, string> = {
+    'information-modal': 'dialog',
+    'action-modal': 'dialog',
+    'destructive-modal': 'alertdialog',
+};
+
 const StyledModal = styled(Modal)<{ $hasTitleIcon: boolean }>`
     ${({ $hasTitleIcon }) => $hasTitleIcon && css`
         padding-left: var(--spacing-4x);
@@ -79,6 +87,7 @@ export interface ModalDialogProps {
     subtitle?: string;
     title?: string;
     titleIcon?: IconName;
+    modalType?: ModalType;
 
     onRequestClose(): void;
 }
@@ -88,6 +97,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     ariaDescribedby,
     ariaHideApp,
     ariaLabel,
+    modalType = 'action-modal',
     cancelButton,
     children,
     className,
@@ -152,18 +162,22 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     }
 
     function getFooter(): ReactElement {
+        const confirmButtonType = modalType === 'destructive-modal' ? 'destructive' : 'primary';
+
         return (
             <ButtonContainer isMobile={isMobile} $hasTitleIcon={hasTitleIcon}>
-                <CancelButton
-                    data-testid="cancel-button"
-                    label={cancelButton?.label || t('cancelButtonLabel')}
-                    buttonType="tertiary"
-                    onClick={handleCancel}
-                />
+                {modalType !== 'information-modal' && (
+                    <CancelButton
+                        data-testid="cancel-button"
+                        label={cancelButton?.label || t('cancelButtonLabel')}
+                        buttonType="tertiary"
+                        onClick={handleCancel}
+                    />
+                )}
                 <ConfirmButton
                     data-testid="confirm-button"
                     label={confirmButton?.label || t('confirmButtonLabel')}
-                    buttonType="primary"
+                    buttonType={confirmButtonType}
                     onClick={handleConfirm}
                     isMobile={isMobile}
                 />
@@ -182,7 +196,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
             hasCloseButton={hasCloseButton}
             modalFooter={footerContent || getFooter()}
             parentSelector={parentSelector}
-            role="dialog"
+            role={MODAL_ROLES[modalType]}
             onAfterOpen={() => titleRef.current?.focus()}
             onRequestClose={onRequestClose}
             isOpen={isOpen}

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -116,7 +116,8 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     const { t } = useTranslation('modal-dialog');
     const titleId = useMemo(uuid, []);
     const titleRef: Ref<HTMLHeadingElement> = useRef(null);
-    const hasTitleIcon = !!(title && titleIcon);
+    const finalTitleIcon = modalType === 'destructive-modal' ? 'alertFilled' : titleIcon;
+    const hasTitleIcon = !!(title && finalTitleIcon);
 
     function handleConfirm(): void {
         confirmButton?.onConfirm?.();
@@ -138,8 +139,8 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
                 <>
                     {title && (
                         <HeadingWrapperComponent>
-                            {titleIcon && (
-                                <TitleIcon name={titleIcon} size="24" data-testid="title-icon" />
+                            {finalTitleIcon && (
+                                <TitleIcon name={finalTitleIcon} size="24" data-testid="title-icon" />
                             )}
                             <Heading
                                 id={titleId}

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -10,9 +10,9 @@ import { Modal } from './modal';
 
 type MobileDeviceContextProps = Pick<DeviceContextProps, 'isMobile'>
 
-type ModalType = 'information-modal' | 'action-modal' | 'destructive-modal';
+export type ModalType = 'information-modal' | 'action-modal' | 'destructive-modal';
 
-const MODAL_ROLES: Record<ModalType, string> = {
+const ModalRoles: Record<ModalType, string> = {
     'information-modal': 'dialog',
     'action-modal': 'dialog',
     'destructive-modal': 'alertdialog',
@@ -116,8 +116,8 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     const { t } = useTranslation('modal-dialog');
     const titleId = useMemo(uuid, []);
     const titleRef: Ref<HTMLHeadingElement> = useRef(null);
-    const finalTitleIcon = modalType === 'destructive-modal' ? 'alertFilled' : titleIcon;
-    const hasTitleIcon = !!(title && finalTitleIcon);
+    const titleIconName = modalType === 'destructive-modal' ? 'alertFilled' : titleIcon;
+    const hasTitleIcon = !!(title && titleIconName);
 
     function handleConfirm(): void {
         confirmButton?.onConfirm?.();
@@ -139,8 +139,8 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
                 <>
                     {title && (
                         <HeadingWrapperComponent>
-                            {finalTitleIcon && (
-                                <TitleIcon name={finalTitleIcon} size="24" data-testid="title-icon" />
+                            {titleIconName && (
+                                <TitleIcon name={titleIconName} size="24" data-testid="title-icon" />
                             )}
                             <Heading
                                 id={titleId}
@@ -197,7 +197,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
             hasCloseButton={hasCloseButton}
             modalFooter={footerContent || getFooter()}
             parentSelector={parentSelector}
-            role={MODAL_ROLES[modalType]}
+            role={ModalRoles[modalType]}
             onAfterOpen={() => titleRef.current?.focus()}
             onRequestClose={onRequestClose}
             isOpen={isOpen}

--- a/packages/storybook/stories/modal-dialog.stories.tsx
+++ b/packages/storybook/stories/modal-dialog.stories.tsx
@@ -346,7 +346,6 @@ export const DestructiveModal: Story = {
                     onRequestClose={closeModal}
                     title="Destructive Modal"
                     modalType="destructive-modal"
-                    titleIcon="alertFilled"
                 >
                     <p style={{ margin: 0 }} id="story-description">
                         This modal has a destructive button. It is used to destroy something.

--- a/packages/storybook/stories/modal-dialog.stories.tsx
+++ b/packages/storybook/stories/modal-dialog.stories.tsx
@@ -303,3 +303,56 @@ export const WithinShadowDOM: Story = {
         );
     },
 };
+
+export const InformationModal: Story = {
+    render: () => {
+        const { isModalOpen, closeModal, openModal } = useModal();
+        return (
+            <>
+                <Button label="Open Modal" buttonType="primary" onClick={openModal} />
+                <ModalDialog
+                    appElement="#storybook-root"
+                    ariaDescribedby="story-description"
+                    isOpen={isModalOpen}
+                    onRequestClose={closeModal}
+                    title="Information Modal"
+                    modalType="information-modal"
+                    confirmButton={{
+                        label: 'Got it',
+                    }}
+                >
+                    <p style={{ margin: 0 }} id="story-description">
+                        This modal has only one button. It is used to inform the user of something.
+                    </p>
+                </ModalDialog>
+            </>
+        );
+    },
+};
+
+export const DestructiveModal: Story = {
+    render: () => {
+        const { isModalOpen, closeModal, openModal } = useModal();
+        return (
+            <>
+                <Button label="Open Modal" buttonType="destructive" onClick={openModal} />
+                <ModalDialog
+                    appElement="#storybook-root"
+                    ariaDescribedby="story-description"
+                    confirmButton={{
+                        label: 'Delete',
+                    }}
+                    isOpen={isModalOpen}
+                    onRequestClose={closeModal}
+                    title="Destructive Modal"
+                    modalType="destructive-modal"
+                    titleIcon="alertFilled"
+                >
+                    <p style={{ margin: 0 }} id="story-description">
+                        This modal has a destructive button. It is used to destroy something.
+                    </p>
+                </ModalDialog>
+            </>
+        );
+    },
+};


### PR DESCRIPTION
:link: [DS-708](https://jira.equisoft.com/browse/DS-708)

## :clipboard: Description
Ajout d'un type: `ModalType = 'information-modal' | 'action-modal' | 'destructive-modal';`

- information-modal: Modale à un bouton. Pour le nouveau variant `Information`.
- Action-modal: Modale à deux boutons. Variant `Par défaut`.
- Destructive-modal: Modale par défaut à deux boutons. Le bouton principale est de type `destructive`. Pour le nouveau vairant `Alert`.

Ajout au Storybook des deux nouvelles variantes de modales.

## :test_tube: Tests fonctionnels
- [ ] Valider le bon fonctionnement des nouvelles variantes de modale avec le Storybook.

## :camera: Screenshots
Stories:
![image](https://github.com/kronostechnologies/design-elements/assets/132286421/c599d95c-a8f7-4d10-8413-df9de3cc63f9)

Information Modal:
![image](https://github.com/kronostechnologies/design-elements/assets/132286421/3fa952bc-32bf-481f-bff1-72d98ee7ca2d)

Destructive Modal:
![image](https://github.com/kronostechnologies/design-elements/assets/132286421/ad752894-363a-4f44-a8b6-c98533e96f46)
