### PR TITLE
chore: fix useLayoutEffect errors in tests

### DIFF
--- a/packages/react/test/setup.ts
+++ b/packages/react/test/setup.ts
@@ -12,3 +12,8 @@ jest.mock('any.scss', () => ({
     unuse: jest.fn(),
     toString: () => 'body {}',
 }));
+
+jest.mock('react', () => ({
+    ...jest.requireActual('react'),
+    useLayoutEffect: jest.requireActual('react').useEffect,
+}));


### PR DESCRIPTION
Empêche l'affichage de nombreuses erreurs à propos de `useLayoutEffect` lors de l'exécution des tests.

Le output des test sera pas mal plus utilisable après ça!