### PR TITLE
fix(Dropdown): keep textbox focused when clicking on disabled options

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -1927,6 +1927,10 @@ input + .c1 {
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 
@@ -3111,6 +3115,10 @@ input + .c1 {
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 
@@ -4230,6 +4238,10 @@ input + .c1 {
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
@@ -78,6 +78,10 @@ input + .c2 {
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
@@ -102,6 +106,10 @@ input + .c2 {
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c11:hover {
@@ -147,6 +155,10 @@ input + .c2 {
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 
@@ -496,6 +508,10 @@ input + .c2 {
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
@@ -520,6 +536,10 @@ input + .c2 {
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c13:hover {
@@ -564,6 +584,10 @@ input + .c2 {
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 
@@ -882,6 +906,10 @@ exports[`Dropdown list matches the snapshot (mobile) 1`] = `
   line-height: var(--size-1halfx);
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
@@ -905,6 +933,10 @@ exports[`Dropdown list matches the snapshot (mobile) 1`] = `
   line-height: var(--size-1halfx);
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c9:hover {
@@ -949,6 +981,10 @@ exports[`Dropdown list matches the snapshot (mobile) 1`] = `
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 
@@ -1278,6 +1314,10 @@ input + .c2 {
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
@@ -1302,6 +1342,10 @@ input + .c2 {
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c12:hover {
@@ -1346,6 +1390,10 @@ input + .c2 {
   -ms-flex-pack: justify;
   justify-content: space-between;
   padding: 0 var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
   width: 100%;
 }
 

--- a/packages/react/src/components/dropdown-list/dropdown-list.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.tsx
@@ -258,13 +258,19 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps> = ({
     }
 
     function handleListboxOptionClick(option: DropdownListOption): void {
-        if (option !== focusedOption) {
-            setFocusedOption(option);
+        if (optionPredicate(option)) {
+            if (option !== focusedOption) {
+                setFocusedOption(option);
+            }
+
+            if (option !== selectedOption) {
+                selectOption(option);
+            }
+
+            closeListbox();
         }
-        if (option !== selectedOption) {
-            selectOption(option);
-        }
-        closeListbox();
+
+        textboxRef.current?.focus();
     }
 
     const handleFoundOption: (option?: DropdownListOption) => void = useCallback((option) => {

--- a/packages/react/src/components/dropdown-list/dropdown-list.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.tsx
@@ -66,6 +66,7 @@ const Textbox = styled.div<TextboxProps>`
     height: ${({ $isMobile }) => ($isMobile ? 'var(--size-2halfx)' : 'var(--size-2x)')};
     justify-content: space-between;
     padding: 0 var(--spacing-1x);
+    user-select: none;
     width: 100%;
     
     ${({ theme }) => focus({ theme }, true)};
@@ -269,8 +270,6 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps> = ({
 
             closeListbox();
         }
-
-        textboxRef.current?.focus();
     }
 
     const handleFoundOption: (option?: DropdownListOption) => void = useCallback((option) => {

--- a/packages/react/src/components/listbox/listbox.test.tsx.snap
+++ b/packages/react/src/components/listbox/listbox.test.tsx.snap
@@ -142,6 +142,10 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c2:hover {
@@ -169,6 +173,10 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c9:hover {
@@ -191,6 +199,10 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c11:hover {
@@ -414,6 +426,10 @@ exports[`Listbox Matches the snapshot 1`] = `
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c2:hover {
@@ -436,6 +452,10 @@ exports[`Listbox Matches the snapshot 1`] = `
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c5:hover {
@@ -458,6 +478,10 @@ exports[`Listbox Matches the snapshot 1`] = `
   min-height: var(--size-1halfx);
   padding: var(--spacing-half) var(--spacing-2x);
   padding-right: var(--spacing-1x);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .c6:hover {

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -189,16 +189,16 @@ const optionPredicate: (option: ListboxOption) => boolean = (option) => !option.
 export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTMLDivElement>> = forwardRef(({
     ariaLabelledBy,
     id: providedId,
+    className,
+    defaultValue,
+    focusable = true,
+    focusedValue,
+    multiselect = false,
     options,
     onChange,
     onFocusChange,
     onKeyDown,
     onOptionClick,
-    className,
-    defaultValue,
-    focusable = true,
-    multiselect = false,
-    focusedValue,
     value,
 }, ref: Ref<HTMLDivElement>) => {
     const id = useId(providedId);
@@ -293,7 +293,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
     }, [focusedOption, options, scrollToOption]);
 
     useLayoutEffect(() => {
-        const initialOption = findOptionsByValue(focusedValue || defaultValue);
+        const initialOption = findOptionsByValue(focusedValue ?? defaultValue);
 
         if (initialOption.length > 0) {
             scrollToOption(initialOption[0], true);
@@ -342,14 +342,17 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
         return () => {
             onOptionClick?.(option);
 
-            if (option !== focusedOption) {
-                setFocusedOption(option);
-                onFocusChange?.(option);
-            }
-            if (multiselect) {
-                toggleOptionSelection(option);
-            } else {
-                selectSingleOption(option);
+            if (optionPredicate(option)) {
+                if (option !== focusedOption) {
+                    setFocusedOption(option);
+                    onFocusChange?.(option);
+                }
+
+                if (multiselect) {
+                    toggleOptionSelection(option);
+                } else {
+                    selectSingleOption(option);
+                }
             }
         };
     }
@@ -444,9 +447,9 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
             data-testid="listbox-container"
             $focusable={focusable}
             id={id}
-            onBlur={handleListboxBlur}
-            onFocus={handleListboxFocus}
-            onKeyDown={handleListboxKeyDown}
+            onBlur={focusable ? handleListboxBlur : undefined}
+            onFocus={focusable ? handleListboxFocus : undefined}
+            onKeyDown={focusable ? handleListboxKeyDown : undefined}
             ref={mergeRefs(ref, containerRef)}
             role="listbox"
             tabIndex={focusable ? 0 : -1}
@@ -465,7 +468,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
                         id={`${id}_${option.value}`}
                         isMobile={isMobile}
                         key={option.value}
-                        onClick={!option.disabled ? handleListItemClick(option) : undefined}
+                        onClick={handleListItemClick(option)}
                         onMouseDown={handleListItemMouseDown}
                         ref={(node) => {
                             const map = itemRefs.current;

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -155,6 +155,8 @@ const ListItem = styled.li<ListItemProps>`
     ${({ isMobile }) => (!isMobile && css`
         padding-right: var(--spacing-1x);
     `)}
+    
+    user-select: none;
 
     &:hover {
         background-color: ${({ theme, disabled }) => (disabled ? theme.greys.white : theme.greys.grey)};
@@ -450,6 +452,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
             onBlur={focusable ? handleListboxBlur : undefined}
             onFocus={focusable ? handleListboxFocus : undefined}
             onKeyDown={focusable ? handleListboxKeyDown : undefined}
+            onMouseDown={!focusable ? (event) => event.preventDefault() : undefined}
             ref={mergeRefs(ref, containerRef)}
             role="listbox"
             tabIndex={focusable ? 0 : -1}

--- a/packages/storybook/stories/listbox.stories.tsx
+++ b/packages/storybook/stories/listbox.stories.tsx
@@ -51,16 +51,16 @@ export const WithDisabledOptions: Story = () => {
     );
 };
 
+const StyledButton = styled(Button)`
+    margin-top: 1rem;
+`;
+
 export const WithControlledValue: Story = () => {
     const [value, setValue] = useState<string | undefined>(undefined);
 
     function handleChange(option: ListboxOption): void {
         setValue(option.value);
     }
-
-    const StyledButton = styled(Button)`
-        margin-top: 1rem;
-    `;
 
     return (
         <>


### PR DESCRIPTION
DS-954

Le textbox du dropdown perdait le focus quand on cliquait sur une option _disabled_. En écoutant `onClick` même sur ces options, on peut rétablir manuellement le focus.

De plus, on retire certains handlers sur la listbox lorsque qu'elle n'est pas focusable.