### PR TITLE
DS-708: fix(ModalDialog): dialogType naming

### DIFF
--- a/packages/react/src/components/modal/modal-dialog.test.tsx
+++ b/packages/react/src/components/modal/modal-dialog.test.tsx
@@ -3,7 +3,7 @@ import { doNothing } from '../../test-utils/callbacks';
 import { getByTestId as enzymeGetByTestId } from '../../test-utils/enzyme-selectors';
 import { mountWithProviders, renderPortalWithProviders } from '../../test-utils/renderer';
 import { DeviceType } from '../device-context-provider/device-context-provider';
-import { ModalDialog, ModalDialogProps, ModalType } from './modal-dialog';
+import { ModalDialog, ModalDialogProps, DialogType } from './modal-dialog';
 import { IconName } from '../icon/icon';
 
 jest.mock('../../utils/uuid');
@@ -154,11 +154,11 @@ describe('Modal-Dialog', () => {
     });
 
     test.each([
-        ['information-modal', 'alertFilled', 'primary', false],
-        ['action-modal', 'home', 'primary', true],
-        ['destructive-modal', 'alertFilled', 'destructive', true],
+        ['information', 'alertFilled', 'primary', false],
+        ['action', 'home', 'primary', true],
+        ['alert', 'alertFilled', 'destructive', true],
     ])(
-        'should respect %s modalType with proper titleIcon and buttons',
+        'should respect %s dialogType with proper titleIcon and buttons',
         (modalType, expectedIcon, expectedButtonType, hasCancelButton) => {
             const wrapper = mountWithProviders(
                 <ModalDialog
@@ -166,7 +166,7 @@ describe('Modal-Dialog', () => {
                     title="test"
                     titleIcon={expectedIcon as IconName}
                     isOpen
-                    modalType={modalType as ModalType}
+                    dialogType={modalType as DialogType}
                     onRequestClose={jest.fn()}
                 >
                     <p id="modal-description">Test Content</p>

--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -10,12 +10,15 @@ import { Modal } from './modal';
 
 type MobileDeviceContextProps = Pick<DeviceContextProps, 'isMobile'>
 
-export type ModalType = 'information-modal' | 'action-modal' | 'destructive-modal';
+export type DialogType =
+    | 'information'
+    | 'action'
+    | 'alert';
 
-const ModalRoles: Record<ModalType, string> = {
-    'information-modal': 'dialog',
-    'action-modal': 'dialog',
-    'destructive-modal': 'alertdialog',
+const ModalRoles: Record<DialogType, string> = {
+    information: 'dialog',
+    action: 'dialog',
+    alert: 'alertdialog',
 };
 
 const StyledModal = styled(Modal)<{ $hasTitleIcon: boolean }>`
@@ -87,7 +90,7 @@ export interface ModalDialogProps {
     subtitle?: string;
     title?: string;
     titleIcon?: IconName;
-    modalType?: ModalType;
+    dialogType?: DialogType;
 
     onRequestClose(): void;
 }
@@ -97,7 +100,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     ariaDescribedby,
     ariaHideApp,
     ariaLabel,
-    modalType = 'action-modal',
+    dialogType = 'action',
     cancelButton,
     children,
     className,
@@ -116,7 +119,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     const { t } = useTranslation('modal-dialog');
     const titleId = useMemo(uuid, []);
     const titleRef: Ref<HTMLHeadingElement> = useRef(null);
-    const titleIconName = modalType === 'destructive-modal' ? 'alertFilled' : titleIcon;
+    const titleIconName = dialogType === 'alert' ? 'alertFilled' : titleIcon;
     const hasTitleIcon = !!(title && titleIconName);
 
     function handleConfirm(): void {
@@ -163,11 +166,11 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
     }
 
     function getFooter(): ReactElement {
-        const confirmButtonType = modalType === 'destructive-modal' ? 'destructive' : 'primary';
+        const confirmButtonType = dialogType === 'alert' ? 'destructive' : 'primary';
 
         return (
             <ButtonContainer isMobile={isMobile} $hasTitleIcon={hasTitleIcon}>
-                {modalType !== 'information-modal' && (
+                {dialogType !== 'information' && (
                     <CancelButton
                         data-testid="cancel-button"
                         label={cancelButton?.label || t('cancelButtonLabel')}
@@ -197,7 +200,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
             hasCloseButton={hasCloseButton}
             modalFooter={footerContent || getFooter()}
             parentSelector={parentSelector}
-            role={ModalRoles[modalType]}
+            role={ModalRoles[dialogType]}
             onAfterOpen={() => titleRef.current?.focus()}
             onRequestClose={onRequestClose}
             isOpen={isOpen}

--- a/packages/storybook/stories/modal-dialog.stories.tsx
+++ b/packages/storybook/stories/modal-dialog.stories.tsx
@@ -304,7 +304,7 @@ export const WithinShadowDOM: Story = {
     },
 };
 
-export const InformationModal: Story = {
+export const InformationDialog: Story = {
     render: () => {
         const { isModalOpen, closeModal, openModal } = useModal();
         return (
@@ -316,7 +316,7 @@ export const InformationModal: Story = {
                     isOpen={isModalOpen}
                     onRequestClose={closeModal}
                     title="Information Modal"
-                    modalType="information-modal"
+                    dialogType="information"
                     confirmButton={{
                         label: 'Got it',
                     }}
@@ -330,7 +330,7 @@ export const InformationModal: Story = {
     },
 };
 
-export const DestructiveModal: Story = {
+export const AlertDialog: Story = {
     render: () => {
         const { isModalOpen, closeModal, openModal } = useModal();
         return (
@@ -344,11 +344,11 @@ export const DestructiveModal: Story = {
                     }}
                     isOpen={isModalOpen}
                     onRequestClose={closeModal}
-                    title="Destructive Modal"
-                    modalType="destructive-modal"
+                    title="Alert Modal"
+                    dialogType="alert"
                 >
                     <p style={{ margin: 0 }} id="story-description">
-                        This modal has a destructive button. It is used to destroy something.
+                        This modal has a destructive button. It is used to alert the user of something.
                     </p>
                 </ModalDialog>
             </>


### PR DESCRIPTION
[DS-708](https://jira.equisoft.com/browse/DS-708)

## Description
Suite à quelques révisions, un renommage de `ModalType` pour `DialogType` était nécessaire et plus approprié.
Ainsi, un renommage du type `destructive` à `alert` était nécessaire et plus approprié pour l'uniformité.

## Tests fonctionnels
- [ ] Valider que le renommage a bien été fait et que ModalDialog s'instancie correctement dans le Storybook
