### PR TITLE
feat(Dropdown)!: update behavior and use updated listbox

### DIFF
--- a/packages/react/src/components/date-picker/calendar-header.tsx
+++ b/packages/react/src/components/date-picker/calendar-header.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { useTranslation } from '../../i18n/use-translation';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
 import { Icon } from '../icon/icon';
-import { Option, DropdownList } from '../dropdown-list/dropdown-list';
+import { DropdownList, DropdownListOption } from '../dropdown-list/dropdown-list';
 
 const Wrapper = styled.div<{ isMobile: boolean }>`
     align-items: center;
@@ -44,10 +44,10 @@ const DropdownListWrapper = styled.div<{ isMobile: boolean }>`
 interface CalendarHeaderProps {
     date: Date;
     months: string[];
-    monthsOptions: Option[];
+    monthsOptions: DropdownListOption[];
     nextMonthButtonDisabled: boolean;
     prevMonthButtonDisabled: boolean;
-    yearsOptions: Option[];
+    yearsOptions: DropdownListOption[];
 
     changeMonth(month: number): void;
 

--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -262,6 +262,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -560,6 +561,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -860,6 +862,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -1158,6 +1161,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -1486,6 +1490,7 @@ label + .c5 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -1803,6 +1808,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -1910,84 +1916,43 @@ input + .c1 {
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
-  box-shadow: none;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2rem;
-  padding-right: var(--spacing-1x);
+  height: var(--size-2x);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
   width: 100%;
 }
 
-.c12:hover {
-  cursor: pointer;
+.c12:focus {
+  outline: none;
 }
 
-.c12 svg {
-  color: #60666E;
+.c12:focus {
+  outline: none;
+  border-color: #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
 }
 
 .c13 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c13:hover {
-  cursor: pointer;
-}
-
-.c13::-webkit-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c13::-moz-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c13:-ms-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c13::placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: pointer;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-
-.c14 > svg {
   height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
   width: var(--size-1x);
 }
 
@@ -2212,7 +2177,7 @@ label + .c3 {
   outline: none;
 }
 
-.c15 {
+.c14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -2234,11 +2199,11 @@ label + .c3 {
   width: var(--size-2x);
 }
 
-.c15:hover {
+.c14:hover {
   background-color: #DBDEE1;
 }
 
-.c15:focus {
+.c14:focus {
   border: 1px solid #006296;
   border-left: none;
   box-shadow: 0 0 0 2px #84C6EA;
@@ -2246,7 +2211,7 @@ label + .c3 {
   z-index: 10;
 }
 
-.c15 > svg {
+.c14 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
@@ -2257,6 +2222,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -2339,38 +2305,34 @@ label + .c3 {
                         class="c10 c11"
                       >
                         <div
+                          aria-controls="uuid2_listbox"
                           aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="listbox_uuid2"
+                          aria-invalid="false"
+                          aria-label="Select a month"
+                          aria-labelledby="uuid2_label"
+                          aria-required="false"
                           class="c12"
-                          data-testid="input-wrapper"
+                          data-testid="month-select"
+                          id="uuid2"
+                          role="combobox"
+                          tabindex="0"
+                          value="october"
                         >
                           <input
-                            aria-activedescendant="uuid2_october"
-                            aria-autocomplete="list"
-                            aria-controls="listbox_uuid2"
-                            aria-label="Select a month"
-                            aria-multiline="false"
-                            class="c13"
-                            data-testid="month-select"
-                            id="uuid2"
-                            type="text"
-                            value="Oct"
+                            data-testid="input"
+                            type="hidden"
+                            value="october"
                           />
-                          <button
-                            aria-labelledby="uuid2"
-                            class="c14"
+                          Oct
+                          <svg
+                            aria-hidden="true"
+                            class="c13"
+                            color="currentColor"
                             data-testid="arrow"
-                            tabindex="-1"
-                            type="button"
-                          >
-                            <svg
-                              color="currentColor"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
-                          </button>
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
                         </div>
                       </div>
                     </div>
@@ -2381,38 +2343,34 @@ label + .c3 {
                         class="c10 c11"
                       >
                         <div
+                          aria-controls="uuid3_listbox"
                           aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="listbox_uuid3"
+                          aria-invalid="false"
+                          aria-label="Select a year"
+                          aria-labelledby="uuid3_label"
+                          aria-required="false"
                           class="c12"
-                          data-testid="input-wrapper"
+                          data-testid="year-select"
+                          id="uuid3"
+                          role="combobox"
+                          tabindex="0"
+                          value="2010"
                         >
                           <input
-                            aria-activedescendant="uuid3_2010"
-                            aria-autocomplete="list"
-                            aria-controls="listbox_uuid3"
-                            aria-label="Select a year"
-                            aria-multiline="false"
-                            class="c13"
-                            data-testid="year-select"
-                            id="uuid3"
-                            type="text"
+                            data-testid="input"
+                            type="hidden"
                             value="2010"
                           />
-                          <button
-                            aria-labelledby="uuid3"
-                            class="c14"
+                          2010
+                          <svg
+                            aria-hidden="true"
+                            class="c13"
+                            color="currentColor"
                             data-testid="arrow"
-                            tabindex="-1"
-                            type="button"
-                          >
-                            <svg
-                              color="currentColor"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
-                          </button>
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
                         </div>
                       </div>
                     </div>
@@ -2974,7 +2932,7 @@ label + .c3 {
     </div>
     <button
       aria-label="Choose date"
-      class="c15"
+      class="c14"
       data-testid="calendar-button"
       tabindex="0"
       type="button"
@@ -2991,7 +2949,7 @@ label + .c3 {
 `;
 
 exports[`Datepicker matches snapshot (open, hasTodayButton) 1`] = `
-.c16 {
+.c15 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3031,45 +2989,45 @@ exports[`Datepicker matches snapshot (open, hasTodayButton) 1`] = `
   user-select: none;
 }
 
-.c16:focus {
+.c15:focus {
   outline: none;
 }
 
-.c16:focus {
+.c15:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c16 > svg {
+.c15 > svg {
   color: inherit;
   height: var(--size-1x);
   width: var(--size-1x);
 }
 
-.c17 {
+.c16 {
   background-color: #FFFFFF;
   border-color: #006296;
   color: #006296;
 }
 
-.c17:focus {
+.c16:focus {
   outline: none;
 }
 
-.c17:focus {
+.c16:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-.c17:hover,
-.c17[aria-expanded='true'] {
+.c16:hover,
+.c16[aria-expanded='true'] {
   border-color: #003A5A;
   color: #003A5A;
 }
 
-.c17:disabled {
+.c16:disabled {
   border-color: #84C6EA;
   color: #84C6EA;
 }
@@ -3142,84 +3100,43 @@ input + .c1 {
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
-  box-shadow: none;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2rem;
-  padding-right: var(--spacing-1x);
+  height: var(--size-2x);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
   width: 100%;
 }
 
-.c12:hover {
-  cursor: pointer;
+.c12:focus {
+  outline: none;
 }
 
-.c12 svg {
-  color: #60666E;
+.c12:focus {
+  outline: none;
+  border-color: #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
 }
 
 .c13 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c13:hover {
-  cursor: pointer;
-}
-
-.c13::-webkit-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c13::-moz-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c13:-ms-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c13::placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: pointer;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-
-.c14 > svg {
   height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
   width: var(--size-1x);
 }
 
@@ -3444,13 +3361,13 @@ label + .c3 {
   outline: none;
 }
 
-.c15 {
+.c14 {
   clear: both;
   padding-top: var(--spacing-1x);
   text-align: center;
 }
 
-.c18 {
+.c17 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -3472,11 +3389,11 @@ label + .c3 {
   width: var(--size-2x);
 }
 
-.c18:hover {
+.c17:hover {
   background-color: #DBDEE1;
 }
 
-.c18:focus {
+.c17:focus {
   border: 1px solid #006296;
   border-left: none;
   box-shadow: 0 0 0 2px #84C6EA;
@@ -3484,7 +3401,7 @@ label + .c3 {
   z-index: 10;
 }
 
-.c18 > svg {
+.c17 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
@@ -3495,6 +3412,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -3577,38 +3495,34 @@ label + .c3 {
                         class="c10 c11"
                       >
                         <div
+                          aria-controls="uuid2_listbox"
                           aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="listbox_uuid2"
+                          aria-invalid="false"
+                          aria-label="Select a month"
+                          aria-labelledby="uuid2_label"
+                          aria-required="false"
                           class="c12"
-                          data-testid="input-wrapper"
+                          data-testid="month-select"
+                          id="uuid2"
+                          role="combobox"
+                          tabindex="0"
+                          value="october"
                         >
                           <input
-                            aria-activedescendant="uuid2_october"
-                            aria-autocomplete="list"
-                            aria-controls="listbox_uuid2"
-                            aria-label="Select a month"
-                            aria-multiline="false"
-                            class="c13"
-                            data-testid="month-select"
-                            id="uuid2"
-                            type="text"
-                            value="Oct"
+                            data-testid="input"
+                            type="hidden"
+                            value="october"
                           />
-                          <button
-                            aria-labelledby="uuid2"
-                            class="c14"
+                          Oct
+                          <svg
+                            aria-hidden="true"
+                            class="c13"
+                            color="currentColor"
                             data-testid="arrow"
-                            tabindex="-1"
-                            type="button"
-                          >
-                            <svg
-                              color="currentColor"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
-                          </button>
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
                         </div>
                       </div>
                     </div>
@@ -3619,38 +3533,34 @@ label + .c3 {
                         class="c10 c11"
                       >
                         <div
+                          aria-controls="uuid3_listbox"
                           aria-expanded="false"
-                          aria-haspopup="listbox"
-                          aria-owns="listbox_uuid3"
+                          aria-invalid="false"
+                          aria-label="Select a year"
+                          aria-labelledby="uuid3_label"
+                          aria-required="false"
                           class="c12"
-                          data-testid="input-wrapper"
+                          data-testid="year-select"
+                          id="uuid3"
+                          role="combobox"
+                          tabindex="0"
+                          value="2010"
                         >
                           <input
-                            aria-activedescendant="uuid3_2010"
-                            aria-autocomplete="list"
-                            aria-controls="listbox_uuid3"
-                            aria-label="Select a year"
-                            aria-multiline="false"
-                            class="c13"
-                            data-testid="year-select"
-                            id="uuid3"
-                            type="text"
+                            data-testid="input"
+                            type="hidden"
                             value="2010"
                           />
-                          <button
-                            aria-labelledby="uuid3"
-                            class="c14"
+                          2010
+                          <svg
+                            aria-hidden="true"
+                            class="c13"
+                            color="currentColor"
                             data-testid="arrow"
-                            tabindex="-1"
-                            type="button"
-                          >
-                            <svg
-                              color="currentColor"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
-                          </button>
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
                         </div>
                       </div>
                     </div>
@@ -4203,11 +4113,11 @@ label + .c3 {
               </div>
             </div>
             <div
-              class="c15"
+              class="c14"
             >
               <button
                 aria-label="Choose today's date"
-                class="c16 c17"
+                class="c15 c16"
                 data-testid="today-button"
                 type="button"
               >
@@ -4224,7 +4134,7 @@ label + .c3 {
     </div>
     <button
       aria-label="Choose date"
-      class="c18"
+      class="c17"
       data-testid="calendar-button"
       tabindex="0"
       type="button"
@@ -4309,84 +4219,43 @@ input + .c1 {
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
-  box-shadow: none;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2.5rem;
-  padding-right: var(--spacing-1x);
+  height: var(--size-2halfx);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
   width: 100%;
 }
 
-.c12:hover {
-  cursor: pointer;
+.c12:focus {
+  outline: none;
 }
 
-.c12 svg {
-  color: #60666E;
+.c12:focus {
+  outline: none;
+  border-color: #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
 }
 
 .c13 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 1rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c13:hover {
-  cursor: pointer;
-}
-
-.c13::-webkit-input-placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c13::-moz-placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c13:-ms-input-placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c13::placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: pointer;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-
-.c14 > svg {
   height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
   width: var(--size-1x);
 }
 
@@ -4613,7 +4482,7 @@ label + .c3 {
   outline: none;
 }
 
-.c15 {
+.c14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -4635,11 +4504,11 @@ label + .c3 {
   width: var(--size-2halfx);
 }
 
-.c15:hover {
+.c14:hover {
   background-color: #DBDEE1;
 }
 
-.c15:focus {
+.c14:focus {
   border: 1px solid #006296;
   border-left: none;
   box-shadow: 0 0 0 2px #84C6EA;
@@ -4647,7 +4516,7 @@ label + .c3 {
   z-index: 10;
 }
 
-.c15 > svg {
+.c14 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
@@ -4658,6 +4527,7 @@ label + .c3 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     date
   </label>
@@ -4736,38 +4606,34 @@ label + .c3 {
                           class="c10 c11"
                         >
                           <div
+                            aria-controls="uuid2_listbox"
                             aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="listbox_uuid2"
+                            aria-invalid="false"
+                            aria-label="Select a month"
+                            aria-labelledby="uuid2_label"
+                            aria-required="false"
                             class="c12"
-                            data-testid="input-wrapper"
+                            data-testid="month-select"
+                            id="uuid2"
+                            role="combobox"
+                            tabindex="0"
+                            value="october"
                           >
                             <input
-                              aria-activedescendant="uuid2_october"
-                              aria-autocomplete="list"
-                              aria-controls="listbox_uuid2"
-                              aria-label="Select a month"
-                              aria-multiline="false"
-                              class="c13"
-                              data-testid="month-select"
-                              id="uuid2"
-                              type="text"
-                              value="Oct"
+                              data-testid="input"
+                              type="hidden"
+                              value="october"
                             />
-                            <button
-                              aria-labelledby="uuid2"
-                              class="c14"
+                            Oct
+                            <svg
+                              aria-hidden="true"
+                              class="c13"
+                              color="currentColor"
                               data-testid="arrow"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <svg
-                                color="currentColor"
-                                focusable="false"
-                                height="24"
-                                width="24"
-                              />
-                            </button>
+                              focusable="false"
+                              height="24"
+                              width="24"
+                            />
                           </div>
                         </div>
                       </div>
@@ -4778,38 +4644,34 @@ label + .c3 {
                           class="c10 c11"
                         >
                           <div
+                            aria-controls="uuid3_listbox"
                             aria-expanded="false"
-                            aria-haspopup="listbox"
-                            aria-owns="listbox_uuid3"
+                            aria-invalid="false"
+                            aria-label="Select a year"
+                            aria-labelledby="uuid3_label"
+                            aria-required="false"
                             class="c12"
-                            data-testid="input-wrapper"
+                            data-testid="year-select"
+                            id="uuid3"
+                            role="combobox"
+                            tabindex="0"
+                            value="2010"
                           >
                             <input
-                              aria-activedescendant="uuid3_2010"
-                              aria-autocomplete="list"
-                              aria-controls="listbox_uuid3"
-                              aria-label="Select a year"
-                              aria-multiline="false"
-                              class="c13"
-                              data-testid="year-select"
-                              id="uuid3"
-                              type="text"
+                              data-testid="input"
+                              type="hidden"
                               value="2010"
                             />
-                            <button
-                              aria-labelledby="uuid3"
-                              class="c14"
+                            2010
+                            <svg
+                              aria-hidden="true"
+                              class="c13"
+                              color="currentColor"
                               data-testid="arrow"
-                              tabindex="-1"
-                              type="button"
-                            >
-                              <svg
-                                color="currentColor"
-                                focusable="false"
-                                height="24"
-                                width="24"
-                              />
-                            </button>
+                              focusable="false"
+                              height="24"
+                              width="24"
+                            />
                           </div>
                         </div>
                       </div>
@@ -5372,7 +5234,7 @@ label + .c3 {
     </div>
     <button
       aria-label="Choose date"
-      class="c15"
+      class="c14"
       data-testid="calendar-button"
       tabindex="0"
       type="button"

--- a/packages/react/src/components/date-picker/utils/datepicker-utils.ts
+++ b/packages/react/src/components/date-picker/utils/datepicker-utils.ts
@@ -1,7 +1,7 @@
 import type { Locale } from 'date-fns';
 import { enCA } from 'date-fns/locale';
 import { range } from '../../../utils/range';
-import { Option } from '../../dropdown-list/dropdown-list';
+import { DropdownListOption } from '../../dropdown-list/dropdown-list';
 
 export type SupportedLocale = 'fr-CA' | 'en-CA' | 'en-US';
 export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
@@ -43,8 +43,8 @@ export function getLocaleDatePlaceholder(locale?: Locale): string {
     return getLocaleDateFormat(locale).toUpperCase();
 }
 
-export function getLocaleMonthsOptions(locale: Locale): Option[] {
-    const monthsOptions: Option[] = [];
+export function getLocaleMonthsOptions(locale: Locale): DropdownListOption[] {
+    const monthsOptions: DropdownListOption[] = [];
     for (let i = 0; i < 12; i++) {
         monthsOptions.push({
             value: locale.localize?.month(i).toLowerCase(),
@@ -55,7 +55,7 @@ export function getLocaleMonthsOptions(locale: Locale): Option[] {
     return monthsOptions;
 }
 
-export function getYearsOptions(minDate?: Date | null, maxDate?: Date | null): Option[] {
+export function getYearsOptions(minDate?: Date | null, maxDate?: Date | null): DropdownListOption[] {
     if (minDate && maxDate && minDate > maxDate) {
         return [];
     }

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Select disabled select has a different style 1`] = `
+exports[`Dropdown list matches the snapshot (disabled) 1`] = `
 .c3 {
   color: #000000;
   display: block;
@@ -39,7 +39,7 @@ input + .c2 {
   margin-bottom: var(--spacing-half);
 }
 
-.c7 {
+.c6 {
   background-color: #FFFFFF;
   border-radius: var(--border-radius);
   box-shadow: 0 0 0 1px #DBDEE1,0 10px 20px 0 rgb(0 0 0 / 19%);
@@ -54,17 +54,7 @@ input + .c2 {
   z-index: 1000;
 }
 
-.c7:focus {
-  outline: none;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c9 {
+.c8 {
   height: 100%;
   list-style-type: none;
   margin: 0;
@@ -72,7 +62,31 @@ input + .c2 {
   width: 100%;
 }
 
-.c10 {
+.c9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  font-weight: var(--font-semi-bold);
+  line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
+  padding: var(--spacing-half) var(--spacing-2x);
+  padding-right: var(--spacing-1x);
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c9:hover {
+  background-color: #DBDEE1;
+}
+
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -85,15 +99,16 @@ input + .c2 {
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
 
-.c10:hover {
+.c11:hover {
   background-color: #DBDEE1;
 }
 
-.c11 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -107,7 +122,7 @@ input + .c2 {
   position: relative;
 }
 
-.c8 {
+.c7 {
   position: absolute;
   width: 100%;
 }
@@ -118,86 +133,46 @@ input + .c2 {
   -ms-flex-align: center;
   align-items: center;
   background-color: #F1F2F2;
-  border: 1px solid #DBDEE1;
+  border: 1px solid #B7BBC2;
   border-radius: var(--border-radius);
-  box-shadow: none;
   box-sizing: border-box;
+  color: #B7BBC2;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2rem;
-  padding-right: var(--spacing-1x);
+  height: var(--size-2x);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
   width: 100%;
 }
 
-.c4:hover {
-  cursor: default;
+.c4:focus {
+  outline: none;
 }
 
-.c4 svg {
-  color: #B7BBC2;
+.c4:focus {
+  outline: none;
+  border-color: #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
 }
 
 .c5 {
-  background-color: #F1F2F2;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c5:hover {
-  cursor: default;
-}
-
-.c5::-webkit-input-placeholder {
-  color: #B7BBC2;
-  font-size: 0.875rem;
-}
-
-.c5::-moz-placeholder {
-  color: #B7BBC2;
-  font-size: 0.875rem;
-}
-
-.c5:-ms-input-placeholder {
-  color: #B7BBC2;
-  font-size: 0.875rem;
-}
-
-.c5::placeholder {
-  color: #B7BBC2;
-  font-size: 0.875rem;
-}
-
-.c6 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  cursor: default;
+  color: #B7BBC2;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-
-.c6 > svg {
   height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
   width: var(--size-1x);
 }
 
@@ -207,210 +182,207 @@ input + .c2 {
   <label
     class="c2 c3"
     for="uuid1"
+    id="uuid1_label"
   >
     Select an option
   </label>
   <div
+    aria-activedescendant="uuid1_ab"
+    aria-controls="uuid1_listbox"
     aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-owns="listbox_uuid1"
+    aria-invalid="false"
+    aria-labelledby="uuid1_label"
+    aria-required="false"
     class="c4"
-    data-testid="input-wrapper"
-    disabled=""
+    data-testid="textbox"
+    id="uuid1"
+    role="combobox"
+    tabindex="0"
+    value="ab"
   >
     <input
-      aria-autocomplete="list"
-      aria-controls="listbox_uuid1"
-      aria-label="Select an option"
-      aria-multiline="false"
-      class="c5"
       data-testid="input"
-      disabled=""
-      id="uuid1"
-      type="text"
-      value=""
+      type="hidden"
+      value="ab"
     />
-    <button
-      aria-labelledby="uuid1"
-      class="c6"
+    Alberta
+    <svg
+      aria-hidden="true"
+      class="c5"
+      color="currentColor"
       data-testid="arrow"
-      disabled=""
-      tabindex="-1"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
+      focusable="false"
+      height="16"
+      width="16"
+    />
   </div>
   <div
-    aria-labelledby="uuid1"
-    class="c7 c8"
+    aria-activedescendant="uuid1_listbox_ab"
+    aria-labelledby="uuid1_label"
+    class="c6 c7"
     data-testid="listbox-container"
-    id="listbox_uuid1"
+    id="uuid1_listbox"
     role="listbox"
-    tabindex="0"
+    tabindex="-1"
   >
     <ul
-      class="c9"
+      class="c8"
       data-testid="listbox-list"
       role="presentation"
     >
       <li
-        class="c10"
-        data-testid="listitem-on"
-        id="listbox_uuid1_on"
-        role="option"
-      >
-        <span
-          class="c11"
-        >
-          Ontario
-        </span>
-      </li>
-      <li
-        class="c10"
-        data-testid="listitem-qc"
-        id="listbox_uuid1_qc"
-        role="option"
-      >
-        <span
-          class="c11"
-        >
-          Quebec
-        </span>
-      </li>
-      <li
-        class="c10"
-        data-testid="listitem-bc"
-        id="listbox_uuid1_bc"
-        role="option"
-      >
-        <span
-          class="c11"
-        >
-          British Columbia
-        </span>
-      </li>
-      <li
-        class="c10"
+        class="c9"
         data-testid="listitem-ab"
-        id="listbox_uuid1_ab"
+        id="uuid1_listbox_ab"
         role="option"
+        selected=""
       >
         <span
-          class="c11"
+          class="c10"
         >
           Alberta
         </span>
       </li>
       <li
-        class="c10"
-        data-testid="listitem-mb"
-        id="listbox_uuid1_mb"
+        class="c11"
+        data-testid="listitem-bc"
+        id="uuid1_listbox_bc"
         role="option"
       >
         <span
-          class="c11"
+          class="c10"
+        >
+          British Columbia
+        </span>
+      </li>
+      <li
+        class="c11"
+        data-testid="listitem-mb"
+        id="uuid1_listbox_mb"
+        role="option"
+      >
+        <span
+          class="c10"
         >
           Manitoba
         </span>
       </li>
       <li
-        class="c10"
-        data-testid="listitem-sk"
-        id="listbox_uuid1_sk"
-        role="option"
-      >
-        <span
-          class="c11"
-        >
-          Saskatchewan
-        </span>
-      </li>
-      <li
-        class="c10"
-        data-testid="listitem-ns"
-        id="listbox_uuid1_ns"
-        role="option"
-      >
-        <span
-          class="c11"
-        >
-          Nova Scotia
-        </span>
-      </li>
-      <li
-        class="c10"
+        class="c11"
         data-testid="listitem-nb"
-        id="listbox_uuid1_nb"
+        id="uuid1_listbox_nb"
         role="option"
       >
         <span
-          class="c11"
+          class="c10"
         >
           New Brunswick
         </span>
       </li>
       <li
-        class="c10"
+        class="c11"
         data-testid="listitem-nl"
-        id="listbox_uuid1_nl"
+        id="uuid1_listbox_nl"
         role="option"
       >
         <span
-          class="c11"
+          class="c10"
         >
           Newfoundland and Labrador
         </span>
       </li>
       <li
-        class="c10"
-        data-testid="listitem-pe"
-        id="listbox_uuid1_pe"
-        role="option"
-      >
-        <span
-          class="c11"
-        >
-          Prince Edward Island
-        </span>
-      </li>
-      <li
-        class="c10"
+        class="c11"
         data-testid="listitem-nt"
-        id="listbox_uuid1_nt"
+        id="uuid1_listbox_nt"
         role="option"
       >
         <span
-          class="c11"
+          class="c10"
         >
           Northwest Territories
         </span>
       </li>
       <li
-        class="c10"
-        data-testid="listitem-nu"
-        id="listbox_uuid1_nu"
+        class="c11"
+        data-testid="listitem-ns"
+        id="uuid1_listbox_ns"
         role="option"
       >
         <span
-          class="c11"
+          class="c10"
+        >
+          Nova Scotia
+        </span>
+      </li>
+      <li
+        class="c11"
+        data-testid="listitem-nu"
+        id="uuid1_listbox_nu"
+        role="option"
+      >
+        <span
+          class="c10"
         >
           Nunavut
         </span>
       </li>
       <li
-        class="c10"
-        data-testid="listitem-yt"
-        id="listbox_uuid1_yt"
+        class="c11"
+        data-testid="listitem-on"
+        id="uuid1_listbox_on"
         role="option"
       >
         <span
-          class="c11"
+          class="c10"
+        >
+          Ontario
+        </span>
+      </li>
+      <li
+        class="c11"
+        data-testid="listitem-pe"
+        id="uuid1_listbox_pe"
+        role="option"
+      >
+        <span
+          class="c10"
+        >
+          Prince Edward Island
+        </span>
+      </li>
+      <li
+        class="c11"
+        data-testid="listitem-qc"
+        id="uuid1_listbox_qc"
+        role="option"
+      >
+        <span
+          class="c10"
+        >
+          Quebec
+        </span>
+      </li>
+      <li
+        class="c11"
+        data-testid="listitem-sk"
+        id="uuid1_listbox_sk"
+        role="option"
+      >
+        <span
+          class="c10"
+        >
+          Saskatchewan
+        </span>
+      </li>
+      <li
+        class="c11"
+        data-testid="listitem-yt"
+        id="uuid1_listbox_yt"
+        role="option"
+      >
+        <span
+          class="c10"
         >
           Yukon
         </span>
@@ -420,9 +392,8 @@ input + .c2 {
 </div>
 `;
 
-exports[`Select invalid select has a different style 1`] = `
-[
-  .c4 {
+exports[`Dropdown list matches the snapshot (invalid) 1`] = `
+.c4 {
   color: #CD2C23;
   display: -webkit-box;
   display: -webkit-flex;
@@ -486,7 +457,7 @@ input + .c2 {
   margin-bottom: var(--spacing-half);
 }
 
-.c9 {
+.c8 {
   background-color: #FFFFFF;
   border-radius: var(--border-radius);
   box-shadow: 0 0 0 1px #DBDEE1,0 10px 20px 0 rgb(0 0 0 / 19%);
@@ -501,17 +472,7 @@ input + .c2 {
   z-index: 1000;
 }
 
-.c9:focus {
-  outline: none;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c11 {
+.c10 {
   height: 100%;
   list-style-type: none;
   margin: 0;
@@ -519,7 +480,31 @@ input + .c2 {
   width: 100%;
 }
 
-.c12 {
+.c11 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
+  font-weight: var(--font-semi-bold);
+  line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
+  padding: var(--spacing-half) var(--spacing-2x);
+  padding-right: var(--spacing-1x);
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c11:hover {
+  background-color: #DBDEE1;
+}
+
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -532,15 +517,16 @@ input + .c2 {
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
 
-.c12:hover {
+.c13:hover {
   background-color: #DBDEE1;
 }
 
-.c13 {
+.c12 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -554,7 +540,7 @@ input + .c2 {
   position: relative;
 }
 
-.c10 {
+.c9 {
   position: absolute;
   width: 100%;
 }
@@ -567,417 +553,643 @@ input + .c2 {
   background-color: #FFFFFF;
   border: 1px solid #CD2C23;
   border-radius: var(--border-radius);
-  box-shadow: none;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2rem;
-  padding-right: var(--spacing-1x);
+  height: var(--size-2x);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
   width: 100%;
 }
 
-.c6:hover {
-  cursor: pointer;
-}
-
-.c6 svg {
-  color: #60666E;
-}
-
-.c7 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
+.c6:focus {
   outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
 }
 
-.c7:hover {
-  cursor: pointer;
-}
-
-.c7::-webkit-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c7::-moz-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c7:-ms-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c7::placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c8 > svg {
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
-<div
-    class="c0 c1"
-  >
-    <label
-      class="c2 c3"
-      for="uuid1"
-    >
-      Select an option
-    </label>
-    <span
-      aria-live="polite"
-      class="c4"
-      id="uuid1_invalid"
-      role="alert"
-    >
-      <svg
-        class="c5"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-      You must select an option
-    </span>
-    <div
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-owns="listbox_uuid1"
-      class="c6"
-      data-testid="input-wrapper"
-    >
-      <input
-        aria-autocomplete="list"
-        aria-controls="listbox_uuid1"
-        aria-label="Select an option"
-        aria-multiline="false"
-        class="c7"
-        data-testid="input"
-        id="uuid1"
-        type="text"
-        value=""
-      />
-      <button
-        aria-labelledby="uuid1"
-        class="c8"
-        data-testid="arrow"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          color="currentColor"
-          focusable="false"
-          height="16"
-          width="16"
-        />
-      </button>
-    </div>
-    <div
-      aria-labelledby="uuid1"
-      class="c9 c10"
-      data-testid="listbox-container"
-      id="listbox_uuid1"
-      role="listbox"
-      tabindex="0"
-    >
-      <ul
-        class="c11"
-        data-testid="listbox-list"
-        role="presentation"
-      >
-        <li
-          class="c12"
-          data-testid="listitem-on"
-          id="listbox_uuid1_on"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Ontario
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-qc"
-          id="listbox_uuid1_qc"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Quebec
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-bc"
-          id="listbox_uuid1_bc"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            British Columbia
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-ab"
-          id="listbox_uuid1_ab"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Alberta
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-mb"
-          id="listbox_uuid1_mb"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Manitoba
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-sk"
-          id="listbox_uuid1_sk"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Saskatchewan
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-ns"
-          id="listbox_uuid1_ns"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Nova Scotia
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-nb"
-          id="listbox_uuid1_nb"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            New Brunswick
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-nl"
-          id="listbox_uuid1_nl"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Newfoundland and Labrador
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-pe"
-          id="listbox_uuid1_pe"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Prince Edward Island
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-nt"
-          id="listbox_uuid1_nt"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Northwest Territories
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-nu"
-          id="listbox_uuid1_nu"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Nunavut
-          </span>
-        </li>
-        <li
-          class="c12"
-          data-testid="listitem-yt"
-          id="listbox_uuid1_yt"
-          role="option"
-        >
-          <span
-            class="c13"
-          >
-            Yukon
-          </span>
-        </li>
-      </ul>
-    </div>
-  </div>,
-  .c0 {
-  border: 0 !important;
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px !important;
-  overflow: hidden;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-}
-
-<input
-    class="c0"
-    data-testid="select-skip-option"
-    id="uuid2"
-    name="uuid1_skip"
-    type="radio"
-    value="skip"
-  />,
-  .c1 {
-  --border-radius: 8px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #FFFFFF;
-  border: 1px solid #60666E;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  color: #60666E;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 1rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  min-height: 3rem;
-  padding: var(--spacing-1x);
-  text-align: center;
-  -webkit-transition: all 0.25s ease-in-out;
-  transition: all 0.25s ease-in-out;
-}
-
-.c1:hover {
-  background: #DBDEE1;
-  border-color: #DBDEE1;
-}
-
-input[type="checkbox"]:checked + .c0,
-input[type="radio"]:checked + .c1 {
-  background: #006296;
-  border-color: #006296;
-  color: #FFFFFF;
-}
-
-input[type="checkbox"]:focus + .c0,
-input[type="radio"]:focus + .c1 {
+.c6:focus {
   outline: none;
   border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
 }
 
-input[type="checkbox"]:disabled + .c0,
-input[type="radio"]:disabled + .c1 {
-  background: #F1F2F2;
-  border-color: #DBDEE1;
-  color: #B7BBC2;
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #60666E;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
+  width: var(--size-1x);
 }
 
-.c1 b {
-  font-size: 1.5rem;
-  font-weight: var(--font-normal);
-  line-height: 2.5rem;
-}
-
-.c1 svg {
-  color: inherit;
-  height: 3rem;
-  width: 3rem;
-}
-
-<label
-    class="c0 c1"
-    for="uuid2"
+<div
+  class="c0 c1"
+>
+  <label
+    class="c2 c3"
+    for="uuid1"
+    id="uuid1_label"
   >
-    Skip this question
-  </label>,
-]
+    Select an option
+  </label>
+  <span
+    aria-live="polite"
+    class="c4"
+    id="uuid1_invalid"
+    role="alert"
+  >
+    <svg
+      class="c5"
+      color="currentColor"
+      focusable="false"
+      height="16"
+      width="16"
+    />
+    You must select an option
+  </span>
+  <div
+    aria-activedescendant="uuid1_ab"
+    aria-controls="uuid1_listbox"
+    aria-describedby="uuid1_invalid"
+    aria-expanded="true"
+    aria-invalid="true"
+    aria-labelledby="uuid1_label"
+    aria-required="false"
+    class="c6"
+    data-testid="textbox"
+    id="uuid1"
+    role="combobox"
+    tabindex="0"
+    value="ab"
+  >
+    <input
+      data-testid="input"
+      type="hidden"
+      value="ab"
+    />
+    Alberta
+    <svg
+      aria-hidden="true"
+      class="c7"
+      color="currentColor"
+      data-testid="arrow"
+      focusable="false"
+      height="16"
+      width="16"
+    />
+  </div>
+  <div
+    aria-activedescendant="uuid1_listbox_ab"
+    aria-labelledby="uuid1_label"
+    class="c8 c9"
+    data-testid="listbox-container"
+    id="uuid1_listbox"
+    role="listbox"
+    tabindex="-1"
+  >
+    <ul
+      class="c10"
+      data-testid="listbox-list"
+      role="presentation"
+    >
+      <li
+        class="c11"
+        data-testid="listitem-ab"
+        id="uuid1_listbox_ab"
+        role="option"
+        selected=""
+      >
+        <span
+          class="c12"
+        >
+          Alberta
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-bc"
+        id="uuid1_listbox_bc"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          British Columbia
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-mb"
+        id="uuid1_listbox_mb"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Manitoba
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-nb"
+        id="uuid1_listbox_nb"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          New Brunswick
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-nl"
+        id="uuid1_listbox_nl"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Newfoundland and Labrador
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-nt"
+        id="uuid1_listbox_nt"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Northwest Territories
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-ns"
+        id="uuid1_listbox_ns"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Nova Scotia
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-nu"
+        id="uuid1_listbox_nu"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Nunavut
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-on"
+        id="uuid1_listbox_on"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Ontario
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-pe"
+        id="uuid1_listbox_pe"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Prince Edward Island
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-qc"
+        id="uuid1_listbox_qc"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Quebec
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-sk"
+        id="uuid1_listbox_sk"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Saskatchewan
+        </span>
+      </li>
+      <li
+        class="c13"
+        data-testid="listitem-yt"
+        id="uuid1_listbox_yt"
+        role="option"
+      >
+        <span
+          class="c12"
+        >
+          Yukon
+        </span>
+      </li>
+    </ul>
+  </div>
+</div>
 `;
 
-exports[`Select matches the snapshot 1`] = `
-[
-  .c3 {
+exports[`Dropdown list matches the snapshot (mobile) 1`] = `
+.c0 {
+  margin: 0 0 var(--spacing-3x);
+}
+
+.c0 input,
+.c0 select,
+.c0 textarea {
+  border-color: #60666E;
+}
+
+.c0:focus {
+  border-color: #006296;
+}
+
+.c0 > :nth-child(0) {
+  margin-bottom: var(--spacing-half);
+}
+
+.c4 {
+  background-color: #FFFFFF;
+  border-radius: var(--border-radius);
+  box-shadow: 0 0 0 1px #DBDEE1,0 10px 20px 0 rgb(0 0 0 / 19%);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  max-height: 160px;
+  overflow-y: auto;
+  padding: var(--spacing-half) 0;
+  position: relative;
+  z-index: 1000;
+}
+
+.c6 {
+  height: 100%;
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.c7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1rem;
+  font-weight: var(--font-semi-bold);
+  line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
+  padding: var(--spacing-half) var(--spacing-2x);
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c7:hover {
+  background-color: #DBDEE1;
+}
+
+.c9 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 1rem;
+  font-weight: var(--font-normal);
+  line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
+  padding: var(--spacing-half) var(--spacing-2x);
+}
+
+.c9:hover {
+  background-color: #DBDEE1;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1 {
+  position: relative;
+}
+
+.c5 {
+  position: absolute;
+  width: 100%;
+}
+
+.c2 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: #FFFFFF;
+  border: 1px solid #60666E;
+  border-radius: var(--border-radius);
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: var(--size-2halfx);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
+  width: 100%;
+}
+
+.c2:focus {
+  outline: none;
+}
+
+.c2:focus {
+  outline: none;
+  border-color: #006296;
+  box-shadow: 0 0 0 2px #84C6EA;
+}
+
+.c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #60666E;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
+  width: var(--size-1x);
+}
+
+<div
+  class="c0 c1"
+>
+  <div
+    aria-activedescendant="uuid1_ab"
+    aria-controls="uuid1_listbox"
+    aria-expanded="true"
+    aria-invalid="false"
+    aria-label="Select an option"
+    aria-labelledby="uuid1_label"
+    aria-required="false"
+    class="c2"
+    data-testid="textbox"
+    id="uuid1"
+    role="combobox"
+    tabindex="0"
+    value="ab"
+  >
+    <input
+      data-testid="input"
+      type="hidden"
+      value="ab"
+    />
+    Alberta
+    <svg
+      aria-hidden="true"
+      class="c3"
+      color="currentColor"
+      data-testid="arrow"
+      focusable="false"
+      height="24"
+      width="24"
+    />
+  </div>
+  <div
+    aria-activedescendant="uuid1_listbox_ab"
+    aria-labelledby="uuid1_label"
+    class="c4 c5"
+    data-testid="listbox-container"
+    id="uuid1_listbox"
+    role="listbox"
+    tabindex="-1"
+  >
+    <ul
+      class="c6"
+      data-testid="listbox-list"
+      role="presentation"
+    >
+      <li
+        class="c7"
+        data-testid="listitem-ab"
+        id="uuid1_listbox_ab"
+        role="option"
+        selected=""
+      >
+        <span
+          class="c8"
+        >
+          Alberta
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-bc"
+        id="uuid1_listbox_bc"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          British Columbia
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-mb"
+        id="uuid1_listbox_mb"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Manitoba
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-nb"
+        id="uuid1_listbox_nb"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          New Brunswick
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-nl"
+        id="uuid1_listbox_nl"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Newfoundland and Labrador
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-nt"
+        id="uuid1_listbox_nt"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Northwest Territories
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-ns"
+        id="uuid1_listbox_ns"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Nova Scotia
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-nu"
+        id="uuid1_listbox_nu"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Nunavut
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-on"
+        id="uuid1_listbox_on"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Ontario
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-pe"
+        id="uuid1_listbox_pe"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Prince Edward Island
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-qc"
+        id="uuid1_listbox_qc"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Quebec
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-sk"
+        id="uuid1_listbox_sk"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Saskatchewan
+        </span>
+      </li>
+      <li
+        class="c9"
+        data-testid="listitem-yt"
+        id="uuid1_listbox_yt"
+        role="option"
+      >
+        <span
+          class="c8"
+        >
+          Yukon
+        </span>
+      </li>
+    </ul>
+  </div>
+</div>
+`;
+
+exports[`Dropdown list matches the snapshot 1`] = `
+.c3 {
   color: #000000;
   display: block;
   font-size: 0.75rem;
@@ -1011,8 +1223,20 @@ input + .c2 {
   border-color: #006296;
 }
 
-.c0 > :nth-child(1) {
+.c0 > :nth-child(2) {
   margin-bottom: var(--spacing-half);
+}
+
+.c4 {
+  color: #60666E;
+  display: block;
+  font-size: 0.75rem;
+  font-weight: var(--font-normal);
+  -webkit-letter-spacing: 0.02rem;
+  -moz-letter-spacing: 0.02rem;
+  -ms-letter-spacing: 0.02rem;
+  letter-spacing: 0.02rem;
+  line-height: 1.25rem;
 }
 
 .c7 {
@@ -1028,16 +1252,6 @@ input + .c2 {
   padding: var(--spacing-half) 0;
   position: relative;
   z-index: 1000;
-}
-
-.c7:focus {
-  outline: none;
-}
-
-.c7:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
 }
 
 .c9 {
@@ -1059,13 +1273,38 @@ input + .c2 {
   display: -ms-flexbox;
   display: flex;
   font-size: 0.875rem;
+  font-weight: var(--font-semi-bold);
+  line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
+  padding: var(--spacing-half) var(--spacing-2x);
+  padding-right: var(--spacing-1x);
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c10:hover {
+  background-color: #DBDEE1;
+}
+
+.c12 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #000000;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
 
-.c10:hover {
+.c12:hover {
   background-color: #DBDEE1;
 }
 
@@ -1088,7 +1327,7 @@ input + .c2 {
   width: 100%;
 }
 
-.c4 {
+.c5 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1096,431 +1335,18 @@ input + .c2 {
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
-  box-shadow: none;
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2rem;
-  padding-right: var(--spacing-1x);
+  height: var(--size-2x);
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: 0 var(--spacing-1x);
   width: 100%;
-}
-
-.c4:hover {
-  cursor: pointer;
-}
-
-.c4 svg {
-  color: #60666E;
-}
-
-.c5 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c5:hover {
-  cursor: pointer;
-}
-
-.c5::-webkit-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c5::-moz-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c5:-ms-input-placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c5::placeholder {
-  color: #60666E;
-  font-size: 0.875rem;
-}
-
-.c6 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c6 > svg {
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
-<div
-    class="c0 c1"
-  >
-    <label
-      class="c2 c3"
-      for="uuid1"
-    >
-      Select an option
-    </label>
-    <div
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-owns="listbox_uuid1"
-      class="c4"
-      data-testid="input-wrapper"
-    >
-      <input
-        aria-autocomplete="list"
-        aria-controls="listbox_uuid1"
-        aria-label="Select an option"
-        aria-multiline="false"
-        class="c5"
-        data-testid="input"
-        id="uuid1"
-        type="text"
-        value=""
-      />
-      <button
-        aria-labelledby="uuid1"
-        class="c6"
-        data-testid="arrow"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          color="currentColor"
-          focusable="false"
-          height="16"
-          width="16"
-        />
-      </button>
-    </div>
-    <div
-      aria-labelledby="uuid1"
-      class="c7 c8"
-      data-testid="listbox-container"
-      id="listbox_uuid1"
-      role="listbox"
-      tabindex="0"
-    >
-      <ul
-        class="c9"
-        data-testid="listbox-list"
-        role="presentation"
-      >
-        <li
-          class="c10"
-          data-testid="listitem-on"
-          id="listbox_uuid1_on"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Ontario
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-qc"
-          id="listbox_uuid1_qc"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Quebec
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-bc"
-          id="listbox_uuid1_bc"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            British Columbia
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-ab"
-          id="listbox_uuid1_ab"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Alberta
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-mb"
-          id="listbox_uuid1_mb"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Manitoba
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-sk"
-          id="listbox_uuid1_sk"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Saskatchewan
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-ns"
-          id="listbox_uuid1_ns"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Nova Scotia
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-nb"
-          id="listbox_uuid1_nb"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            New Brunswick
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-nl"
-          id="listbox_uuid1_nl"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Newfoundland and Labrador
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-pe"
-          id="listbox_uuid1_pe"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Prince Edward Island
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-nt"
-          id="listbox_uuid1_nt"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Northwest Territories
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-nu"
-          id="listbox_uuid1_nu"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Nunavut
-          </span>
-        </li>
-        <li
-          class="c10"
-          data-testid="listitem-yt"
-          id="listbox_uuid1_yt"
-          role="option"
-        >
-          <span
-            class="c11"
-          >
-            Yukon
-          </span>
-        </li>
-      </ul>
-    </div>
-  </div>,
-  .c0 {
-  border: 0 !important;
-  -webkit-clip: rect(1px,1px,1px,1px);
-  clip: rect(1px,1px,1px,1px);
-  height: 1px !important;
-  overflow: hidden;
-  padding: 0 !important;
-  position: absolute !important;
-  width: 1px !important;
-}
-
-<input
-    class="c0"
-    data-testid="select-skip-option"
-    id="uuid2"
-    name="uuid1_skip"
-    type="radio"
-    value="skip"
-  />,
-  .c1 {
-  --border-radius: 8px;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background: #FFFFFF;
-  border: 1px solid #60666E;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  color: #60666E;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 1rem;
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0;
-  -moz-letter-spacing: 0;
-  -ms-letter-spacing: 0;
-  letter-spacing: 0;
-  line-height: 1.5rem;
-  min-height: 3rem;
-  padding: var(--spacing-1x);
-  text-align: center;
-  -webkit-transition: all 0.25s ease-in-out;
-  transition: all 0.25s ease-in-out;
-}
-
-.c1:hover {
-  background: #DBDEE1;
-  border-color: #DBDEE1;
-}
-
-input[type="checkbox"]:checked + .c0,
-input[type="radio"]:checked + .c1 {
-  background: #006296;
-  border-color: #006296;
-  color: #FFFFFF;
-}
-
-input[type="checkbox"]:focus + .c0,
-input[type="radio"]:focus + .c1 {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-input[type="checkbox"]:disabled + .c0,
-input[type="radio"]:disabled + .c1 {
-  background: #F1F2F2;
-  border-color: #DBDEE1;
-  color: #B7BBC2;
-}
-
-.c1 b {
-  font-size: 1.5rem;
-  font-weight: var(--font-normal);
-  line-height: 2.5rem;
-}
-
-.c1 svg {
-  color: inherit;
-  height: 3rem;
-  width: 3rem;
-}
-
-<label
-    class="c0 c1"
-    for="uuid2"
-  >
-    Skip this question
-  </label>,
-]
-`;
-
-exports[`Select mobile select has a different style 1`] = `
-.c0 {
-  margin: 0 0 var(--spacing-3x);
-}
-
-.c0 input,
-.c0 select,
-.c0 textarea {
-  border-color: #60666E;
-}
-
-.c0:focus {
-  border-color: #006296;
-}
-
-.c0 > :nth-child(0) {
-  margin-bottom: var(--spacing-half);
-}
-
-.c5 {
-  background-color: #FFFFFF;
-  border-radius: var(--border-radius);
-  box-shadow: 0 0 0 1px #DBDEE1,0 10px 20px 0 rgb(0 0 0 / 19%);
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  max-height: 160px;
-  overflow-y: auto;
-  padding: var(--spacing-half) 0;
-  position: relative;
-  z-index: 1000;
 }
 
 .c5:focus {
@@ -1529,347 +1355,240 @@ exports[`Select mobile select has a different style 1`] = `
 
 .c5:focus {
   outline: none;
+  border-color: #006296;
   box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c7 {
-  height: 100%;
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  width: 100%;
-}
-
-.c8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #000000;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-size: 1rem;
-  font-weight: var(--font-normal);
-  line-height: var(--size-1halfx);
-  padding: var(--spacing-half) var(--spacing-2x);
-}
-
-.c8:hover {
-  background-color: #DBDEE1;
-}
-
-.c9 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-}
-
-.c1 {
-  position: relative;
 }
 
 .c6 {
-  position: absolute;
-  width: 100%;
-}
-
-.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
-  border: 1px solid #60666E;
-  border-radius: var(--border-radius);
-  box-shadow: none;
-  box-sizing: border-box;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  height: 2.5rem;
-  padding-right: var(--spacing-1x);
-  width: 100%;
-}
-
-.c2:hover {
-  cursor: pointer;
-}
-
-.c2 svg {
-  color: #60666E;
-}
-
-.c3 {
-  background-color: #FFFFFF;
-  border: none;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  caret-color: transparent;
-  font-size: 1rem;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  max-height: 100%;
-  min-width: 0;
-  outline: none;
-  overflow: hidden;
-  padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
-}
-
-.c3:hover {
-  cursor: pointer;
-}
-
-.c3::-webkit-input-placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c3::-moz-placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c3:-ms-input-placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c3::placeholder {
-  color: #60666E;
-  font-size: 1rem;
-}
-
-.c4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  cursor: pointer;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.c4 > svg {
   height: var(--size-1x);
+  margin-left: auto;
+  padding: var(--spacing-half);
   width: var(--size-1x);
 }
 
 <div
   class="c0 c1"
 >
+  <label
+    class="c2 c3"
+    for="uuid1"
+    id="uuid1_label"
+  >
+    Select an option
+  </label>
+  <span
+    class="c4"
+    id="uuid1_hint"
+  >
+    Hint
+  </span>
   <div
+    aria-activedescendant="uuid1_ab"
+    aria-controls="uuid1_listbox"
+    aria-describedby="uuid1_hint"
     aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-owns="listbox_uuid1"
-    class="c2"
-    data-testid="input-wrapper"
+    aria-invalid="false"
+    aria-labelledby="uuid1_label"
+    aria-required="false"
+    class="c5"
+    data-testid="textbox"
+    id="uuid1"
+    role="combobox"
+    tabindex="0"
+    value="ab"
   >
     <input
-      aria-autocomplete="list"
-      aria-controls="listbox_uuid1"
-      aria-label="Select an option"
-      aria-multiline="false"
-      class="c3"
       data-testid="input"
-      id="uuid1"
-      type="text"
-      value=""
+      type="hidden"
+      value="ab"
     />
-    <button
-      aria-labelledby="uuid1"
-      class="c4"
+    Alberta
+    <svg
+      aria-hidden="true"
+      class="c6"
+      color="currentColor"
       data-testid="arrow"
-      tabindex="-1"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
+      focusable="false"
+      height="16"
+      width="16"
+    />
   </div>
   <div
-    aria-labelledby="uuid1"
-    class="c5 c6"
+    aria-activedescendant="uuid1_listbox_ab"
+    aria-labelledby="uuid1_label"
+    class="c7 c8"
     data-testid="listbox-container"
-    id="listbox_uuid1"
+    id="uuid1_listbox"
     role="listbox"
-    tabindex="0"
+    tabindex="-1"
   >
     <ul
-      class="c7"
+      class="c9"
       data-testid="listbox-list"
       role="presentation"
     >
       <li
-        class="c8"
-        data-testid="listitem-on"
-        id="listbox_uuid1_on"
-        role="option"
-      >
-        <span
-          class="c9"
-        >
-          Ontario
-        </span>
-      </li>
-      <li
-        class="c8"
-        data-testid="listitem-qc"
-        id="listbox_uuid1_qc"
-        role="option"
-      >
-        <span
-          class="c9"
-        >
-          Quebec
-        </span>
-      </li>
-      <li
-        class="c8"
-        data-testid="listitem-bc"
-        id="listbox_uuid1_bc"
-        role="option"
-      >
-        <span
-          class="c9"
-        >
-          British Columbia
-        </span>
-      </li>
-      <li
-        class="c8"
+        class="c10"
         data-testid="listitem-ab"
-        id="listbox_uuid1_ab"
+        id="uuid1_listbox_ab"
         role="option"
+        selected=""
       >
         <span
-          class="c9"
+          class="c11"
         >
           Alberta
         </span>
       </li>
       <li
-        class="c8"
-        data-testid="listitem-mb"
-        id="listbox_uuid1_mb"
+        class="c12"
+        data-testid="listitem-bc"
+        id="uuid1_listbox_bc"
         role="option"
       >
         <span
-          class="c9"
+          class="c11"
+        >
+          British Columbia
+        </span>
+      </li>
+      <li
+        class="c12"
+        data-testid="listitem-mb"
+        id="uuid1_listbox_mb"
+        role="option"
+      >
+        <span
+          class="c11"
         >
           Manitoba
         </span>
       </li>
       <li
-        class="c8"
-        data-testid="listitem-sk"
-        id="listbox_uuid1_sk"
-        role="option"
-      >
-        <span
-          class="c9"
-        >
-          Saskatchewan
-        </span>
-      </li>
-      <li
-        class="c8"
-        data-testid="listitem-ns"
-        id="listbox_uuid1_ns"
-        role="option"
-      >
-        <span
-          class="c9"
-        >
-          Nova Scotia
-        </span>
-      </li>
-      <li
-        class="c8"
+        class="c12"
         data-testid="listitem-nb"
-        id="listbox_uuid1_nb"
+        id="uuid1_listbox_nb"
         role="option"
       >
         <span
-          class="c9"
+          class="c11"
         >
           New Brunswick
         </span>
       </li>
       <li
-        class="c8"
+        class="c12"
         data-testid="listitem-nl"
-        id="listbox_uuid1_nl"
+        id="uuid1_listbox_nl"
         role="option"
       >
         <span
-          class="c9"
+          class="c11"
         >
           Newfoundland and Labrador
         </span>
       </li>
       <li
-        class="c8"
-        data-testid="listitem-pe"
-        id="listbox_uuid1_pe"
-        role="option"
-      >
-        <span
-          class="c9"
-        >
-          Prince Edward Island
-        </span>
-      </li>
-      <li
-        class="c8"
+        class="c12"
         data-testid="listitem-nt"
-        id="listbox_uuid1_nt"
+        id="uuid1_listbox_nt"
         role="option"
       >
         <span
-          class="c9"
+          class="c11"
         >
           Northwest Territories
         </span>
       </li>
       <li
-        class="c8"
-        data-testid="listitem-nu"
-        id="listbox_uuid1_nu"
+        class="c12"
+        data-testid="listitem-ns"
+        id="uuid1_listbox_ns"
         role="option"
       >
         <span
-          class="c9"
+          class="c11"
+        >
+          Nova Scotia
+        </span>
+      </li>
+      <li
+        class="c12"
+        data-testid="listitem-nu"
+        id="uuid1_listbox_nu"
+        role="option"
+      >
+        <span
+          class="c11"
         >
           Nunavut
         </span>
       </li>
       <li
-        class="c8"
-        data-testid="listitem-yt"
-        id="listbox_uuid1_yt"
+        class="c12"
+        data-testid="listitem-on"
+        id="uuid1_listbox_on"
         role="option"
       >
         <span
-          class="c9"
+          class="c11"
+        >
+          Ontario
+        </span>
+      </li>
+      <li
+        class="c12"
+        data-testid="listitem-pe"
+        id="uuid1_listbox_pe"
+        role="option"
+      >
+        <span
+          class="c11"
+        >
+          Prince Edward Island
+        </span>
+      </li>
+      <li
+        class="c12"
+        data-testid="listitem-qc"
+        id="uuid1_listbox_qc"
+        role="option"
+      >
+        <span
+          class="c11"
+        >
+          Quebec
+        </span>
+      </li>
+      <li
+        class="c12"
+        data-testid="listitem-sk"
+        id="uuid1_listbox_sk"
+        role="option"
+      >
+        <span
+          class="c11"
+        >
+          Saskatchewan
+        </span>
+      </li>
+      <li
+        class="c12"
+        data-testid="listitem-yt"
+        id="uuid1_listbox_yt"
+        role="option"
+      >
+        <span
+          class="c11"
         >
           Yukon
         </span>

--- a/packages/react/src/components/dropdown-list/dropdown-list.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.tsx
@@ -1,9 +1,7 @@
 import {
-    ChangeEvent,
+    FocusEvent,
     KeyboardEvent,
     useCallback,
-    useEffect,
-    useMemo,
     useRef,
     useState,
     VoidFunctionComponent,
@@ -12,51 +10,43 @@ import styled from 'styled-components';
 import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { useTranslation } from '../../i18n/use-translation';
 import { Theme } from '../../themes';
-import { eventIsInside } from '../../utils/events';
+import { focus } from '../../utils/css-state';
 import { isLetterOrNumber } from '../../utils/regex';
-import { v4 as uuid } from '../../utils/uuid';
-import { ChooserButton } from '../chooser-button/chooser-button';
 import { useDeviceContext } from '../device-context-provider/device-context-provider';
-import { FieldContainer, FieldContainerProps } from '../field-container/field-container';
+import { FieldContainer } from '../field-container/field-container';
 import { Icon } from '../icon/icon';
 import { Listbox, ListboxOption } from '../listbox/listbox';
 import { TooltipProps } from '../tooltip/tooltip';
+import { useAriaConditionalIds } from '../../hooks/use-aria-conditional-ids';
+import { useId } from '../../hooks/use-id';
+import { useListCursor } from '../../hooks/use-list-cursor';
+import { useClickOutside } from '../../hooks/use-click-outside';
+import { useListSearch } from '../../hooks/use-list-search';
 
-interface InputProps {
-    searchable?: boolean;
-    isMobile: boolean;
-    disabled?: boolean;
+interface TextboxProps {
+    $disabled?: boolean;
+    $isMobile: boolean;
     theme: Theme;
+    $valid: boolean;
+    value: string;
 }
 
-interface InputWrapperProps extends InputProps {
-    isMobile: boolean;
-    focus?: boolean;
-    containerOutline: boolean;
-    valid: boolean;
-}
-
-export interface Option extends ListboxOption {
+export interface DropdownListOption extends ListboxOption {
     label: string;
 }
 
-function getBorderColor({
-    disabled, focus, theme, valid,
-}: InputWrapperProps): string {
-    if (disabled) {
-        return theme.greys.grey;
+function getBorderColor({ $disabled, theme, $valid }: TextboxProps): string {
+    if ($disabled) {
+        return theme.greys['mid-grey'];
     }
-    if (!valid) {
+    if (!$valid) {
         return theme.notifications['alert-2.1'];
-    }
-    if (focus) {
-        return theme.main['primary-1.1'];
     }
 
     return theme.greys['dark-grey'];
 }
 
-const StyledFieldContainer = styled(FieldContainer)<FieldContainerProps>`
+const StyledFieldContainer = styled(FieldContainer)`
     position: relative;
 `;
 
@@ -65,82 +55,35 @@ const StyledListbox = styled(Listbox)`
     width: 100%;
 `;
 
-const InputWrapper = styled.div<InputWrapperProps>`
+const Textbox = styled.div<TextboxProps>`
     align-items: center;
-    background-color: ${({ disabled, theme }) => (disabled ? theme.greys['light-grey'] : theme.greys.white)};
+    background-color: ${({ $disabled, theme }) => ($disabled ? theme.greys['light-grey'] : theme.greys.white)};
     border: 1px solid ${getBorderColor};
     border-radius: var(--border-radius);
-    box-shadow: ${({ containerOutline, theme }) => (containerOutline ? theme.tokens['focus-box-shadow'] : 'none')};
     box-sizing: border-box;
+    ${({ $disabled, theme }) => $disabled && `color: ${theme.greys['mid-grey']}`};
     display: flex;
-    height: ${({ isMobile }) => (isMobile ? '2.5rem' : '2rem')};
-    padding-right: var(--spacing-1x);
+    height: ${({ $isMobile }) => ($isMobile ? 'var(--size-2halfx)' : 'var(--size-2x)')};
+    justify-content: space-between;
+    padding: 0 var(--spacing-1x);
     width: 100%;
-
-    &:hover {
-        cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
-    }
-
-    svg {
-        color: ${({ disabled, theme }) => (disabled ? theme.greys['mid-grey'] : theme.greys['dark-grey'])};
-    }
+    
+    ${({ theme }) => focus({ theme }, true)};
 `;
 
-function getInputCursor({ disabled, searchable }: InputProps): string {
-    if (disabled) {
-        return 'default';
-    }
-    if (searchable) {
-        return 'text';
-    }
-    return 'pointer';
-}
-
-function filterOptions(optionsArray: Option[], filterValue: string): Option[] {
-    return optionsArray.filter((option) => option.label.toLowerCase().startsWith(filterValue.toLowerCase()));
-}
-
-const StyledInput = styled.input<InputProps>`
-    background-color: ${({ disabled, theme }) => (disabled ? theme.greys['light-grey'] : theme.greys.white)};
-    border: none;
-    border-radius: var(--border-radius);
-    box-sizing: border-box;
-    caret-color: ${({ searchable }) => (searchable ? 'unset' : 'transparent')};
-    font-size: ${({ isMobile }) => (isMobile ? '1rem' : '0.875rem')};
-    letter-spacing: 0.025rem;
-    max-height: 100%;
-    min-width: 0;
-    outline: none;
-    overflow: hidden;
-    padding: var(--spacing-1x) 0 var(--spacing-1x) var(--spacing-1x);
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    width: 100%;
-
-    &:hover {
-        cursor: ${getInputCursor};
-    }
-
-    &::placeholder {
-        color: ${({ disabled, theme }) => (disabled ? theme.greys['mid-grey'] : theme.greys['dark-grey'])};
-        font-size: ${({ isMobile }) => (isMobile ? '1rem' : '0.875rem')};
-    }
-`;
-
-const Arrow = styled.button<{ disabled?: boolean }>`
+const Arrow = styled(Icon)<{ $disabled?: boolean }>`
     align-items: center;
-    cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
+    color: ${({ $disabled, theme }) => ($disabled ? theme.greys['mid-grey'] : theme.greys['dark-grey'])};
     display: flex;
-
-    > svg {
-        height: var(--size-1x);
-        width: var(--size-1x);
-    }
+    height: var(--size-1x);
+    margin-left: auto;
+    padding: var(--spacing-half);
+    width: var(--size-1x);
 `;
 
 interface DropdownListProps {
     /**
-     * Sets input's aria-label
+     * Aria label for the input (used when no visual label is present)
      */
     ariaLabel?: string;
     className?: string;
@@ -164,17 +107,8 @@ interface DropdownListProps {
     /**
      * { disabled?: boolean, value: string; label: string; }[]
      */
-    options: Option[];
-    placeholder?: string;
+    options: DropdownListOption[];
     required?: boolean;
-    /**
-     * Adds search functionality with autocomplete
-     */
-    searchable?: boolean;
-    /**
-     * Adds a skip button
-     */
-    skipOption?: { label: string; value?: string };
     tooltip?: TooltipProps;
     /**
      * Sets input validity
@@ -194,8 +128,11 @@ interface DropdownListProps {
     /**
      * OnChange callback function, invoked when an option is selected
      */
-    onChange?(option: Option): void;
+    onChange?(option: DropdownListOption): void;
 }
+
+const optionPredicate: (option: DropdownListOption) => boolean = (option) => !option.disabled;
+const searchPropertyAccessor: (option: DropdownListOption) => string = (option) => option.label;
 
 export const DropdownList: VoidFunctionComponent<DropdownListProps> = ({
     ariaLabel,
@@ -204,15 +141,12 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps> = ({
     defaultValue,
     disabled,
     noMargin,
-    id,
+    id: providedId,
     label,
     onChange,
     options,
     name,
-    placeholder,
     required,
-    searchable,
-    skipOption,
     tooltip,
     valid = true,
     validationErrorMessage,
@@ -220,410 +154,265 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps> = ({
     hint,
     ...otherProps
 }) => {
-    const { t } = useTranslation('select');
+    const { t } = useTranslation('dropdown-list');
     const { device, isMobile } = useDeviceContext();
-    const fieldId = useMemo(() => id || uuid(), [id]);
+    const id = useId(providedId);
     const dataAttributes = useDataAttributes(otherProps);
 
-    const [autoFocus, setAutofocus] = useState(false);
-    const [containerOutline, setContainerOutline] = useState(false);
-    const [focus, setFocus] = useState(false);
-    const [open, setOpen] = useState(defaultOpen);
-    const [searchValue, setSearchValue] = useState('');
-    const [focusedValue, setFocusedValue] = useState<string>();
-    const [selectedOptionValue, setSelectedOptionValue] = useState(defaultValue || value);
-    const skipSelected = useMemo(
-        () => skipOption && skipOption.value === selectedOptionValue,
-        [selectedOptionValue, skipOption],
-    );
-    const inputRef = useRef<HTMLInputElement>(null);
-    const wrapperRef = useRef<HTMLDivElement>(null);
+    const textboxRef = useRef<HTMLDivElement>(null);
     const listboxRef = useRef<HTMLDivElement>(null);
-    const [shouldFilterOptions, setShouldFilterOptions] = useState<boolean | undefined>(searchable);
-    const filteredOptions = useMemo(
-        () => {
-            if (!shouldFilterOptions) {
-                return options;
-            }
-            return filterOptions(options, searchValue);
-        },
-        [options, searchValue, shouldFilterOptions],
+
+    const [open, setOpen] = useState(defaultOpen);
+
+    function findOptionByValue(searchValue?: string): DropdownListOption | undefined {
+        return options.find((option) => option.value === searchValue);
+    }
+
+    function getDefaultOption(): DropdownListOption | undefined {
+        let defaultOption: DropdownListOption | undefined;
+
+        if (value !== undefined || defaultValue !== undefined) {
+            defaultOption = findOptionByValue(value ?? defaultValue);
+        }
+
+        if (defaultOption === undefined) {
+            defaultOption = options.find(optionPredicate);
+        }
+
+        return defaultOption;
+    }
+
+    const [selectedOption, setSelectedOption] = useState<DropdownListOption | undefined>(
+        () => getDefaultOption(),
     );
 
-    const findOptionByValue: (needle?: string) => Option | undefined = useCallback(
-        (needle) => options.find((option) => option.value === needle),
-        [options],
-    );
-    const [inputValue, setInputValue] = useState(() => findOptionByValue(selectedOptionValue)?.label ?? '');
+    const {
+        selectedElement: focusedOption,
+        setSelectedElement: setFocusedOption,
+        selectPrevious: focusPreviousOption,
+        selectNext: focusNextOption,
+        selectFirst: focusFirstOption,
+        selectLast: focusLastOption,
+    } = useListCursor({
+        elements: options,
+        initialElement: selectedOption,
+        predicate: optionPredicate,
+    });
 
-    useEffect(() => {
-        const wantedOption = findOptionByValue(value);
-        if (wantedOption) {
-            setSelectedOptionValue(wantedOption.value);
-            setInputValue(wantedOption.label);
-        } else if (skipOption && skipOption.value === value) {
-            setSelectedOptionValue(skipOption.value);
-            setInputValue('');
-        }
-    }, [findOptionByValue, options, skipOption, skipSelected, value]);
+    const [previousValue, setPreviousValue] = useState<string | undefined>(value);
 
-    const handleOpen: () => void = useCallback(() => {
-        if (!disabled) {
-            if (!open) {
-                setFocus(true);
-                if (searchable && inputRef.current) {
-                    inputRef.current.focus();
-                    setFocusedValue('');
-                } else {
-                    setFocusedValue(selectedOptionValue);
-                }
-            } else {
-                inputRef.current?.focus();
-                setAutofocus(false);
-                setFocusedValue('');
-            }
-            setOpen(!open);
-        }
-    }, [disabled, open, searchable, selectedOptionValue]);
-
-    const handleClickOutside: (event: MouseEvent) => void = useCallback((event) => {
-        const clickIsOutside = !eventIsInside(event, wrapperRef.current, listboxRef.current);
-        const shouldClose = (wrapperRef.current === null || clickIsOutside) && open;
-
-        if (shouldClose) {
-            handleOpen();
-            inputRef.current?.blur();
-        }
-    }, [open, handleOpen]);
-
-    useEffect(() => {
-        document.addEventListener('mouseup', handleClickOutside);
-        return () => document.removeEventListener('mouseup', handleClickOutside);
-    }, [handleClickOutside, open]);
-
-    function findOption(optionsArray: Option[], findValue: string): Option | undefined {
-        return optionsArray.find((option) => option.label.toLowerCase() === findValue.toLowerCase());
+    if (value !== previousValue) {
+        const newOption = findOptionByValue(value);
+        setSelectedOption(newOption);
+        setFocusedOption(newOption);
+        setPreviousValue(value);
     }
 
-    function focusFirstElementFromArray(array: Option[]): void {
-        const firstArrayElement = array.find((element) => !element.disabled);
-
-        if (firstArrayElement) {
-            setFocusedValue(firstArrayElement.value);
+    function openListbox(): void {
+        if (disabled) {
+            return;
         }
-    }
 
-    function focusLastElementFromArray(array: Option[]): void {
-        const lastArrayElement = [...array].reverse().find((element) => !element.disabled);
-
-        if (lastArrayElement) {
-            setFocusedValue(lastArrayElement.value);
+        if (!focusedOption && selectedOption) {
+            setFocusedOption(selectedOption);
         }
+
+        setOpen(true);
     }
 
-    function resetField(): void {
-        setFocusedValue('');
-        setInputValue('');
-        setSelectedOptionValue('');
-        setSearchValue('');
-    }
-
-    const matchInputValueToOption: () => void = useCallback(() => {
-        const matchingOption = findOption(options, inputValue);
-
-        if (matchingOption) {
-            setSelectedOptionValue(matchingOption.value);
-            setInputValue(matchingOption.label);
-        }
-    }, [inputValue, options]);
-
-    function handleSkipChange(): void {
-        if (!skipSelected && skipOption) {
-            setSelectedOptionValue(skipOption.value);
-            setInputValue('');
-            onChange?.({ label: skipOption.label, value: skipOption.value ?? skipOption.label });
-        }
-    }
-
-    function handleArrowClick(): void {
-        handleOpen();
-        matchInputValueToOption();
-    }
-
-    function handleBlur(): void {
-        matchInputValueToOption();
-        if (!open) {
-            setFocus(false);
-        }
-        setContainerOutline(false);
-    }
-
-    const handleChange: (option: Option) => void = useCallback((option) => {
+    const closeListbox: () => void = useCallback(() => {
         setOpen(false);
-        setFocus(false);
-        setFocusedValue('');
-        setInputValue(option.label);
-        setSelectedOptionValue(option.value);
-        setShouldFilterOptions(false);
-        onChange?.(option);
-        if (searchable) {
-            setAutofocus(false);
-            setSearchValue(option.label);
-        }
-        inputRef.current?.focus();
-    }, [onChange, searchable]);
-
-    function handleFocus(): void {
-        setFocus(true);
-        setContainerOutline(true);
-    }
-
-    const handleFocusedValueChange: (option?: Option) => void = useCallback((option) => {
-        if (option) {
-            setInputValue(option.label);
-        }
     }, []);
 
-    function handleInputChange(event: ChangeEvent<HTMLInputElement>): void {
-        if (searchable) {
-            const newValue = event.currentTarget.value;
-            const newFilteredOptions = filterOptions(options, newValue);
-            if (inputValue !== newValue) {
-                setShouldFilterOptions(true);
-            }
+    const selectOption: (option: DropdownListOption) => void = useCallback((option) => {
+        setSelectedOption(option);
+        onChange?.(option);
+    }, [onChange, setSelectedOption]);
 
-            if (newValue === '') {
-                setFocusedValue('');
-                setSearchValue('');
-                setInputValue(newValue);
-                setOpen(false);
-                setSelectedOptionValue('');
-            } else {
-                setInputValue(newValue);
-                setSearchValue(newValue);
-                setOpen(newFilteredOptions.length >= 1);
+    const handleClickOutside: () => void = useCallback(() => {
+        if (open) {
+            if (focusedOption && focusedOption !== selectedOption) {
+                selectOption(focusedOption);
             }
+            closeListbox();
+        }
+    }, [closeListbox, focusedOption, open, selectOption, selectedOption]);
+
+    useClickOutside([textboxRef, listboxRef], handleClickOutside);
+
+    function handleTextboxBlur(event: FocusEvent): void {
+        if (open && event.relatedTarget !== listboxRef.current) {
+            if (focusedOption && focusedOption !== selectedOption) {
+                selectOption(focusedOption);
+            }
+            closeListbox();
         }
     }
 
-    useEffect(() => {
-        if (open && (!focusedValue || !filteredOptions.find((option) => option.value === focusedValue))) {
-            if (filteredOptions.length > 0) {
-                focusFirstElementFromArray(filteredOptions);
-            } else {
-                setSelectedOptionValue('');
-                setFocusedValue('');
-            }
-        }
-    }, [focusedValue, filteredOptions, open]);
-
-    const handleInputClick: () => void = useCallback(() => {
-        if (searchable) {
-            setFocusedValue('');
+    function handleTextboxClick(): void {
+        if (open) {
+            closeListbox();
         } else {
-            handleOpen();
-            matchInputValueToOption();
+            openListbox();
         }
-        setAutofocus(false);
-    }, [handleOpen, matchInputValueToOption, searchable]);
+    }
 
-    const handleInputKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void = useCallback((event) => {
+    function handleListboxOptionClick(option: DropdownListOption): void {
+        if (option !== focusedOption) {
+            setFocusedOption(option);
+        }
+        if (option !== selectedOption) {
+            selectOption(option);
+        }
+        closeListbox();
+    }
+
+    const handleFoundOption: (option?: DropdownListOption) => void = useCallback((option) => {
+        if (option) {
+            setFocusedOption(option);
+        }
+    }, [setFocusedOption]);
+
+    const {
+        handleSearchInput,
+    } = useListSearch({
+        elements: options,
+        focusedElement: focusedOption,
+        onFoundElementChange: handleFoundOption,
+        searchPropertyAccessor,
+        predicate: optionPredicate,
+    });
+
+    function handleTextboxKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
         switch (event.key) {
             case 'ArrowDown':
+                event.preventDefault();
                 if (!open) {
-                    handleOpen();
-                    if (searchable || !selectedOptionValue) {
-                        focusFirstElementFromArray(filteredOptions);
-                    } else {
-                        setFocusedValue(selectedOptionValue);
-                    }
-                } else if (searchable) {
-                    if (searchValue !== '') {
-                        const optionToSelect = filteredOptions.length > 1 ? filteredOptions[1] : filteredOptions[0];
-                        setTimeout(() => setFocusedValue(optionToSelect.value), 10);
-                    } else {
-                        setTimeout(() => focusFirstElementFromArray(filteredOptions), 10);
-                    }
+                    openListbox();
+                } else {
+                    focusNextOption();
                 }
-                setAutofocus(true);
                 break;
             case 'ArrowUp':
+                event.preventDefault();
                 if (!open) {
-                    handleOpen();
-                    if (searchable || !selectedOptionValue) {
-                        focusLastElementFromArray(filteredOptions);
-                    } else {
-                        setTimeout(() => setFocusedValue(selectedOptionValue), 10);
-                    }
-                } else if (searchable) {
-                    setTimeout(() => focusLastElementFromArray(filteredOptions), 10);
-                } else if (autoFocus) {
-                    setAutofocus(false);
+                    openListbox();
+                } else {
+                    focusPreviousOption();
                 }
-                setAutofocus(true);
+                break;
+            case 'Home':
+                event.preventDefault();
+                if (!open) {
+                    openListbox();
+                }
+                focusFirstOption();
+                break;
+            case 'End':
+                event.preventDefault();
+                if (!open) {
+                    openListbox();
+                }
+                focusLastOption();
                 break;
             case 'Enter':
                 event.preventDefault();
-                if (searchValue !== '' && filteredOptions.length > 0 && open) {
-                    const optionToSelect = findOptionByValue(focusedValue);
-                    if (optionToSelect) {
-                        handleChange(optionToSelect);
+                if (!open) {
+                    openListbox();
+                } else {
+                    if (focusedOption && focusedOption !== selectedOption) {
+                        selectOption(focusedOption);
                     }
-                } else if (!open && !searchable) {
-                    handleOpen();
-                    setTimeout(() => setFocusedValue(selectedOptionValue), 10);
+                    closeListbox();
                 }
                 break;
             case ' ':
+                event.preventDefault();
                 if (!open) {
-                    event.preventDefault();
-                    handleOpen();
-                    if (!searchable) {
-                        setTimeout(() => setFocusedValue(selectedOptionValue), 10);
-                    }
+                    openListbox();
                 }
                 break;
             case 'Escape':
-                if (searchable) {
-                    resetField();
-                }
                 if (open) {
-                    handleOpen();
-                    matchInputValueToOption();
+                    setFocusedOption(undefined);
+                    closeListbox();
                 }
                 break;
             default:
-                break;
+                if (isLetterOrNumber(event.key)) {
+                    event.preventDefault();
+                    if (!open) {
+                        openListbox();
+                    }
+                    handleSearchInput(event.key);
+                }
         }
-    }, [
-        autoFocus,
-        filteredOptions,
-        handleChange,
-        handleOpen,
-        matchInputValueToOption,
-        open,
-        searchValue,
-        searchable,
-        selectedOptionValue,
-        findOptionByValue,
-        focusedValue,
+    }
+
+    const ariaDescribedBy = useAriaConditionalIds([
+        { id: `${id}_hint`, include: !!hint },
+        { id: `${id}_invalid`, include: !valid },
     ]);
 
-    const handleListboxKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void = useCallback((event) => {
-        if (event.key === 'Escape') {
-            if (searchable) {
-                resetField();
-            } else {
-                matchInputValueToOption();
-            }
-            setFocusedValue('');
-            handleOpen();
-        } else if (event.key === 'ArrowUp' && !focusedValue) {
-            focusLastElementFromArray(options);
-        } else if (isLetterOrNumber(event.key)) /* Check if key is a character */ {
-            if (searchable) {
-                setAutofocus(false);
-                setFocusedValue('');
-                inputRef.current?.focus();
-            } else {
-                const suggestOption = options.find((option) => option.label.toLowerCase()
-                    .startsWith(event.key.toLowerCase()));
-                if (suggestOption) {
-                    setFocusedValue(suggestOption.value);
-                }
-            }
-        }
-    }, [focusedValue, handleOpen, matchInputValueToOption, options, searchable]);
-
     return (
-        <>
-            <StyledFieldContainer
-                className={className}
-                noMargin={noMargin}
-                fieldId={fieldId}
-                label={label}
-                required={required}
-                tooltip={tooltip}
-                valid={valid}
-                validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
-                hint={hint}
+        <StyledFieldContainer
+            className={className}
+            noMargin={noMargin}
+            fieldId={id}
+            label={label}
+            required={required}
+            tooltip={tooltip}
+            valid={valid}
+            validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
+            hint={hint}
+        >
+            <Textbox
+                aria-label={!label ? ariaLabel || t('inputAriaLabel') : undefined}
+                aria-activedescendant={open && focusedOption ? `${id}_${focusedOption.value}` : undefined}
+                aria-controls={`${id}_listbox`}
+                aria-describedby={ariaDescribedBy}
+                aria-expanded={open}
+                aria-invalid={!valid ? 'true' : 'false'}
+                aria-labelledby={`${id}_label`}
+                aria-required={required ? 'true' : 'false'}
+                data-testid="textbox"
+                id={id}
+                $isMobile={isMobile}
+                $disabled={disabled}
+                onBlur={handleTextboxBlur}
+                onClick={handleTextboxClick}
+                onKeyDown={handleTextboxKeyDown}
+                ref={textboxRef}
+                role="combobox"
+                tabIndex={0}
+                $valid={valid}
+                value={selectedOption?.value ?? ''}
+                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
             >
-                <InputWrapper
-                    aria-expanded={open}
-                    aria-haspopup="listbox"
-                    aria-owns={`listbox_${fieldId}`}
-                    data-testid="input-wrapper"
-                    containerOutline={containerOutline}
-                    isMobile={isMobile}
-                    disabled={disabled}
-                    focus={focus}
-                    ref={wrapperRef}
-                    role={searchable ? 'combobox' : undefined}
-                    valid={valid}
-                    onClick={handleInputClick}
-                >
-                    <StyledInput
-                        aria-label={ariaLabel || label || t('inputAriaLabel')}
-                        aria-activedescendant={selectedOptionValue ? `${fieldId}_${selectedOptionValue}` : undefined}
-                        aria-autocomplete={searchable ? 'both' : 'list'}
-                        aria-controls={`listbox_${fieldId}`}
-                        aria-multiline="false"
-                        data-testid="input"
-                        id={fieldId}
-                        isMobile={isMobile}
-                        disabled={disabled}
-                        name={name}
-                        onBlur={handleBlur}
-                        onChange={handleInputChange}
-                        onFocus={handleFocus}
-                        onKeyDown={handleInputKeyDown}
-                        placeholder={placeholder}
-                        ref={inputRef}
-                        required={required}
-                        searchable={searchable}
-                        type="text"
-                        value={inputValue}
-                        {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
-                    />
-                    <Arrow
-                        aria-labelledby={fieldId}
-                        type="button"
-                        data-testid="arrow"
-                        tabIndex={-1}
-                        onClick={disabled ? undefined : handleArrowClick}
-                        disabled={disabled}
-                    >
-                        <Icon name={open ? 'chevronUp' : 'chevronDown'} size={device === 'mobile' ? '24' : '16'} />
-                    </Arrow>
-                </InputWrapper>
-                {open && (
-                    <StyledListbox
-                        ariaLabelledBy={fieldId}
-                        ref={listboxRef}
-                        data-testid="listbox"
-                        defaultValue={defaultValue}
-                        focusedValue={focusedValue}
-                        id={`listbox_${fieldId}`}
-                        onChange={handleChange}
-                        onFocusChange={searchable ? undefined : handleFocusedValueChange}
-                        onKeyDown={handleListboxKeyDown}
-                        options={filteredOptions}
-                        value={selectedOptionValue}
-                    />
-                )}
-            </StyledFieldContainer>
-            {skipOption && (
-                <ChooserButton
-                    checked={skipSelected}
-                    data-testid="select-skip-option"
-                    groupName={`${fieldId}_skip`}
-                    onChange={handleSkipChange}
-                    type="radio"
-                    value={skipOption.value}
-                >
-                    {skipOption.label}
-                </ChooserButton>
+                <input type="hidden" name={name} value={selectedOption?.value} data-testid="input" />
+                {selectedOption?.label ?? ''}
+                <Arrow
+                    aria-hidden="true"
+                    data-testid="arrow"
+                    $disabled={disabled}
+                    name={open ? 'chevronUp' : 'chevronDown'}
+                    size={device === 'mobile' ? '24' : '16'}
+                />
+            </Textbox>
+
+            {open && (
+                <StyledListbox
+                    ariaLabelledBy={`${id}_label`}
+                    ref={listboxRef}
+                    data-testid="listbox"
+                    focusable={false}
+                    focusedValue={focusedOption?.value}
+                    id={`${id}_listbox`}
+                    onOptionClick={handleListboxOptionClick}
+                    options={options}
+                    value={[selectedOption?.value ?? '']}
+                />
             )}
-        </>
+        </StyledFieldContainer>
     );
 };

--- a/packages/react/src/components/field-container/field-container.test.tsx.snap
+++ b/packages/react/src/components/field-container/field-container.test.tsx.snap
@@ -45,6 +45,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="test-id"
+    id="test-id_label"
   >
     test label
   </label>
@@ -123,6 +124,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="test-id"
+    id="test-id_label"
   >
     test label
   </label>
@@ -190,6 +192,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="test-id"
+    id="test-id_label"
   >
     test label
   </label>

--- a/packages/react/src/components/field-container/field-container.tsx
+++ b/packages/react/src/components/field-container/field-container.tsx
@@ -79,7 +79,7 @@ export const FieldContainer: FunctionComponent<PropsWithChildren<FieldContainerP
             valid={valid}
             {...props /* eslint-disable-line react/jsx-props-no-spreading */}
         >
-            {label && <Label forId={fieldId} tooltip={tooltip} required={required}>{label}</Label>}
+            {label && <Label id={`${fieldId}_label`} forId={fieldId} tooltip={tooltip} required={required}>{label}</Label>}
             {hint && <StyledHint id={`${fieldId}_hint`} isMobile={isMobile}>{hint}</StyledHint>}
             {!valid && (
                 <InvalidField

--- a/packages/react/src/components/label/label.tsx
+++ b/packages/react/src/components/label/label.tsx
@@ -31,6 +31,7 @@ const StyledTooltip = styled(Tooltip)`
 interface LabelProps {
     className?: string;
     forId: string;
+    id?: string;
     required?: boolean;
     requiredLabelType?: 'text';
     tooltip?: TooltipProps;
@@ -57,14 +58,14 @@ const RequiredLabel: FunctionComponent<RequiredLabelProps> = ({ type }) => {
 };
 
 const Label: FunctionComponent<PropsWithChildren<LabelProps>> = ({
-    className, children, forId, tooltip, required, requiredLabelType = 'text',
+    className, children, forId, id, tooltip, required, requiredLabelType = 'text',
 }) => {
     const WrapperComponent = tooltip ? StyledDiv : Fragment;
     const { isMobile } = useDeviceContext();
 
     return (
         <WrapperComponent>
-            <StyledLabel className={className} htmlFor={forId} isMobile={isMobile}>
+            <StyledLabel className={className} htmlFor={forId} id={id} isMobile={isMobile}>
                 {children}
                 {required && <RequiredLabel type={requiredLabelType} />}
             </StyledLabel>

--- a/packages/react/src/components/listbox/listbox.test.tsx.snap
+++ b/packages/react/src/components/listbox/listbox.test.tsx.snap
@@ -139,6 +139,7 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-semi-bold);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
@@ -165,6 +166,7 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
@@ -186,6 +188,7 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
@@ -408,6 +411,7 @@ exports[`Listbox Matches the snapshot 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
@@ -429,6 +433,7 @@ exports[`Listbox Matches the snapshot 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-semi-bold);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }
@@ -450,6 +455,7 @@ exports[`Listbox Matches the snapshot 1`] = `
   font-size: 0.875rem;
   font-weight: var(--font-normal);
   line-height: var(--size-1halfx);
+  min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
 }

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -73,6 +73,11 @@ interface ListboxProps {
      * Callback function, invoked when focused value changes
      */
     onFocusChange?(option?: ListboxOption): void;
+
+    /**
+     * Callback function, invoked when an option is clicked
+     */
+    onOptionClick?(option?: ListboxOption): void;
 }
 
 interface ContainerProps {
@@ -144,6 +149,7 @@ const ListItem = styled.li<ListItemProps>`
     font-size: ${({ isMobile }) => (isMobile ? '1rem' : '0.875rem')};
     font-weight: ${({ selected }) => (selected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
     line-height: var(--size-1halfx);
+    min-height: var(--size-1halfx);
     padding: var(--spacing-half) var(--spacing-2x);
   
     ${({ isMobile }) => (!isMobile && css`
@@ -187,6 +193,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
     onChange,
     onFocusChange,
     onKeyDown,
+    onOptionClick,
     className,
     defaultValue,
     focusable = true,
@@ -223,7 +230,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
     });
 
     const [selectedOptions, setSelectedOptions] = useState<ListboxOption[]>(
-        () => findOptionsByValue(value || defaultValue),
+        () => findOptionsByValue(value ?? defaultValue),
     );
 
     function isOptionSelected(option: ListboxOption): boolean {
@@ -333,6 +340,8 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
 
     function handleListItemClick(option: ListboxOption): () => void {
         return () => {
+            onOptionClick?.(option);
+
             if (option !== focusedOption) {
                 setFocusedOption(option);
                 onFocusChange?.(option);

--- a/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
+++ b/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
@@ -235,6 +235,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     test
   </label>
@@ -550,6 +551,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     test
   </label>
@@ -755,6 +757,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     test
   </label>
@@ -1007,6 +1010,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     test
   </label>

--- a/packages/react/src/components/text-area/text-area.test.tsx.snap
+++ b/packages/react/src/components/text-area/text-area.test.tsx.snap
@@ -122,6 +122,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     Comment (required)
   </label>
@@ -260,6 +261,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     Comment (required)
   </label>

--- a/packages/react/src/components/text-area/text-area.tsx
+++ b/packages/react/src/components/text-area/text-area.tsx
@@ -8,6 +8,7 @@ import { FieldContainer } from '../field-container/field-container';
 import { inputsStyle } from '../text-input/styles/inputs';
 import { TooltipProps } from '../tooltip/tooltip';
 import { ScreenReaderOnlyText } from '../screen-reader-only-text/ScreenReaderOnlyText';
+import { useAriaConditionalIds } from '../../hooks/use-aria-conditional-ids';
 
 const StyledTextArea = styled.textarea`
     ${(props) => inputsStyle(props.theme)};
@@ -129,21 +130,11 @@ export const TextArea: VoidFunctionComponent<TextAreaProps> = ({
         return t('validationErrorMessage');
     }
 
-    function getAriaDescribedBy(): string | undefined {
-        let describedBy = '';
-
-        if (hint) {
-            describedBy += ` ${idTextArea}_hint`;
-        }
-        if (!validity && getValidationErrorMessage()) {
-            describedBy += ` ${idTextArea}_invalid`;
-        }
-        if (maxLength) {
-            describedBy += ` ${idCounter}`;
-        }
-
-        return describedBy.trim() || undefined;
-    }
+    const ariaDescribedBy = useAriaConditionalIds([
+        { id: `${idTextArea}_hint`, include: !!hint },
+        { id: `${idTextArea}_invalid`, include: !validity && !!getValidationErrorMessage() },
+        { id: idCounter, include: !!maxLength },
+    ]);
 
     return (
         <FieldContainer
@@ -163,7 +154,7 @@ export const TextArea: VoidFunctionComponent<TextAreaProps> = ({
                 defaultValue={defaultValue}
                 disabled={disabled}
                 id={idTextArea}
-                aria-describedby={getAriaDescribedBy()}
+                aria-describedby={ariaDescribedBy}
                 onBlur={handleBlur}
                 onChange={handleChange}
                 onFocus={handleFocus}

--- a/packages/react/src/components/text-input/text-input.test.tsx.snap
+++ b/packages/react/src/components/text-input/text-input.test.tsx.snap
@@ -117,6 +117,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     Telephone
   </label>
@@ -250,6 +251,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     Telephone (required)
   </label>
@@ -383,6 +385,7 @@ input + .c1 {
   <label
     class="c1 c2"
     for="uuid1"
+    id="uuid1_label"
   >
     Telephone
   </label>

--- a/packages/react/src/hooks/use-aria-conditional-ids.ts
+++ b/packages/react/src/hooks/use-aria-conditional-ids.ts
@@ -1,0 +1,11 @@
+interface ConditionalId {
+    id: string | undefined;
+    include?: boolean;
+}
+
+export function useAriaConditionalIds(conditionalIds: ConditionalId[]): string | undefined {
+    return conditionalIds
+        .filter((conditionalId) => conditionalId.id && (conditionalId.include ?? true))
+        .map((conditionalId) => conditionalId.id)
+        .join(' ') || undefined;
+}

--- a/packages/react/src/hooks/use-click-outside.ts
+++ b/packages/react/src/hooks/use-click-outside.ts
@@ -1,0 +1,18 @@
+import { MutableRefObject, useEffect } from 'react';
+import { eventIsInside } from '../utils/events';
+
+export function useClickOutside<T extends HTMLElement>(
+    targets: MutableRefObject<T | null>[],
+    callback: () => void,
+): void {
+    useEffect(() => {
+        function handleClick(event: MouseEvent): void {
+            if (!eventIsInside(event, ...targets.map((ref) => ref.current))) {
+                callback();
+            }
+        }
+
+        document.addEventListener('mousedown', handleClick);
+        return () => document.removeEventListener('mousedown', handleClick);
+    }, [callback, targets]);
+}

--- a/packages/react/src/hooks/use-list-search.ts
+++ b/packages/react/src/hooks/use-list-search.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef } from 'react';
+import { allSameLetter } from '../utils/string';
+
+interface UseListSearchRequest<T> {
+    elements: T[];
+    focusedElement?: T;
+    onFoundElementChange?: (element: T | undefined) => void;
+    searchPropertyAccessor: (element: T) => string;
+    predicate?: (element: T) => boolean;
+    searchResetTimeout?: number;
+}
+
+interface UseListSearchResponse {
+    handleSearchInput: (char: string) => void;
+}
+
+export function useListSearch<T>({
+    elements,
+    focusedElement,
+    onFoundElementChange,
+    searchPropertyAccessor,
+    predicate = () => true,
+    searchResetTimeout = 500,
+}: UseListSearchRequest<T>): UseListSearchResponse {
+    const searchTimeout = useRef<NodeJS.Timeout | undefined>(undefined);
+    const searchString = useRef('');
+
+    const filterElements: (list: T[], searchText: string) => T[] = useCallback(
+        (list, searchText) => list.filter((element) => {
+            const matches = searchPropertyAccessor(element).toLowerCase().startsWith(searchText.toLowerCase());
+            return matches && predicate(element);
+        }),
+        [predicate, searchPropertyAccessor],
+    );
+
+    const findElement: (searchText: string) => T | undefined = useCallback((searchText) => {
+        const startIndex = focusedElement ? elements.indexOf(focusedElement) + 1 : 0;
+        const sortedElements = [
+            ...elements.slice(startIndex),
+            ...elements.slice(0, startIndex),
+        ];
+
+        const firstMatch = filterElements(sortedElements, searchText)[0];
+
+        if (firstMatch) {
+            return firstMatch;
+        }
+
+        if (allSameLetter(searchText)) {
+            const matches = filterElements(sortedElements, searchText[0]);
+            return matches[0];
+        }
+
+        return undefined;
+    }, [filterElements, focusedElement, elements]);
+
+    const handleSearchInput: (char: string) => void = useCallback((char) => {
+        if (searchTimeout.current !== undefined) {
+            clearTimeout(searchTimeout.current);
+        }
+
+        searchTimeout.current = setTimeout(() => {
+            searchString.current = '';
+        }, searchResetTimeout);
+
+        searchString.current += char;
+
+        if (onFoundElementChange) {
+            onFoundElementChange(findElement(searchString.current));
+        }
+    }, [findElement, onFoundElementChange, searchResetTimeout]);
+
+    return {
+        handleSearchInput,
+    };
+}

--- a/packages/react/src/i18n/translations.ts
+++ b/packages/react/src/i18n/translations.ts
@@ -24,6 +24,10 @@ export const Translations = {
             monthSelectLabel: 'Select a month',
             yearSelectLabel: 'Select a year',
         },
+        'dropdown-list': {
+            inputAriaLabel: 'Select an option',
+            validationErrorMessage: 'You must select an option',
+        },
         'error-summary': {
             title: 'The form contains one or more errors',
             message: 'Please correct them to proceed to the next step.',
@@ -85,10 +89,6 @@ export const Translations = {
             Neutral: 'Information',
             dismissLabel: 'Dismiss banner',
         },
-        select: {
-            inputAriaLabel: 'Select an option',
-            validationErrorMessage: 'You must select an option',
-        },
         'skip-link': {
             label: 'Skip to main content',
         },
@@ -144,6 +144,10 @@ export const Translations = {
             monthNextButtonLabel: 'Aller au mois suivant',
             monthSelectLabel: 'Choisissez un mois',
             yearSelectLabel: 'Choisissez une année',
+        },
+        'dropdown-list': {
+            inputAriaLabel: 'Choisissez une option',
+            validationErrorMessage: 'Vous devez choisir une option',
         },
         'error-summary': {
             title: 'Le formulaire contient une ou plusieurs erreurs',
@@ -205,10 +209,6 @@ export const Translations = {
             Discovery: 'Truc de pro',
             Neutral: 'Information',
             dismissLabel: 'Rejeter la bannière',
-        },
-        select: {
-            inputAriaLabel: 'Choisissez une option',
-            validationErrorMessage: 'Vous devez choisir une option',
         },
         'skip-link': {
             label: 'Passer au contenu principal',

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -12,7 +12,7 @@ export { Avatar } from './components/avatar/avatar';
 export { Checkbox } from './components/checkbox/checkbox';
 export { CheckboxGroup } from './components/checkbox-group/checkbox-group';
 export { Datepicker, DatepickerHandles } from './components/date-picker/date-picker';
-export { DropdownList } from './components/dropdown-list/dropdown-list';
+export { DropdownList, DropdownListOption } from './components/dropdown-list/dropdown-list';
 export { MoneyInput } from './components/money-input/money-input';
 export { NumericInput } from './components/numeric-input/numeric-input';
 export { OptionButton } from './components/option-button/option-button';

--- a/packages/react/src/utils/string.test.ts
+++ b/packages/react/src/utils/string.test.ts
@@ -1,0 +1,13 @@
+import { allSameLetter } from './string';
+
+describe('string', () => {
+    describe('allSameLetter', () => {
+        test('should return true when all letters are the same', () => {
+            expect(allSameLetter('aaaa')).toBe(true);
+        });
+
+        test('should return false when not all letters are the same', () => {
+            expect(allSameLetter('aaab')).toBe(false);
+        });
+    });
+});

--- a/packages/react/src/utils/string.ts
+++ b/packages/react/src/utils/string.ts
@@ -1,0 +1,4 @@
+export function allSameLetter(text: string): boolean {
+    const chars = text.split('');
+    return chars.every((letter) => letter === chars[0]);
+}

--- a/packages/storybook/stories/dropdown-list.stories.tsx
+++ b/packages/storybook/stories/dropdown-list.stories.tsx
@@ -1,39 +1,33 @@
-import { DropdownList } from '@equisoft/design-elements-react';
-import { Option } from '@equisoft/design-elements-react/dist/components/dropdown-list/dropdown-list';
-import { StoryFn as Story } from '@storybook/react';
 import { useState } from 'react';
+import { Button, DropdownList, DropdownListOption } from '@equisoft/design-elements-react';
+import { StoryFn as Story } from '@storybook/react';
 import styled from 'styled-components';
 import { decorateWith } from './utils/decorator';
 import { rawCodeParameters } from './utils/parameters';
 import { ShadowDomDecorator } from './utils/shadow-dom-decorator';
 
 const Container = styled.div`
-    height: 240px;
+    height: 260px;
 `;
 
 const provinces = [
-    { value: 'on', label: 'Ontario' },
-    { value: 'qc', label: 'Quebec' },
-    { value: 'bc', label: 'British Columbia' },
     { value: 'ab', label: 'Alberta' },
-    { value: 'mb', label: 'Manitoba' },
-    { value: 'sk', label: 'Saskatchewan' },
-    { value: 'ns', label: 'Nova Scotia' },
+    { value: 'bc', label: 'British Columbia' },
+    { value: 'mb', label: 'Manitoba', disabled: true },
     { value: 'nb', label: 'New Brunswick' },
     { value: 'nl', label: 'Newfoundland and Labrador' },
-    { value: 'pe', label: 'Prince Edward Island' },
     { value: 'nt', label: 'Northwest Territories' },
+    { value: 'ns', label: 'Nova Scotia' },
     { value: 'nu', label: 'Nunavut' },
+    { value: 'on', label: 'Ontario', disabled: true },
+    { value: 'pe', label: 'Prince Edward Island' },
+    { value: 'qc', label: 'Quebec' },
+    { value: 'sk', label: 'Saskatchewan' },
     { value: 'yt', label: 'Yukon' },
 ];
 
-const skipOption = {
-    label: 'Skip this question',
-    value: 'skip',
-};
-
 export default {
-    title: 'Components/Controls/Dropdown-list',
+    title: 'Components/Controls/Dropdown List',
     component: DropdownList,
     decorators: [decorateWith(Container)],
 };
@@ -61,10 +55,6 @@ export const InsideShadowDom: Story = () => (
 );
 InsideShadowDom.decorators = [ShadowDomDecorator];
 
-export const CustomPlaceholder: Story = () => (
-    <DropdownList label="Select an option" options={provinces} placeholder="Custom placeholder" />
-);
-
 export const Disabled: Story = () => (
     <DropdownList label="Select an option" options={provinces} disabled />
 );
@@ -76,12 +66,8 @@ export const Invalid: Story = () => (
 export const Required: Story = () => (
     <form onSubmit={(event) => event.preventDefault()}>
         <DropdownList required label="Select an option" options={provinces} />
-        <button type="submit">Submit</button>
+        <Button type="submit" buttonType="primary">Submit</Button>
     </form>
-);
-
-export const Searchable: Story = () => (
-    <DropdownList label="Select an option" options={provinces} searchable />
 );
 
 export const WithCallback: Story = () => (
@@ -97,12 +83,23 @@ export const WithDefaultValue: Story = () => (
     <DropdownList label="Select an option" options={provinces} defaultValue="qc" />
 );
 
+export const WithControlledValue: Story = () => {
+    const [value, setValue] = useState<string | undefined>(undefined);
+
+    function handleChange(option: DropdownListOption): void {
+        setValue(option.value);
+    }
+
+    return (
+        <>
+            <DropdownList label="Select an option" options={provinces} onChange={handleChange} value={value} />
+            <Button buttonType="primary" onClick={() => setValue('qc')}>Set value to Quebec</Button>
+        </>
+    );
+};
+
 export const WithoutLabel: Story = () => (
     <DropdownList options={provinces} />
-);
-
-export const WithSkip: Story = () => (
-    <DropdownList label="Select an option" options={provinces} skipOption={skipOption} />
 );
 
 export const WithDisabledOptions: Story = () => {
@@ -116,20 +113,24 @@ export const WithDisabledOptions: Story = () => {
     return <DropdownList label="Select an option" options={disabledOptions} />;
 };
 
-export const ControlledWithSkipSelected: Story = () => {
-    const [value, setValue] = useState(skipOption.value);
+export const WithDisabledDefaultOption: Story = () => {
+    const [value, setValue] = useState<string>('');
 
-    const handleChange: (option: Option) => void = (option) => {
+    function handleChange(option: DropdownListOption): void {
         setValue(option.value);
-    };
+    }
+
+    const options = [
+        { value: '', label: '', disabled: true },
+        { value: 'optionA', label: 'Option A' },
+        { value: 'optionB', label: 'Option B' },
+        { value: 'optionC', label: 'Option C' },
+    ];
 
     return (
-        <DropdownList
-            label="Select an option"
-            options={provinces}
-            skipOption={skipOption}
-            onChange={handleChange}
-            value={value}
-        />
+        <>
+            <DropdownList label="Select an option" options={options} value={value} onChange={handleChange} />
+            <Button buttonType="primary" onClick={() => setValue('')}>Re-select empty option</Button>
+        </>
     );
 };


### PR DESCRIPTION
DS-247

The search functionality is being moved to the upcoming combobox/autocomplete components. Thus, the text input in the dropdown was replaced by a `<div>` and a hidden input to hold the value when the component is used in a form. It now acts as a simple `<select>`.

The remaining code was also refactored to use the new listbox and to improve its general shape.

Note: I did not include the multi-select feature in this PR. It should be done in a separate story.