### PR TITLE
feat(MenuButton): groups and icons

### DIFF
--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -7,7 +7,7 @@ import { Icon, IconName } from '../icon/icon';
 import { Menu, MenuOption } from '../menu/menu';
 import { eventIsInside } from '../../utils/events';
 
-export type MenuDirection = 'right' | 'left';
+export type MenuPlacement = 'right' | 'left';
 
 const StyledContainer = styled.div`
     position: relative;
@@ -17,14 +17,14 @@ const StyledMenu = styled(Menu)`
     max-width: ${menuDimensions.maxWidth};
     min-width: ${menuDimensions.minWidth};
     position: absolute;
-    ${({ direction }) => (direction === 'left' ? 'right: 0;' : 'left: 0;')}
+    ${({ $placement }) => ($placement === 'left' ? 'right: 0;' : 'left: 0;')}
 `;
 
 const StyledIcon = styled(Icon)`
     margin-left: var(--spacing-1x);
 `;
 
-interface Props {
+export interface MenuButtonProps {
     autofocus?: boolean;
     buttonType: ButtonType;
     className?: string;
@@ -33,10 +33,10 @@ interface Props {
     inverted?: boolean;
     options: MenuOption[];
     onMenuVisibilityChanged?(isOpen: boolean): void;
-    menuDirection?: MenuDirection;
+    menuPlacement?: MenuPlacement;
 }
 
-export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
+export const MenuButton: FunctionComponent<PropsWithChildren<MenuButtonProps>> = ({
     autofocus,
     buttonType,
     children,
@@ -46,7 +46,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
     inverted,
     options,
     onMenuVisibilityChanged,
-    menuDirection = 'right',
+    menuPlacement = 'right',
 }) => {
     const [visible, setVisible] = useState(!!defaultOpen);
     const [initialFocusIndex, setInitialFocusIndex] = useState(0);
@@ -123,6 +123,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
                     autofocus={autofocus}
                     data-testid="menu-button"
                     type="button"
+                    aria-label="Menu"
                     aria-haspopup="menu"
                     aria-expanded={visible}
                     buttonType={buttonType}
@@ -153,7 +154,7 @@ export const MenuButton: FunctionComponent<PropsWithChildren<Props>> = ({
             )}
             {visible && (
                 <StyledMenu
-                    direction={menuDirection}
+                    $placement={menuPlacement}
                     options={options}
                     initialFocusIndex={initialFocusIndex}
                     onOptionSelect={handleOnOptionSelect}

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -4,7 +4,7 @@ import { menuDimensions } from '../../tokens/menuDimensions';
 import { Button, ButtonType } from '../buttons/button';
 import { IconButton } from '../buttons/icon-button';
 import { Icon, IconName } from '../icon/icon';
-import { Menu, MenuOption } from '../menu/menu';
+import { Menu, MenuItem } from '../menu/menu';
 import { eventIsInside } from '../../utils/events';
 
 export type MenuPlacement = 'right' | 'left';
@@ -31,7 +31,7 @@ export interface MenuButtonProps {
     defaultOpen?: boolean;
     iconName?: IconName;
     inverted?: boolean;
-    options: MenuOption[];
+    options: MenuItem[];
     onMenuVisibilityChanged?(isOpen: boolean): void;
     menuPlacement?: MenuPlacement;
 }

--- a/packages/react/src/components/menu/menu.test.tsx
+++ b/packages/react/src/components/menu/menu.test.tsx
@@ -1,8 +1,10 @@
 import ReactDOM from 'react-dom';
 import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { expectFocusToBeOn } from '../../test-utils/enzyme-utils';
-import { mountWithTheme } from '../../test-utils/renderer';
+import { mountWithTheme, renderWithTheme } from '../../test-utils/renderer';
 import { Menu, MenuOption } from './menu';
+
+jest.mock('../../utils/uuid');
 
 function givenOptions(): MenuOption[] {
     return [
@@ -48,7 +50,7 @@ describe('Menu', () => {
         optionsWithSubMenu = givenOptionsWithSubMenu(options);
     });
 
-    it('should call onClick callback when option is clicked', () => {
+    test('should call onClick callback when option is clicked', () => {
         const wrapper = mountWithTheme(<Menu options={options} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('click');
@@ -56,7 +58,7 @@ describe('Menu', () => {
         expect(options[0].onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should call onKeyDown callback when a key is pressed inside menu', () => {
+    test('should call onKeyDown callback when a key is pressed inside menu', () => {
         const callback = jest.fn();
         const wrapper = mountWithTheme(<Menu options={options} onKeyDown={callback} />);
 
@@ -65,7 +67,7 @@ describe('Menu', () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    it('should call onOptionSelect callback when an option is selected', () => {
+    test('should call onOptionSelect callback when an option is selected', () => {
         const callback = jest.fn();
         const wrapper = mountWithTheme(<Menu options={options} onOptionSelect={callback} />);
 
@@ -74,7 +76,7 @@ describe('Menu', () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    it('should open subMenu when option is clicked given option as subMenu', () => {
+    test('should open subMenu when option is clicked given option as subMenu', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('click');
@@ -82,7 +84,7 @@ describe('Menu', () => {
         expect(getByTestId(wrapper, 'menu-option-0-sub-menu').exists()).toBe(true);
     });
 
-    it('should open subMenu when ArrowRight key is pressed given option as subMenu', () => {
+    test('should open subMenu when ArrowRight key is pressed given option as subMenu', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} initialFocusIndex={0} />);
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'ArrowRight' });
@@ -90,7 +92,7 @@ describe('Menu', () => {
         expect(getByTestId(wrapper, 'menu-option-0-sub-menu').exists()).toBe(true);
     });
 
-    it('should open subMenu when mouse enters given option as subMenu', () => {
+    test('should open subMenu when mouse enters given option as subMenu', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('mouseEnter');
@@ -98,7 +100,7 @@ describe('Menu', () => {
         expect(getByTestId(wrapper, 'menu-option-0-sub-menu').exists()).toBe(true);
     });
 
-    it('should collapse subMenu when mouse leaves given option as subMenu', () => {
+    test('should collapse subMenu when mouse leaves given option as subMenu', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('mouseEnter');
@@ -107,7 +109,7 @@ describe('Menu', () => {
         expect(getByTestId(wrapper, 'menu-option-0-sub-menu').exists()).toBe(false);
     });
 
-    it('subMenu should stay open when mouse enters', () => {
+    test('subMenu should stay open when mouse enters', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('mouseEnter');
@@ -116,7 +118,7 @@ describe('Menu', () => {
         expect(getByTestId(wrapper, 'menu-option-0-sub-menu').exists()).toBe(true);
     });
 
-    it('subMenu should close when mouse leaves', () => {
+    test('subMenu should close when mouse leaves', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu-option-0').simulate('mouseEnter');
@@ -125,7 +127,7 @@ describe('Menu', () => {
         expect(getByTestId(wrapper, 'menu-option-0-sub-menu').exists()).toBe(false);
     });
 
-    it('should collapse subMenu when ArrowLeft key is pressed inside subMenu', () => {
+    test('should collapse subMenu when ArrowLeft key is pressed inside subMenu', () => {
         const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} initialFocusIndex={0} />);
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'ArrowRight' });
@@ -145,7 +147,7 @@ describe('Menu', () => {
             ReactDOM.unmountComponentAtNode(divElement);
         });
 
-        it('should be on the first option when initialFocus is set to 0', () => {
+        test('should be on the first option when initialFocus is set to 0', () => {
             const wrapper = mountWithTheme(
                 <div id="root">
                     <Menu options={options} initialFocusIndex={0} />
@@ -156,7 +158,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, 'menu-option-0'));
         });
 
-        it('should be on the next option when ArrowDown key is pressed', () => {
+        test('should be on the next option when ArrowDown key is pressed', () => {
             const wrapper = mountWithTheme(
                 <Menu options={options} initialFocusIndex={0} />,
                 { attachTo: divElement },
@@ -167,7 +169,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, 'menu-option-1'));
         });
 
-        it('should be on the first option when ArrowDown key is pressed on last option', () => {
+        test('should be on the first option when ArrowDown key is pressed on last option', () => {
             const wrapper = mountWithTheme(
                 <Menu options={options} initialFocusIndex={options.length - 1} />,
                 { attachTo: divElement },
@@ -178,7 +180,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, 'menu-option-0'));
         });
 
-        it('should be on the previous option when ArrowUp key is pressed', () => {
+        test('should be on the previous option when ArrowUp key is pressed', () => {
             const wrapper = mountWithTheme(
                 <Menu options={options} initialFocusIndex={1} />,
                 { attachTo: divElement },
@@ -189,7 +191,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, `menu-option-${0}`));
         });
 
-        it('should be on the last option when ArrowUp key is pressed on first option', () => {
+        test('should be on the last option when ArrowUp key is pressed on first option', () => {
             const wrapper = mountWithTheme(
                 <Menu options={options} initialFocusIndex={0} />,
                 { attachTo: divElement },
@@ -200,7 +202,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, `menu-option-${options.length - 1}`));
         });
 
-        it('should be on the first option starting with typed character', () => {
+        test('should be on the first option starting with typed character', () => {
             const wrapper = mountWithTheme(
                 <Menu options={options} initialFocusIndex={0} />,
                 { attachTo: divElement },
@@ -211,7 +213,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, 'menu-option-2'));
         });
 
-        it('should be on the first element of subMenu when ArrowRight key is pressed given option as subMenu', () => {
+        test('should be on the first element of subMenu when ArrowRight key is pressed given option as subMenu', () => {
             const wrapper = mountWithTheme(
                 <Menu options={optionsWithSubMenu} initialFocusIndex={0} />,
                 { attachTo: divElement },
@@ -222,7 +224,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, 'sub-menu-option-0'));
         });
 
-        it('should be on the subMenu parent option when ArrowLeft key is pressed inside subMenu', () => {
+        test('should be on the subMenu parent option when ArrowLeft key is pressed inside subMenu', () => {
             const wrapper = mountWithTheme(
                 <Menu options={optionsWithSubMenu} initialFocusIndex={0} />,
                 { attachTo: divElement },
@@ -234,7 +236,7 @@ describe('Menu', () => {
             expectFocusToBeOn(getByTestId(wrapper, 'menu-option-0'));
         });
 
-        it('should stay inside the menu when the subMenu is open by hovering with the mouse', () => {
+        test('should stay inside the menu when the subMenu is open by hovering with the mouse', () => {
             const wrapper = mountWithTheme(
                 <Menu options={optionsWithSubMenu} initialFocusIndex={0} />,
                 { attachTo: divElement },
@@ -244,5 +246,51 @@ describe('Menu', () => {
 
             expectFocusToBeOn(getByTestId(wrapper, 'menu-option-0'));
         });
+    });
+
+    test('matches the snapshot (menu with icons)', () => {
+        const tree = renderWithTheme(<Menu
+            options={[
+                {
+                    label: 'Option 1',
+                    iconName: 'check',
+                },
+                {
+                    label: 'Option 2',
+                    iconName: 'settings',
+                },
+            ]}
+        />);
+        expect(tree).toMatchSnapshot();
+    });
+
+    test('matches the snapshot (menu with groups)', () => {
+        const tree = renderWithTheme(<Menu
+            options={[
+                {
+                    groupLabel: 'Group 1',
+                    groupOptions: [
+                        {
+                            label: 'Option 1.1',
+                        },
+                        {
+                            label: 'Option 1.2',
+                        },
+                    ],
+                },
+                {
+                    groupLabel: 'Group 2',
+                    groupOptions: [
+                        {
+                            label: 'Option 2.1',
+                        },
+                        {
+                            label: 'Option 2.2',
+                        },
+                    ],
+                },
+            ]}
+        />);
+        expect(tree).toMatchSnapshot();
     });
 });

--- a/packages/react/src/components/menu/menu.test.tsx.snap
+++ b/packages/react/src/components/menu/menu.test.tsx.snap
@@ -1,0 +1,272 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Menu matches the snapshot (menu with groups) 1`] = `
+.c0 {
+  background-color: #FFFFFF;
+  border: 1px solid #878f9a;
+  border-radius: var(--border-radius);
+  box-shadow: 0 8px 16px 0 rgb(0 0 0 / 10%);
+  box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  max-height: calc(var(--spacing-half) + 128px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: var(--spacing-half) 0;
+  -webkit-scroll-behavior: smooth;
+  -moz-scroll-behavior: smooth;
+  -ms-scroll-behavior: smooth;
+  scroll-behavior: smooth;
+  width: 100%;
+}
+
+.c2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  gap: var(--spacing-1x);
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c2:focus {
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+  outline: none;
+}
+
+.c2:hover {
+  background-color: #DBDEE1;
+}
+
+.c1 {
+  color: #60666e;
+  display: block;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  overflow: hidden;
+  padding: var(--spacing-base) var(--spacing-2x) var(--spacing-half);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c3 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+<div
+  class="c0"
+  data-testid="menu"
+  role="menu"
+>
+  <div
+    aria-labelledby="menu-group-0"
+    role="group"
+  >
+    <span
+      class="c1"
+      id="menu-group-0"
+    >
+      Group 1
+    </span>
+    <button
+      class="c2"
+      data-testid="sub-menu-option-0"
+      role="menuitem"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class="c3"
+      >
+        Option 1.1
+      </span>
+    </button>
+    <button
+      class="c2"
+      data-testid="sub-menu-option-1"
+      role="menuitem"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class="c3"
+      >
+        Option 1.2
+      </span>
+    </button>
+  </div>
+  <div
+    aria-labelledby="menu-group-1"
+    role="group"
+  >
+    <span
+      class="c1"
+      id="menu-group-1"
+    >
+      Group 2
+    </span>
+    <button
+      class="c2"
+      data-testid="sub-menu-option-0"
+      role="menuitem"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class="c3"
+      >
+        Option 2.1
+      </span>
+    </button>
+    <button
+      class="c2"
+      data-testid="sub-menu-option-1"
+      role="menuitem"
+      tabindex="-1"
+      type="button"
+    >
+      <span
+        class="c3"
+      >
+        Option 2.2
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`Menu matches the snapshot (menu with icons) 1`] = `
+.c0 {
+  background-color: #FFFFFF;
+  border: 1px solid #878f9a;
+  border-radius: var(--border-radius);
+  box-shadow: 0 8px 16px 0 rgb(0 0 0 / 10%);
+  box-sizing: border-box;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  margin: 0;
+  max-height: calc(var(--spacing-half) + 128px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: var(--spacing-half) 0;
+  -webkit-scroll-behavior: smooth;
+  -moz-scroll-behavior: smooth;
+  -ms-scroll-behavior: smooth;
+  scroll-behavior: smooth;
+  width: 100%;
+}
+
+.c1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  cursor: pointer;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  gap: var(--spacing-1x);
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  text-align: left;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  width: 100%;
+}
+
+.c1:focus {
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+  outline: none;
+}
+
+.c1:hover {
+  background-color: #DBDEE1;
+}
+
+.c3 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c2 {
+  width: 16px;
+}
+
+<div
+  class="c0"
+  data-testid="menu"
+  role="menu"
+>
+  <button
+    class="c1"
+    data-testid="menu-option-0"
+    role="menuitem"
+    tabindex="-1"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c2"
+      color="#60666E"
+      focusable="false"
+      height="16"
+      width="16"
+    />
+    <span
+      class="c3"
+    >
+      Option 1
+    </span>
+  </button>
+  <button
+    class="c1"
+    data-testid="menu-option-1"
+    role="menuitem"
+    tabindex="-1"
+    type="button"
+  >
+    <svg
+      aria-hidden="true"
+      class="c2"
+      color="#60666E"
+      focusable="false"
+      height="16"
+      width="16"
+    />
+    <span
+      class="c3"
+    >
+      Option 2
+    </span>
+  </button>
+</div>
+`;

--- a/packages/react/src/components/menu/menu.tsx
+++ b/packages/react/src/components/menu/menu.tsx
@@ -136,7 +136,7 @@ export interface MenuGroup {
     groupOptions: MenuOption[];
 }
 
-type MenuItem = MenuGroup | MenuOption;
+export type MenuItem = MenuGroup | MenuOption;
 
 interface ListOption extends MenuOption {
     focusIndex: number,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,7 @@
 export { Button } from './components/buttons/button';
 export { IconButton } from './components/buttons/icon-button';
 export { NavListOption } from './components/nav-list/nav-list-option';
-export { MenuButton } from './components/menu-button/menu-button';
+export { MenuButton, MenuButtonProps } from './components/menu-button/menu-button';
 export { DropdownNavigation } from './components/dropdown-navigation/dropdown-navigation';
 export { BentoMenuButton } from './components/bento-menu-button/bento-menu-button';
 export { ToggleButtonGroup } from './components/toggle-button-group/toggle-button-group';

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -148,44 +148,46 @@ export const OptionsWithIcons: Story = () => (
     </>
 );
 
+const optionsWithGroups: MenuButtonProps['options'] = [
+    {
+        groupLabel: 'Group 1',
+        groupOptions: [
+            {
+                label: 'Option 1.1',
+                onClick: () => console.info('Option 1.1 clicked'),
+            },
+            {
+                label: 'Option 1.2',
+                onClick: () => console.info('Option 1.2 clicked'),
+            },
+            {
+                label: 'Option 1.3',
+                onClick: () => console.info('Option 1.3 clicked'),
+            },
+        ],
+    },
+    {
+        groupLabel: 'Group 2',
+        groupOptions: [
+            {
+                label: 'Option 2.1',
+                onClick: () => console.info('Option 2.1 clicked'),
+            },
+            {
+                label: 'Option 2.2',
+                onClick: () => console.info('Option 2.2 clicked'),
+            },
+            {
+                label: 'Option 2.3',
+                onClick: () => console.info('Option 2.3 clicked'),
+            },
+        ],
+    },
+];
+
 export const OptionsWithGrouping: Story = () => (
     <MenuButton
-        options={[
-            {
-                groupLabel: 'Group 1',
-                groupOptions: [
-                    {
-                        label: 'Option 1.1',
-                        onClick: () => console.info('Option 1.1 clicked'),
-                    },
-                    {
-                        label: 'Option 1.2',
-                        onClick: () => console.info('Option 1.2 clicked'),
-                    },
-                    {
-                        label: 'Option 1.3',
-                        onClick: () => console.info('Option 1.3 clicked'),
-                    },
-                ],
-            },
-            {
-                groupLabel: 'Group 2',
-                groupOptions: [
-                    {
-                        label: 'Option 2.1',
-                        onClick: () => console.info('Option 2.1 clicked'),
-                    },
-                    {
-                        label: 'Option 2.2',
-                        onClick: () => console.info('Option 2.2 clicked'),
-                    },
-                    {
-                        label: 'Option 2.3',
-                        onClick: () => console.info('Option 2.3 clicked'),
-                    },
-                ],
-            },
-        ]}
+        options={optionsWithGroups}
         buttonType="primary"
     >
         Button

--- a/packages/storybook/stories/menu-button.stories.tsx
+++ b/packages/storybook/stories/menu-button.stories.tsx
@@ -1,4 +1,4 @@
-import { MenuButton, Tooltip } from '@equisoft/design-elements-react';
+import { MenuButton, MenuButtonProps, Tooltip } from '@equisoft/design-elements-react';
 import { StoryFn as Story } from '@storybook/react';
 import styled from 'styled-components';
 import { decorateWith } from './utils/decorator';
@@ -74,6 +74,41 @@ const submenuOptions = [
     },
 ];
 
+const optionsWithIcons: MenuButtonProps['options'] = [
+    {
+        label: 'Option 1',
+        onClick: () => console.info('Option 1 clicked'),
+    },
+    {
+        label: 'Option 2',
+        iconName: 'check',
+        onClick: () => console.info('Option 2 clicked'),
+    },
+    {
+        label: 'Option 3',
+        iconName: 'settings',
+        onClick: () => console.info('Option 3 clicked'),
+    },
+];
+
+const optionsWithIconsAndSubmenu: MenuButtonProps['options'] = [
+    {
+        label: 'Option 1',
+        onClick: () => console.info('Option 1 clicked'),
+    },
+    {
+        label: 'Option 2',
+        iconName: 'check',
+        onClick: () => console.info('Option 2 clicked'),
+        options,
+    },
+    {
+        label: 'Option 3',
+        iconName: 'settings',
+        onClick: () => console.info('Option 3 clicked'),
+    },
+];
+
 export const Normal: Story = () => (
     <>
         <MenuButton options={options} buttonType="primary">Button</MenuButton>
@@ -88,13 +123,13 @@ export const IconButton: Story = () => (
     <MenuButton iconName="moreVertical" options={options} buttonType="primary" />
 );
 
-export const LeftDirection: Story = () => (
+export const LeftPlacement: Story = () => (
     <MenuButton
         className="end-align"
         iconName="moreVertical"
         options={options}
         buttonType="primary"
-        menuDirection="left"
+        menuPlacement="left"
     />
 );
 
@@ -106,6 +141,57 @@ export const WithSubmenu: Story = () => (
     <MenuButton options={submenuOptions} buttonType="primary">Button</MenuButton>
 );
 
+export const OptionsWithIcons: Story = () => (
+    <>
+        <MenuButton options={optionsWithIcons} buttonType="primary">Button</MenuButton>
+        <MenuButton options={optionsWithIconsAndSubmenu} buttonType="primary">With submenu</MenuButton>
+    </>
+);
+
+export const OptionsWithGrouping: Story = () => (
+    <MenuButton
+        options={[
+            {
+                groupLabel: 'Group 1',
+                groupOptions: [
+                    {
+                        label: 'Option 1.1',
+                        onClick: () => console.info('Option 1.1 clicked'),
+                    },
+                    {
+                        label: 'Option 1.2',
+                        onClick: () => console.info('Option 1.2 clicked'),
+                    },
+                    {
+                        label: 'Option 1.3',
+                        onClick: () => console.info('Option 1.3 clicked'),
+                    },
+                ],
+            },
+            {
+                groupLabel: 'Group 2',
+                groupOptions: [
+                    {
+                        label: 'Option 2.1',
+                        onClick: () => console.info('Option 2.1 clicked'),
+                    },
+                    {
+                        label: 'Option 2.2',
+                        onClick: () => console.info('Option 2.2 clicked'),
+                    },
+                    {
+                        label: 'Option 2.3',
+                        onClick: () => console.info('Option 2.3 clicked'),
+                    },
+                ],
+            },
+        ]}
+        buttonType="primary"
+    >
+        Button
+    </MenuButton>
+);
+
 export const Scrollable: Story = () => (
     <MenuButton options={scrollableOptions} buttonType="primary">Button</MenuButton>
 );
@@ -114,7 +200,7 @@ export const VisibilityChangeEvent: Story = () => (
     <MenuButton
         options={options}
         buttonType="primary"
-        onMenuVisibilityChanged={(visibility) => console.info(visibility)}
+        onMenuVisibilityChanged={(visibility) => console.info(`MenuButton visibility: ${visibility}`)}
     >
         Button
     </MenuButton>
@@ -136,7 +222,7 @@ export const TooltipWrapperWithClickableItems: Story = () => (
                 },
             ]}
             buttonType="primary"
-            onMenuVisibilityChanged={(visibility) => console.info(visibility)}
+            onMenuVisibilityChanged={(visibility) => console.info(`MenuButton visibility: ${visibility}`)}
         >
             Menu
         </MenuButton>


### PR DESCRIPTION
## PR Description
DS-638

New features:
- Options can now have icons.
- Options can now be grouped.

Fixes: 
- Add an aria-label on the button when it contains only an icon.
- Remove the "direction" attribute from the html (the menu position was now renamed to placement).
- Remove one unnecessary div.

![image](https://github.com/kronostechnologies/design-elements/assets/3039571/55ec1fe0-f8b2-4ee5-b569-d672212f6581)
![image](https://github.com/kronostechnologies/design-elements/assets/3039571/229c670a-2aa2-4136-92a2-685c935d87e4)

## New component checklist
- [x] The new component and its tests are in the same component folder.
- [x] The component is unit tested and/or snapshot tested.
- [x] All of the relevant Storybook stories have been added to the `storybook` package.
- [x] There are no linting errors or warnings in the modified/new code.
- [x] All GitHub checks are successful.
