### PR TITLE
feat(Storybook): sort arguments alphabetically

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -20,6 +20,9 @@ const parameters: Parameters = {
             type: 'dynamic',
             excludeDecorators: true,
         },
+        controls: {
+            sort: 'alpha',
+        },
     },
 };
 


### PR DESCRIPTION
While Storybook use the same order as defined in the Props interface, but sometimes it's not possible when your interface extends or has intersected types. So this config will make Storybook to always sort the arguments.

**Before**
<img width="491" alt="before" src="https://github.com/kronostechnologies/design-elements/assets/3039571/53b2af6b-295d-4037-af42-943ec3f10a4b">

**After**
<img width="448" alt="after" src="https://github.com/kronostechnologies/design-elements/assets/3039571/bf06f6b0-911a-4e74-b89f-0ba7bd2e76d5">
