### PR TITLE
fix(TextInput): make sure that blur event doesn't break error message.

### DIFF
--- a/packages/react/src/components/text-input/text-input.test.tsx
+++ b/packages/react/src/components/text-input/text-input.test.tsx
@@ -74,6 +74,15 @@ describe('TextInput', () => {
         expect(container.prop('valid')).toBe(true);
     });
 
+    test('should set as invalid when valid prop is false and input trigger blur again', () => {
+        const wrapper = shallow(<TextInput valid={false} />);
+
+        const textInput = getByTestId(wrapper, 'text-input');
+        textInput.simulate('blur', { currentTarget: { checkValidity: () => true } });
+
+        expect(wrapper.prop('valid')).toBe(false);
+    });
+
     test('onChange callback is called when content is changed', () => {
         const callback = jest.fn();
         const wrapper = setup(callback);

--- a/packages/react/src/components/text-input/text-input.test.tsx
+++ b/packages/react/src/components/text-input/text-input.test.tsx
@@ -74,13 +74,44 @@ describe('TextInput', () => {
         expect(container.prop('valid')).toBe(true);
     });
 
-    test('should set as invalid when valid prop is false and input trigger blur again', () => {
+    test('should set as invalid when valid prop is false and input trigger blur with checkValidity is true', () => {
         const wrapper = shallow(<TextInput valid={false} />);
 
         const textInput = getByTestId(wrapper, 'text-input');
         textInput.simulate('blur', { currentTarget: { checkValidity: () => true } });
+        const container = getByTestId(wrapper, 'field-container');
 
-        expect(wrapper.prop('valid')).toBe(false);
+        expect(container.prop('valid')).toBe(false);
+    });
+
+    test('should set as valid when valid prop is true and input trigger blur with checkValidity is true', () => {
+        const wrapper = shallow(<TextInput valid />);
+
+        const textInput = getByTestId(wrapper, 'text-input');
+        textInput.simulate('blur', { currentTarget: { checkValidity: () => true } });
+        const container = getByTestId(wrapper, 'field-container');
+
+        expect(container.prop('valid')).toBe(true);
+    });
+
+    test('should set as valid when valid prop is true and input trigger blur with checkValidity is false', () => {
+        const wrapper = shallow(<TextInput valid />);
+
+        const textInput = getByTestId(wrapper, 'text-input');
+        textInput.simulate('blur', { currentTarget: { checkValidity: () => false } });
+        const container = getByTestId(wrapper, 'field-container');
+
+        expect(container.prop('valid')).toBe(true);
+    });
+
+    test('should set as invalid when valid prop is false and input trigger blur with checkValidity is false', () => {
+        const wrapper = shallow(<TextInput valid={false} />);
+
+        const textInput = getByTestId(wrapper, 'text-input');
+        textInput.simulate('blur', { currentTarget: { checkValidity: () => false } });
+        const container = getByTestId(wrapper, 'field-container');
+
+        expect(container.prop('valid')).toBe(false);
     });
 
     test('onChange callback is called when content is changed', () => {

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -105,12 +105,12 @@ export const TextInput = forwardRef(({
     }, [id, ariaDescribedBy, validity, hint]);
 
     const handleBlur: (event: FocusEvent<HTMLInputElement>) => void = useCallback((event) => {
-        setValidity({ validity: event.currentTarget.checkValidity() });
+        setValidity({ validity: (valid ?? true) && event.currentTarget.checkValidity() });
 
         if (onBlur) {
             onBlur(event);
         }
-    }, [onBlur]);
+    }, [onBlur, valid]);
 
     const handleOnInvalid: FormEventHandler<HTMLInputElement> = useCallback(() => {
         setValidity({ validity: false });

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -105,7 +105,9 @@ export const TextInput = forwardRef(({
     }, [id, ariaDescribedBy, validity, hint]);
 
     const handleBlur: (event: FocusEvent<HTMLInputElement>) => void = useCallback((event) => {
-        setValidity({ validity: (valid ?? true) && event.currentTarget.checkValidity() });
+        if (valid === undefined) {
+            setValidity({ validity: event.currentTarget.checkValidity() });
+        }
 
         if (onBlur) {
             onBlur(event);
@@ -113,8 +115,10 @@ export const TextInput = forwardRef(({
     }, [onBlur, valid]);
 
     const handleOnInvalid: FormEventHandler<HTMLInputElement> = useCallback(() => {
-        setValidity({ validity: false });
-    }, []);
+        if (valid === undefined) {
+            setValidity({ validity: false });
+        }
+    }, [valid]);
 
     const handleChange: (event: ChangeEvent<HTMLInputElement>) => void = useCallback((event) => {
         if (onChange) {

--- a/packages/storybook/stories/text-input.stories.tsx
+++ b/packages/storybook/stories/text-input.stories.tsx
@@ -117,8 +117,8 @@ export const RequiredInForm: Story = () => {
 export const FormWithCustomValidation: Story = () => {
     const [value, setValue] = useState('REFERRAL-111');
     const [valid, setValid] = useState(true);
-    const validate = (): void => {
-        if (value === 'REFERRAL-111') {
+    const validate = (validationValue: string): void => {
+        if (validationValue === 'REFERRAL-111') {
             setValid(false);
         } else {
             setValid(true);
@@ -127,7 +127,7 @@ export const FormWithCustomValidation: Story = () => {
 
     const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
         event.preventDefault();
-        validate();
+        validate(value);
     };
 
     return (
@@ -136,7 +136,11 @@ export const FormWithCustomValidation: Story = () => {
                 label="Enter your referral number (REFERRAL-111 already exists)"
                 type="text"
                 value={value}
-                onChange={(event) => setValue(event.currentTarget.value)}
+                onChange={(event) => {
+                    const inputValue = event.currentTarget.value;
+                    setValue(inputValue);
+                    validate(inputValue);
+                }}
                 valid={valid}
                 validationErrorMessage="This referral number already exists"
             />


### PR DESCRIPTION
En ce moment, la prop valid dans TextInput ne fonctionne pas correctement quand on trigger blur, le message d'erreur disparaît et on doit reloader la section pour qu'il revienne.

### Tests spécifiques
- [ ] Dans la le storybook de TextInput s'assurer que les messages d'erreurs fonctionne correctement quand on reclique dans le champ et quitte(blur), surtout pour la validation custom.

### Qualité du Code
- [ ] Les nouvelles fonctionnalités sont testées unitairement.
