### PR TITLE
fix(Table): typing error on props data

### DIFF
--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -204,7 +204,7 @@ export interface TableProps<T extends object> {
     columns: TableColumn<T>;
     /** Array of Objects that defines your table data.
      * See stories code or refer to react-table docs for more information */
-    data: T[] & CustomRowProps[];
+    data: (T & CustomRowProps)[];
     /**
      * Adds row numbers
      * @default false


### PR DESCRIPTION
DS-927

The previous syntax works only with TypeScript 5+, also "(A & B)[]" is a better syntax.