### PR TITLE
fix(inputs): remplace error icon

### DIFF
--- a/packages/react/src/components/feedbacks/invalid-field.tsx
+++ b/packages/react/src/components/feedbacks/invalid-field.tsx
@@ -38,7 +38,7 @@ const InvalidField: VoidFunctionComponent<InvalidFieldProps> = ({ controlId, fee
             role="alert"
         >
             {!noIcon && (
-                <StyledIcon><Icon name="alertTriangle" size={isMobile ? '24' : '16'} /></StyledIcon>
+                <StyledIcon><Icon name="alertOctagon" size={isMobile ? '24' : '16'} /></StyledIcon>
             )}
             <StyledSpan>{feedbackMsg}</StyledSpan>
         </Field>

--- a/packages/react/src/components/password-creation-input/password-rule.tsx
+++ b/packages/react/src/components/password-creation-input/password-rule.tsx
@@ -78,7 +78,7 @@ export const PasswordRule: VoidFunctionComponent<PasswordConditionProps> = ({
                 <StyledIcon
                     aria-label={`${t('error')},`}
                     focusable
-                    name="alertTriangle"
+                    name="alertOctagon"
                     role="img"
                     size="16"
                 />


### PR DESCRIPTION
The icon used for the error message was not the correct one; the triangle has been replaced with an octagon.