### PR TITLE
chore(yarn): use pnp strict mode

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,9 +13,25 @@ packageExtensions:
   "@equisoft/design-elements-react@*":
     dependencies:
       core-js: "*"
+  "@radix-ui/react-select@*":
+    dependencies:
+      react-dom: "^17"
+  "@storybook/components@*":
+    dependencies:
+      react: "^17"
+      react-dom: "^17"
   "@storybook/core-common@*":
     dependencies:
       "@storybook/react-webpack5": "*"
+  "@storybook/react@*":
+    dependencies:
+      react: "^17"
+  "@storybook/react-dom-shim@*":
+    dependencies:
+      react-dom: "^17"
+  "@storybook/theming@*":
+    dependencies:
+      react: "^17"
   react-shadow@*:
     peerDependencies:
       styled-components: "*"
@@ -29,7 +45,5 @@ plugins:
     spec: "@yarnpkg/plugin-workspace-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-licenses-audit.cjs
     spec: "https://raw.githubusercontent.com/tophat/yarn-plugin-licenses/master/bundles/@yarnpkg/plugin-licenses-audit.js"
-
-pnpMode: loose
 
 yarnPath: .yarn/releases/yarn-3.6.1.cjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -13702,7 +13702,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:~17.0.2":
+"react-dom@npm:^17, react-dom@npm:~17.0.2":
   version: 17.0.2
   resolution: "react-dom@npm:17.0.2"
   dependencies:
@@ -13975,7 +13975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:~17.0.2":
+"react@npm:^17, react@npm:~17.0.2":
   version: 17.0.2
   resolution: "react@npm:17.0.2"
   dependencies:


### PR DESCRIPTION
Met Yarn PnP en mode strict, ce qui enlève les erreurs [MODULE_NOT_FOUND] lors de la compilation et des tests. Les problèmes de dépendances de Storybook ont pu être contournées via les packageExtensions.

Par contre, c'était nécessaire de spécifier une version majeure pour éviter que les nouvelles dépendances pointent vers react 18. Il faudra penser à mettre ça à jour quand on changera de version majeure.