### PR TITLE
feat(TextInput): add valid prop to TextInput

### DIFF
--- a/packages/react/src/components/text-input/text-input.test.tsx
+++ b/packages/react/src/components/text-input/text-input.test.tsx
@@ -62,6 +62,20 @@ describe('TextInput', () => {
         expect(container.prop('valid')).toBe(false);
     });
 
+    test('should set as invalid when valid prop is false', () => {
+        const wrapper = shallow(<TextInput valid={false} />);
+
+        const container = getByTestId(wrapper, 'field-container');
+        expect(container.prop('valid')).toBe(false);
+    });
+
+    test('should set as valid when valid prop is true', () => {
+        const wrapper = shallow(<TextInput valid />);
+
+        const container = getByTestId(wrapper, 'field-container');
+        expect(container.prop('valid')).toBe(true);
+    });
+
     test('onChange callback is called when content is changed', () => {
         const callback = jest.fn();
         const wrapper = setup(callback);

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -10,6 +10,7 @@ import {
     ReactElement,
     Ref,
     useCallback,
+    useEffect,
     useMemo,
     useState,
 } from 'react';
@@ -44,6 +45,7 @@ interface TextInputProps extends PartialInputProps {
     placeholder?: string;
     required?: boolean;
     type?: string;
+    valid?: boolean;
     validationErrorMessage?: string;
     hint?: string;
 
@@ -77,6 +79,7 @@ export const TextInput = forwardRef(({
     placeholder,
     required,
     type,
+    valid,
     validationErrorMessage,
     value,
     autoComplete,
@@ -90,7 +93,7 @@ export const TextInput = forwardRef(({
 }: TextInputProps, ref: Ref<HTMLInputElement>): ReactElement => {
     const { isMobile } = useDeviceContext();
     const { t } = useTranslation('text-input');
-    const [{ validity }, setValidity] = useState({ validity: true });
+    const [{ validity }, setValidity] = useState({ validity: valid ?? true });
     const id = useMemo(() => providedId || uuid(), [providedId]);
     const dataAttributes = useDataAttributes(otherProps);
 
@@ -117,6 +120,12 @@ export const TextInput = forwardRef(({
             onFocus(event);
         }
     }, [onFocus]);
+
+    useEffect(() => {
+        if (valid !== undefined) {
+            setValidity({ validity: valid });
+        }
+    }, [valid]);
 
     return (
         <FieldContainer

--- a/packages/storybook/stories/text-input.stories.tsx
+++ b/packages/storybook/stories/text-input.stories.tsx
@@ -1,6 +1,6 @@
 import { Button, TextInput } from '@equisoft/design-elements-react';
 import { StoryFn as Story } from '@storybook/react';
-import { FormEventHandler } from 'react';
+import { FormEventHandler, useState } from 'react';
 import { rawCodeParameters } from './utils/parameters';
 
 export default {
@@ -108,6 +108,37 @@ export const RequiredInForm: Story = () => {
                 label="Last Name"
                 type="text"
                 validationErrorMessage="This field is required"
+            />
+            <Button type="submit" buttonType="primary">Submit</Button>
+        </form>
+    );
+};
+
+export const FormWithCustomValidation: Story = () => {
+    const [value, setValue] = useState('REFERRAL-111');
+    const [valid, setValid] = useState(true);
+    const validate = (): void => {
+        if (value === 'REFERRAL-111') {
+            setValid(false);
+        } else {
+            setValid(true);
+        }
+    };
+
+    const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
+        event.preventDefault();
+        validate();
+    };
+
+    return (
+        <form noValidate onSubmit={handleSubmit}>
+            <TextInput
+                label="Enter your referral number (REFERRAL-111 already exists)"
+                type="text"
+                value={value}
+                onChange={(event) => setValue(event.currentTarget.value)}
+                valid={valid}
+                validationErrorMessage="This referral number already exists"
             />
             <Button type="submit" buttonType="primary">Submit</Button>
         </form>


### PR DESCRIPTION
[DS-822](https://jira.equisoft.com/browse/DS-822)

Jusqu'à maintenant, TextInput affichait le message d'erreur quand:
- le champ est vide avec l'attribut `required`.
- la valeur du champ ne respecte pas le pattern de l'attribut `pattern`.

Ajout d'un attribut `valid` pour contrôler l'affichage du message d'erreur pour une validation personnalisée.