### PR TITLE
fix(Tooltip): some border artifacts from inverted

### DIFF
--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 
 .c1 {
   background-color: #60666E;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #60666E;
   border-radius: var(--border-radius-half);
   box-shadow: 0 10px 20px 0 rgb(0 0 0 / 19%);
   box-sizing: border-box;
@@ -64,7 +64,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="bottom"] > .c2::before {
-  border-color: transparent transparent #FFFFFF transparent;
+  border-color: transparent transparent #60666E transparent;
   border-width: 0 0.5rem 0.5rem;
   position: absolute;
   top: -2px;
@@ -84,7 +84,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="top"] > .c2::before {
-  border-color: #FFFFFF transparent transparent transparent;
+  border-color: #60666E transparent transparent transparent;
   border-width: 0.5rem 0.5rem 0;
   position: absolute;
   top: 0;
@@ -104,7 +104,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="right"] > .c2::before {
-  border-color: transparent #FFFFFF transparent transparent;
+  border-color: transparent #60666E transparent transparent;
   border-width: 0.5rem 0.5rem 0.5rem 0;
 }
 
@@ -123,7 +123,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="left"] > .c2::before {
-  border-color: transparent transparent transparent #FFFFFF;
+  border-color: transparent transparent transparent #60666E;
   border-width: 0.5rem 0 0.5rem 0.5rem;
 }
 
@@ -203,6 +203,7 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
     aria-hidden={false}
     data-popper-interactive={false}
     data-testid="tooltip-content-container"
+    inverted={false}
     isMobile={false}
     role="tooltip"
     style={
@@ -280,7 +281,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 
 .c1 {
   background-color: #60666E;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #60666E;
   border-radius: var(--border-radius-half);
   box-shadow: 0 10px 20px 0 rgb(0 0 0 / 19%);
   box-sizing: border-box;
@@ -313,7 +314,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 }
 
 .c1[data-popper-placement*="bottom"] > .c2::before {
-  border-color: transparent transparent #FFFFFF transparent;
+  border-color: transparent transparent #60666E transparent;
   border-width: 0 0.5rem 0.5rem;
   position: absolute;
   top: -2px;
@@ -333,7 +334,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 }
 
 .c1[data-popper-placement*="top"] > .c2::before {
-  border-color: #FFFFFF transparent transparent transparent;
+  border-color: #60666E transparent transparent transparent;
   border-width: 0.5rem 0.5rem 0;
   position: absolute;
   top: 0;
@@ -353,7 +354,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 }
 
 .c1[data-popper-placement*="right"] > .c2::before {
-  border-color: transparent #FFFFFF transparent transparent;
+  border-color: transparent #60666E transparent transparent;
   border-width: 0.5rem 0.5rem 0.5rem 0;
 }
 
@@ -372,7 +373,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
 }
 
 .c1[data-popper-placement*="left"] > .c2::before {
-  border-color: transparent transparent transparent #FFFFFF;
+  border-color: transparent transparent transparent #60666E;
   border-width: 0.5rem 0 0.5rem 0.5rem;
 }
 
@@ -451,6 +452,7 @@ exports[`Tooltip Has default desktop styles 1`] = `
     aria-hidden={true}
     data-popper-interactive={false}
     data-testid="tooltip-content-container"
+    inverted={false}
     isMobile={false}
     role="tooltip"
     style={
@@ -528,7 +530,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 
 .c1 {
   background-color: #60666E;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #60666E;
   border-radius: var(--border-radius-half);
   box-shadow: 0 10px 20px 0 rgb(0 0 0 / 19%);
   box-sizing: border-box;
@@ -564,7 +566,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="bottom"] > .c2::before {
-  border-color: transparent transparent #FFFFFF transparent;
+  border-color: transparent transparent #60666E transparent;
   border-width: 0 0.5rem 0.5rem;
   position: absolute;
   top: -2px;
@@ -584,7 +586,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="top"] > .c2::before {
-  border-color: #FFFFFF transparent transparent transparent;
+  border-color: #60666E transparent transparent transparent;
   border-width: 0.5rem 0.5rem 0;
   position: absolute;
   top: 0;
@@ -604,7 +606,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="right"] > .c2::before {
-  border-color: transparent #FFFFFF transparent transparent;
+  border-color: transparent #60666E transparent transparent;
   border-width: 0.5rem 0.5rem 0.5rem 0;
 }
 
@@ -623,7 +625,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
 }
 
 .c1[data-popper-placement*="left"] > .c2::before {
-  border-color: transparent transparent transparent #FFFFFF;
+  border-color: transparent transparent transparent #60666E;
   border-width: 0.5rem 0 0.5rem 0.5rem;
 }
 
@@ -703,6 +705,7 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
     aria-hidden={false}
     data-popper-interactive={false}
     data-testid="tooltip-content-container"
+    inverted={false}
     isMobile={true}
     role="tooltip"
     style={
@@ -780,7 +783,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 
 .c1 {
   background-color: #60666E;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #60666E;
   border-radius: var(--border-radius-half);
   box-shadow: 0 10px 20px 0 rgb(0 0 0 / 19%);
   box-sizing: border-box;
@@ -813,7 +816,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 }
 
 .c1[data-popper-placement*="bottom"] > .c2::before {
-  border-color: transparent transparent #FFFFFF transparent;
+  border-color: transparent transparent #60666E transparent;
   border-width: 0 0.5rem 0.5rem;
   position: absolute;
   top: -2px;
@@ -833,7 +836,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 }
 
 .c1[data-popper-placement*="top"] > .c2::before {
-  border-color: #FFFFFF transparent transparent transparent;
+  border-color: #60666E transparent transparent transparent;
   border-width: 0.5rem 0.5rem 0;
   position: absolute;
   top: 0;
@@ -853,7 +856,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 }
 
 .c1[data-popper-placement*="right"] > .c2::before {
-  border-color: transparent #FFFFFF transparent transparent;
+  border-color: transparent #60666E transparent transparent;
   border-width: 0.5rem 0.5rem 0.5rem 0;
 }
 
@@ -872,7 +875,7 @@ exports[`Tooltip Has mobile styles 1`] = `
 }
 
 .c1[data-popper-placement*="left"] > .c2::before {
-  border-color: transparent transparent transparent #FFFFFF;
+  border-color: transparent transparent transparent #60666E;
   border-width: 0.5rem 0 0.5rem 0.5rem;
 }
 
@@ -951,6 +954,7 @@ exports[`Tooltip Has mobile styles 1`] = `
     aria-hidden={true}
     data-popper-interactive={false}
     data-testid="tooltip-content-container"
+    inverted={false}
     isMobile={true}
     role="tooltip"
     style={

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -41,9 +41,9 @@ const TooltipArrow = styled.div`
     }
 `;
 
-const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
+const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean, inverted: boolean }>`
     background-color: ${({ theme }) => theme.greys['dark-grey']};
-    border: 1px solid ${({ theme }) => theme.greys.white};
+    border: 1px solid ${({ theme, inverted }) => (inverted ? theme.greys.white : theme.greys['dark-grey'])};
     border-radius: var(--border-radius-half);
     box-shadow: 0 10px 20px 0 rgb(0 0 0 / 19%);
     box-sizing: border-box;
@@ -69,7 +69,7 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
     }
 
     &[data-popper-placement*="bottom"] > ${TooltipArrow}::before {
-        border-color: transparent transparent ${({ theme }) => theme.greys.white} transparent;
+        border-color: transparent transparent ${({ theme, inverted }) => (inverted ? theme.greys.white : theme.greys['dark-grey'])} transparent;
         border-width: 0 0.5rem 0.5rem;
         position: absolute;
         top: -2px;
@@ -89,7 +89,7 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
     }
 
     &[data-popper-placement*="top"] > ${TooltipArrow}::before {
-        border-color: ${({ theme }) => theme.greys.white} transparent transparent transparent;
+        border-color: ${({ theme, inverted }) => (inverted ? theme.greys.white : theme.greys['dark-grey'])} transparent transparent transparent;
         border-width: 0.5rem 0.5rem 0;
         position: absolute;
         top: 0;
@@ -109,7 +109,7 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
     }
 
     &[data-popper-placement*="right"] > ${TooltipArrow}::before {
-        border-color: transparent ${({ theme }) => theme.greys.white} transparent transparent;
+        border-color: transparent ${({ theme, inverted }) => (inverted ? theme.greys.white : theme.greys['dark-grey'])} transparent transparent;
         border-width: 0.5rem 0.5rem 0.5rem 0;
     }
 
@@ -128,7 +128,7 @@ const TooltipContainer = styled.div<{ isMobile?: boolean, visible: boolean }>`
     }
 
     &[data-popper-placement*="left"] > ${TooltipArrow}::before {
-        border-color: transparent transparent transparent ${({ theme }) => theme.greys.white};
+        border-color: transparent transparent transparent ${({ theme, inverted }) => (inverted ? theme.greys.white : theme.greys['dark-grey'])};
         border-width: 0.5rem 0 0.5rem 0.5rem;
     }
 
@@ -318,6 +318,7 @@ export const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
                 role="tooltip"
                 ref={popperTooltip.setTooltipRef}
                 visible={popperTooltip.visible}
+                inverted={invertedIcon}
                 {...popperTooltip.getTooltipProps() /* eslint-disable-line react/jsx-props-no-spreading */}
             >
                 <TooltipArrow


### PR DESCRIPTION
Le white border ne devrait pas être là si on est pas en mode inverted
![Disclosure___Tooltip_-_Docs_⋅_Storybook](https://github.com/kronostechnologies/design-elements/assets/5271680/9989ea51-9914-4508-af8a-077575273b6f)
