### PR TITLE
fix(date-picker): ensure one datepicker is open

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -20,6 +20,7 @@ import datepickerCss from 'react-datepicker/dist/react-datepicker.min.css';
 import styled, { createGlobalStyle, css } from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { Theme } from '../../themes';
+import { eventIsInside } from '../../utils/events';
 import { v4 as uuid } from '../../utils/uuid';
 import { Button } from '../buttons/button';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
@@ -408,20 +409,6 @@ export const Datepicker = forwardRef(({
         }
     }, [currentLocale, firstDayOfWeek]);
 
-    useEffect(() => {
-        function closeOnOtherOpen(): void {
-            if (dateInputRef.current?.isCalendarOpen()) {
-                dateInputRef.current.setOpen(false);
-            }
-        }
-
-        document.addEventListener('closeOtherDatepickers', closeOnOtherOpen);
-
-        return () => {
-            document.removeEventListener('closeOtherDatepickers', closeOnOtherOpen);
-        };
-    }, []);
-
     function focusCalendarDate(): void {
         setTimeout(() => {
             const dateToFocus = calendarRef.current
@@ -453,12 +440,7 @@ export const Datepicker = forwardRef(({
         calendarButtonRef.current?.focus();
     }
 
-    function handleCalendarButtonMouseDown(event: MouseEvent<HTMLButtonElement>): void {
-        event.stopPropagation();
-
-        const customEvent = new Event('closeOtherDatepickers');
-        document.dispatchEvent(customEvent);
-
+    function handleCalendarButtonMouseDown(): void {
         if (dateInputRef.current?.isCalendarOpen()) {
             dateInputRef.current?.setOpen(false);
         } else {
@@ -484,13 +466,11 @@ export const Datepicker = forwardRef(({
 
     function handleClickOutside(event: MouseEvent<HTMLInputElement>): void {
         if (
-            calendarRef.current
-            && dateInputRef.current
+            dateInputRef.current
             && calendarButtonRef.current
-            && !calendarRef.current.contains(event.target as Node)
-            && !calendarButtonRef.current.contains(event.target as Node)
+            && eventIsInside(event as unknown as Event, calendarButtonRef.current)
         ) {
-            dateInputRef.current.setOpen(false);
+            dateInputRef.current.setOpen(true);
         }
     }
 

--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -408,6 +408,20 @@ export const Datepicker = forwardRef(({
         }
     }, [currentLocale, firstDayOfWeek]);
 
+    useEffect(() => {
+        function closeOnOtherOpen(): void {
+            if (dateInputRef.current?.isCalendarOpen()) {
+                dateInputRef.current.setOpen(false);
+            }
+        }
+
+        document.addEventListener('closeOtherDatepickers', closeOnOtherOpen);
+
+        return () => {
+            document.removeEventListener('closeOtherDatepickers', closeOnOtherOpen);
+        };
+    }, []);
+
     function focusCalendarDate(): void {
         setTimeout(() => {
             const dateToFocus = calendarRef.current
@@ -441,6 +455,10 @@ export const Datepicker = forwardRef(({
 
     function handleCalendarButtonMouseDown(event: MouseEvent<HTMLButtonElement>): void {
         event.stopPropagation();
+
+        const customEvent = new Event('closeOtherDatepickers');
+        document.dispatchEvent(customEvent);
+
         if (dateInputRef.current?.isCalendarOpen()) {
             dateInputRef.current?.setOpen(false);
         } else {
@@ -463,6 +481,18 @@ export const Datepicker = forwardRef(({
             onChange(date);
         }
     }, [onChange]);
+
+    function handleClickOutside(event: MouseEvent<HTMLInputElement>): void {
+        if (
+            calendarRef.current
+            && dateInputRef.current
+            && calendarButtonRef.current
+            && !calendarRef.current.contains(event.target as Node)
+            && !calendarButtonRef.current.contains(event.target as Node)
+        ) {
+            dateInputRef.current.setOpen(false);
+        }
+    }
 
     function handleInputClick(): void {
         dateInputRef.current?.setOpen(false, true);
@@ -567,6 +597,7 @@ export const Datepicker = forwardRef(({
                         onCalendarClose={onCalendarClose}
                         onCalendarOpen={onCalendarOpen}
                         onFocus={onFocus}
+                        onClickOutside={handleClickOutside}
                         onInputClick={handleInputClick}
                         onKeyDown={handleCalendarKeyDown}
                         open={open}


### PR DESCRIPTION
[DS-889](https://jira.equisoft.com/browse/DS-889)

## Description
Auparavant, lorsqu'un utilisateur ouvrait le calendrier d'un composant Datepicker puis cliquait sur le bouton d'un autre composant Datepicker, les deux calendriers restaient ouverts simultanément. Cette PR corrige ce comportement afin qu'un seul calendrier puisse être ouvert à la fois.

Ajout d'un événement personnalisé pour fermer les autres instances de Datepicker lors de l'ouverture d'un nouveau.
À l'aide d'un listener d'événements sur le document permettant d'écouter cet événement et fermer le Datepicker actuellement ouvert si nécessaire.

## Tests fonctionnels

- [ ] Valider le bon fonctionnement du datepicker
- [ ] Valider qu'il ne peut y avoir plus d'un datepicker ouvert à la fois