### PR TITLE
fix(user-profile,nav-item): pass target to html-link and use external-link

### DIFF
--- a/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
@@ -66,20 +66,20 @@ export const HtmlLink = styled.a<LinkProps>`
 `;
 
 export const StyledExternalLink = styled(ExternalLink)`
-  ${NavItemStyle}
+    ${NavItemStyle}
   
-  &:visited {
-    svg {
-      color: ${({ theme }) => theme.greys.black};
+    &:visited {
+        svg {
+            color: ${({ theme }) => theme.greys.black};
+        }
     }
-  }
-  
-  span {
-    color: ${({ theme }) => theme.greys.black};
-    padding: 0 0 0 var(--spacing-half);
-  }
-  
-  padding: 0 var(--spacing-2x);
+    
+    span {
+        color: ${({ theme }) => theme.greys.black};
+        padding: 0 0 0 var(--spacing-half);
+    }
+    
+    padding: 0 var(--spacing-2x);
 `;
 
 export const NavItem = forwardRef(({
@@ -107,6 +107,19 @@ export const NavItem = forwardRef(({
     }
 
     function renderNavItem(): ReactElement {
+        if (isExternalLink) {
+            return (
+                <StyledExternalLink
+                    disabled={disabled}
+                    href={href}
+                    label={label}
+                    onClick={onClick}
+                    target={target}
+                    $device={device}
+                />
+            );
+        }
+
         if (isHtmlLink) {
             return (
                 <HtmlLink
@@ -129,19 +142,6 @@ export const NavItem = forwardRef(({
                     />
                     {opensInNewTab && renderScreenReaderOnlyText()}
                 </HtmlLink>
-            );
-        }
-
-        if (isExternalLink) {
-            return (
-                <StyledExternalLink
-                    disabled={disabled}
-                    href={href}
-                    label={label}
-                    onClick={onClick}
-                    target={target}
-                    $device={device}
-                />
             );
         }
 

--- a/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
+++ b/packages/react/src/components/dropdown-menu/list-items/nav-item.tsx
@@ -7,6 +7,7 @@ import { DeviceContextProps, useDeviceContext } from '../../device-context-provi
 import { IconName } from '../../icon/icon';
 import { ScreenReaderOnlyText } from '../../screen-reader-only-text/ScreenReaderOnlyText';
 import { ItemContent } from './item-content';
+import { ExternalLink } from '../../external-link/external-link';
 
 export interface NavItemProps {
     value: string;
@@ -16,6 +17,7 @@ export interface NavItemProps {
     label?: string;
     lozenge?: string;
     end?: boolean;
+    isExternalLink?: boolean;
     isHtmlLink?: boolean;
     disabled?: boolean;
     target?: string;
@@ -63,6 +65,23 @@ export const HtmlLink = styled.a<LinkProps>`
     ${NavItemStyle};
 `;
 
+export const StyledExternalLink = styled(ExternalLink)`
+  ${NavItemStyle}
+  
+  &:visited {
+    svg {
+      color: ${({ theme }) => theme.greys.black};
+    }
+  }
+  
+  span {
+    color: ${({ theme }) => theme.greys.black};
+    padding: 0 0 0 var(--spacing-half);
+  }
+  
+  padding: 0 var(--spacing-2x);
+`;
+
 export const NavItem = forwardRef(({
     href,
     value,
@@ -71,6 +90,7 @@ export const NavItem = forwardRef(({
     label,
     disabled,
     onClick,
+    isExternalLink = false,
     isHtmlLink = false,
     lozenge,
     end,
@@ -86,9 +106,9 @@ export const NavItem = forwardRef(({
         );
     }
 
-    return (
-        <li>
-            {isHtmlLink && (
+    function renderNavItem(): ReactElement {
+        if (isHtmlLink) {
+            return (
                 <HtmlLink
                     aria-disabled={disabled ? 'true' : 'false'}
                     ref={ref}
@@ -109,31 +129,51 @@ export const NavItem = forwardRef(({
                     />
                     {opensInNewTab && renderScreenReaderOnlyText()}
                 </HtmlLink>
-            )}
-            {!isHtmlLink && (
-                <StyledNavItem
-                    aria-disabled={disabled ? 'true' : 'false'}
-                    tabIndex={disabled ? -1 : 0}
-                    ref={ref}
-                    to={href}
-                    $hasIcon={!!iconName}
-                    $device={device}
-                    data-testid={`listitem-${value}`}
+            );
+        }
+
+        if (isExternalLink) {
+            return (
+                <StyledExternalLink
                     disabled={disabled}
-                    end={end}
+                    href={href}
+                    label={label}
+                    onClick={onClick}
                     target={target}
-                    onClick={disabled ? undefined : onClick}
-                >
-                    <ItemContent
-                        device={device}
-                        label={label || value}
-                        description={description}
-                        iconName={iconName}
-                        lozenge={lozenge}
-                    />
-                    {opensInNewTab && renderScreenReaderOnlyText()}
-                </StyledNavItem>
-            )}
+                    $device={device}
+                />
+            );
+        }
+
+        return (
+            <StyledNavItem
+                aria-disabled={disabled ? 'true' : 'false'}
+                tabIndex={disabled ? -1 : 0}
+                ref={ref}
+                to={href}
+                $hasIcon={!!iconName}
+                $device={device}
+                data-testid={`listitem-${value}`}
+                disabled={disabled}
+                end={end}
+                target={target}
+                onClick={disabled ? undefined : onClick}
+            >
+                <ItemContent
+                    device={device}
+                    label={label || value}
+                    description={description}
+                    iconName={iconName}
+                    lozenge={lozenge}
+                />
+                {opensInNewTab && renderScreenReaderOnlyText()}
+            </StyledNavItem>
+        );
+    }
+
+    return (
+        <li>
+            {renderNavItem()}
         </li>
     );
 });

--- a/packages/react/src/components/external-link/external-link.tsx
+++ b/packages/react/src/components/external-link/external-link.tsx
@@ -45,7 +45,7 @@ export interface ExternalLinkProps {
     label?: string;
     target?: string;
 
-    onClick?(): void;
+    onClick?(event: MouseEvent<Element, globalThis.MouseEvent>): void;
 }
 
 export const ExternalLink: VoidFunctionComponent<ExternalLinkProps> = ({
@@ -64,7 +64,7 @@ export const ExternalLink: VoidFunctionComponent<ExternalLinkProps> = ({
         if (!href) {
             event.preventDefault();
         }
-        onClick?.();
+        onClick?.(event);
     }, [href, onClick]);
 
     return (

--- a/packages/react/src/components/user-profile/user-profile.test.tsx
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx
@@ -6,27 +6,35 @@ import { getFirstFocusableItem, UserProfile } from './user-profile';
 const onClick = jest.fn();
 const options: NavItemProps[] = [
     {
-        label: 'Option A',
-        value: 'optionA',
         href: '/testa',
+        label: 'Option A',
         onClick,
+        value: 'optionA',
     },
     {
-        label: 'Option B',
-        value: 'optionB',
-        href: '/testb',
-        onClick,
         disabled: true,
+        href: '/testb',
+        label: 'Option B',
+        onClick,
+        value: 'optionB',
     },
     {
+        href: '/testc',
         label: 'Option C',
         value: 'optionC',
-        href: '/testc',
     },
     {
+        href: 'www.test.ca',
+        isHtmlLink: true,
         label: 'Option D',
+        target: '_blank',
         value: 'optionD',
-        href: '/testd',
+    },
+    {
+        href: 'www.test.ca',
+        isExternalLink: true,
+        label: 'Option E',
+        value: 'optionE',
     },
 ];
 

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -143,6 +143,97 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   width: initial;
 }
 
+.c19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #006296;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c19:hover {
+  color: #003A5A;
+}
+
+.c19:visited {
+  color: #62a;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c19:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c19:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c18 {
+  border: 0;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c23 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: 1rem;
+  margin-left: var(--spacing-half);
+  margin-right: 0;
+  width: 1rem;
+}
+
+.c20 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c20:visited svg {
+  color: #62a;
+}
+
+.c22 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .c9 {
   margin: 0;
   overflow-y: auto;
@@ -308,6 +399,98 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   pointer-events: none;
 }
 
+.c17 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c17:hover {
+  background-color: #DBDEE1;
+}
+
+.c17[disabled],
+.c17[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c21 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0 var(--spacing-2x);
+}
+
+.c21:focus {
+  outline: none;
+}
+
+.c21:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c21:hover {
+  background-color: #DBDEE1;
+}
+
+.c21[disabled],
+.c21[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c21:visited svg {
+  color: #000000;
+}
+
+.c21 span {
+  color: #000000;
+  padding: 0 0 0 var(--spacing-half);
+}
+
 .c5 {
   margin-right: var(--spacing-1x);
 }
@@ -449,10 +632,10 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
       <li>
         <a
           aria-disabled="false"
-          class="c14"
-          data-testid="listitem-optionD"
-          href="/testd"
+          class="c17"
+          href="www.test.ca"
           tabindex="0"
+          target="_blank"
         >
           <div
             class="c15"
@@ -467,6 +650,41 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
               </span>
             </div>
           </div>
+          <span
+            class="c18"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          aria-disabled="false"
+          class="c19 c20 c21"
+          href="www.test.ca"
+          target="_blank"
+        >
+          <span
+            class="c22"
+          >
+            Option E
+          </span>
+          <svg
+            aria-label="opens in a new tab"
+            class="c23"
+            color="currentColor"
+            focusable="false"
+            height="16"
+            role="img"
+            width="16"
+          />
+          <span
+            class="c18"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
         </a>
       </li>
     </ul>
@@ -617,6 +835,97 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   width: initial;
 }
 
+.c19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #006296;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c19:hover {
+  color: #003A5A;
+}
+
+.c19:visited {
+  color: #62a;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c19:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c19:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c18 {
+  border: 0;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c23 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: 1rem;
+  margin-left: var(--spacing-half);
+  margin-right: 0;
+  width: 1rem;
+}
+
+.c20 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c20:visited svg {
+  color: #62a;
+}
+
+.c22 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .c9 {
   margin: 0;
   overflow-y: auto;
@@ -782,6 +1091,98 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   pointer-events: none;
 }
 
+.c17 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c17:hover {
+  background-color: #DBDEE1;
+}
+
+.c17[disabled],
+.c17[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c21 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0 var(--spacing-2x);
+}
+
+.c21:focus {
+  outline: none;
+}
+
+.c21:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c21:hover {
+  background-color: #DBDEE1;
+}
+
+.c21[disabled],
+.c21[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c21:visited svg {
+  color: #000000;
+}
+
+.c21 span {
+  color: #000000;
+  padding: 0 0 0 var(--spacing-half);
+}
+
 .c5 {
   margin-right: var(--spacing-1x);
 }
@@ -924,10 +1325,10 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
       <li>
         <a
           aria-disabled="false"
-          class="c14"
-          data-testid="listitem-optionD"
-          href="/testd"
+          class="c17"
+          href="www.test.ca"
           tabindex="0"
+          target="_blank"
         >
           <div
             class="c15"
@@ -942,6 +1343,41 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
               </span>
             </div>
           </div>
+          <span
+            class="c18"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          aria-disabled="false"
+          class="c19 c20 c21"
+          href="www.test.ca"
+          target="_blank"
+        >
+          <span
+            class="c22"
+          >
+            Option E
+          </span>
+          <svg
+            aria-label="opens in a new tab"
+            class="c23"
+            color="currentColor"
+            focusable="false"
+            height="16"
+            role="img"
+            width="16"
+          />
+          <span
+            class="c18"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
         </a>
       </li>
     </ul>
@@ -1087,6 +1523,97 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   min-width: 200px;
   right: 0;
   width: initial;
+}
+
+.c18 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #006296;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c18:hover {
+  color: #003A5A;
+}
+
+.c18:visited {
+  color: #62a;
+}
+
+.c18:focus {
+  outline: none;
+}
+
+.c18:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c18:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c18:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c17 {
+  border: 0;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c22 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: 1rem;
+  margin-left: var(--spacing-half);
+  margin-right: 0;
+  width: 1rem;
+}
+
+.c19 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c19:visited svg {
+  color: #62a;
+}
+
+.c21 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c8 {
@@ -1254,6 +1781,98 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   pointer-events: none;
 }
 
+.c16 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1rem;
+  height: 2.5rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.c16:focus {
+  outline: none;
+}
+
+.c16:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c16:hover {
+  background-color: #DBDEE1;
+}
+
+.c16[disabled],
+.c16[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c20 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1rem;
+  height: 2.5rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0 var(--spacing-2x);
+}
+
+.c20:focus {
+  outline: none;
+}
+
+.c20:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c20:hover {
+  background-color: #DBDEE1;
+}
+
+.c20[disabled],
+.c20[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c20:visited svg {
+  color: #000000;
+}
+
+.c20 span {
+  color: #000000;
+  padding: 0 0 0 var(--spacing-half);
+}
+
 .c1 button {
   height: -webkit-fit-content;
   height: -moz-fit-content;
@@ -1394,10 +2013,10 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
       <li>
         <a
           aria-disabled="false"
-          class="c13"
-          data-testid="listitem-optionD"
-          href="/testd"
+          class="c16"
+          href="www.test.ca"
           tabindex="0"
+          target="_blank"
         >
           <div
             class="c14"
@@ -1412,6 +2031,41 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
               </span>
             </div>
           </div>
+          <span
+            class="c17"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          aria-disabled="false"
+          class="c18 c19 c20"
+          href="www.test.ca"
+          target="_blank"
+        >
+          <span
+            class="c21"
+          >
+            Option E
+          </span>
+          <svg
+            aria-label="opens in a new tab"
+            class="c22"
+            color="currentColor"
+            focusable="false"
+            height="16"
+            role="img"
+            width="16"
+          />
+          <span
+            class="c17"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
         </a>
       </li>
     </ul>
@@ -1560,6 +2214,97 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
   min-width: 200px;
   right: 0;
   width: initial;
+}
+
+.c19 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #006296;
+  cursor: pointer;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+.c19:hover {
+  color: #003A5A;
+}
+
+.c19:visited {
+  color: #62a;
+}
+
+.c19:focus {
+  outline: none;
+}
+
+.c19:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c19:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.c19:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
+}
+
+.c18 {
+  border: 0;
+  -webkit-clip: rect(0,0,0,0);
+  clip: rect(0,0,0,0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.c23 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: 1rem;
+  margin-left: var(--spacing-half);
+  margin-right: 0;
+  width: 1rem;
+}
+
+.c20 {
+  -webkit-align-items: baseline;
+  -webkit-box-align: baseline;
+  -ms-flex-align: baseline;
+  align-items: baseline;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+}
+
+.c20:visited svg {
+  color: #62a;
+}
+
+.c22 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .c9 {
@@ -1727,6 +2472,98 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
   pointer-events: none;
 }
 
+.c17 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.c17:focus {
+  outline: none;
+}
+
+.c17:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c17:hover {
+  background-color: #DBDEE1;
+}
+
+.c17[disabled],
+.c17[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c21 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  height: 2rem;
+  line-height: 2rem;
+  padding: 0 var(--spacing-2x);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 0 var(--spacing-2x);
+}
+
+.c21:focus {
+  outline: none;
+}
+
+.c21:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px #84C6EA;
+  box-shadow: inset 0 0 0 2px #84C6EA,inset 0 0 0 3px #006296;
+}
+
+.c21:hover {
+  background-color: #DBDEE1;
+}
+
+.c21[disabled],
+.c21[disabled] * {
+  color: #B7BBC2;
+  cursor: default;
+  fill: #B7BBC2;
+  pointer-events: none;
+}
+
+.c21:visited svg {
+  color: #000000;
+}
+
+.c21 span {
+  color: #000000;
+  padding: 0 0 0 var(--spacing-half);
+}
+
 .c5 {
   margin-right: var(--spacing-1x);
 }
@@ -1869,10 +2706,10 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
       <li>
         <a
           aria-disabled="false"
-          class="c14"
-          data-testid="listitem-optionD"
-          href="/testd"
+          class="c17"
+          href="www.test.ca"
           tabindex="0"
+          target="_blank"
         >
           <div
             class="c15"
@@ -1887,6 +2724,41 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
               </span>
             </div>
           </div>
+          <span
+            class="c18"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
+        </a>
+      </li>
+      <li>
+        <a
+          aria-disabled="false"
+          class="c19 c20 c21"
+          href="www.test.ca"
+          target="_blank"
+        >
+          <span
+            class="c22"
+          >
+            Option E
+          </span>
+          <svg
+            aria-label="opens in a new tab"
+            class="c23"
+            color="currentColor"
+            focusable="false"
+            height="16"
+            role="img"
+            width="16"
+          />
+          <span
+            class="c18"
+            data-testid="screen-reader-text"
+          >
+            (opens in a new tab)
+          </span>
         </a>
       </li>
     </ul>

--- a/packages/react/src/components/user-profile/user-profile.tsx
+++ b/packages/react/src/components/user-profile/user-profile.tsx
@@ -98,8 +98,10 @@ export const UserProfile: VoidFunctionComponent<UserProfileProps> = ({
                                 href={action.href}
                                 label={action.label}
                                 isHtmlLink={action.isHtmlLink}
+                                isExternalLink={action.isExternalLink}
                                 lozenge={action.lozenge}
                                 disabled={action.disabled}
+                                target={action.target}
                                 onClick={action.disabled ? undefined : (event) => {
                                     action.onClick?.(event);
                                     close();

--- a/packages/storybook/stories/user-profile.stories.tsx
+++ b/packages/storybook/stories/user-profile.stories.tsx
@@ -47,7 +47,7 @@ const options: NavItemProps[] = [
         label: 'Google',
         value: 'google',
         href: 'https://www.google.ca',
-        isHtmlLink: true,
+        isExternalLink: true,
     },
 ];
 


### PR DESCRIPTION
Ref: https://jira.equisoft.com/browse/DS-919

## Contexte
- Le props target n'était pas passé au nav-item du component user-profile.
- Ajout de la propriété `isExternalLink` qui permet de render un lien externe avec l'icône correspondante: 
![Screenshot 2024-01-08 at 1 46 20 PM](https://github.com/kronostechnologies/design-elements/assets/106986557/9b1e2973-f1d2-40a1-b599-a70bf6dd0ca9)

