### PR TITLE
fix(numeric-input): show error message initially

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -1497,7 +1497,7 @@ label + .c5 {
   <span
     aria-live="polite"
     class="c3"
-    data-testid="invalid-error-message"
+    data-testid="invalid-field"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -1497,6 +1497,7 @@ label + .c5 {
   <span
     aria-live="polite"
     class="c3"
+    data-testid="invalid-error-message"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
@@ -662,7 +662,7 @@ input + .c2 {
   <span
     aria-live="polite"
     class="c4"
-    data-testid="invalid-error-message"
+    data-testid="invalid-field"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
@@ -662,6 +662,7 @@ input + .c2 {
   <span
     aria-live="polite"
     class="c4"
+    data-testid="invalid-error-message"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/feedbacks/invalid-field.test.tsx.snap
+++ b/packages/react/src/components/feedbacks/invalid-field.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`Invalid field Matches the snapshot 1`] = `
 <span
   aria-live="polite"
   class="c0"
+  data-testid="invalid-error-message"
   id="test-id_invalid"
   role="alert"
 >

--- a/packages/react/src/components/feedbacks/invalid-field.test.tsx.snap
+++ b/packages/react/src/components/feedbacks/invalid-field.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Invalid field Matches the snapshot 1`] = `
 <span
   aria-live="polite"
   class="c0"
-  data-testid="invalid-error-message"
+  data-testid="invalid-field"
   id="test-id_invalid"
   role="alert"
 >

--- a/packages/react/src/components/feedbacks/invalid-field.tsx
+++ b/packages/react/src/components/feedbacks/invalid-field.tsx
@@ -29,6 +29,7 @@ const InvalidField: VoidFunctionComponent<InvalidFieldProps> = ({ controlId, fee
 
     return (
         <Field
+            data-testid="invalid-error-message"
             aria-live="polite"
             id={`${controlId}_invalid`}
             isMobile={isMobile}

--- a/packages/react/src/components/feedbacks/invalid-field.tsx
+++ b/packages/react/src/components/feedbacks/invalid-field.tsx
@@ -29,7 +29,7 @@ const InvalidField: VoidFunctionComponent<InvalidFieldProps> = ({ controlId, fee
 
     return (
         <Field
-            data-testid="invalid-error-message"
+            data-testid="invalid-field"
             aria-live="polite"
             id={`${controlId}_invalid`}
             isMobile={isMobile}

--- a/packages/react/src/components/field-container/field-container.test.tsx.snap
+++ b/packages/react/src/components/field-container/field-container.test.tsx.snap
@@ -131,7 +131,7 @@ input + .c1 {
   <span
     aria-live="polite"
     class="c3"
-    data-testid="invalid-error-message"
+    data-testid="invalid-field"
     id="test-id_invalid"
     role="alert"
   >

--- a/packages/react/src/components/field-container/field-container.test.tsx.snap
+++ b/packages/react/src/components/field-container/field-container.test.tsx.snap
@@ -131,6 +131,7 @@ input + .c1 {
   <span
     aria-live="polite"
     class="c3"
+    data-testid="invalid-error-message"
     id="test-id_invalid"
     role="alert"
   >

--- a/packages/react/src/components/field-container/field-container.tsx
+++ b/packages/react/src/components/field-container/field-container.tsx
@@ -83,7 +83,6 @@ export const FieldContainer: FunctionComponent<PropsWithChildren<FieldContainerP
             {hint && <StyledHint id={`${fieldId}_hint`} isMobile={isMobile}>{hint}</StyledHint>}
             {!valid && (
                 <InvalidField
-                    data-testid="text-input-error-msg"
                     controlId={fieldId}
                     feedbackMsg={validationErrorMessage}
                     noIcon={noInvalidFieldIcon}

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx
@@ -82,21 +82,21 @@ describe('NumericInput', () => {
 
     test('should display error message on invalid value', () => {
         const wrapper = mountWithTheme(<NumericInput value="2" min={100} />);
-        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(true);
+        expect(getByTestId(wrapper, 'invalid-field').exists()).toBe(true);
     });
 
     test('should display error message on invalid defaultValue', () => {
         const wrapper = mountWithTheme(<NumericInput defaultValue="2" min={100} />);
-        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(true);
+        expect(getByTestId(wrapper, 'invalid-field').exists()).toBe(true);
     });
 
     test('should not have error message on required when value is empty', () => {
         const wrapper = mountWithTheme(<NumericInput value="" required />);
-        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(false);
+        expect(getByTestId(wrapper, 'invalid-field').exists()).toBe(false);
     });
 
     test('should not have error message on required when defaultValue is empty', () => {
         const wrapper = mountWithTheme(<NumericInput defaultValue="" required />);
-        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(false);
+        expect(getByTestId(wrapper, 'invalid-field').exists()).toBe(false);
     });
 });

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx
@@ -82,7 +82,6 @@ describe('NumericInput', () => {
 
     test('should display error message on invalid value', () => {
         const wrapper = mountWithTheme(<NumericInput value="2" min={100} />);
-        // eslint-disable-next-line no-console
         expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(true);
     });
 
@@ -93,7 +92,6 @@ describe('NumericInput', () => {
 
     test('should not have error message on required when value is empty', () => {
         const wrapper = mountWithTheme(<NumericInput value="" required />);
-        // eslint-disable-next-line no-console
         expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(false);
     });
 

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx
@@ -1,7 +1,7 @@
 import { shallow } from 'enzyme';
 import { NumericInput } from './numeric-input';
 import { getByTestId } from '../../test-utils/enzyme-selectors';
-import { renderWithTheme } from '../../test-utils/renderer';
+import { mountWithTheme, renderWithTheme } from '../../test-utils/renderer';
 
 describe('NumericInput', () => {
     test('matches the snapshot (Normal - Adornment at start)', () => {
@@ -78,5 +78,27 @@ describe('NumericInput', () => {
         const wrapper = shallow(<NumericInput value="test" />);
 
         expect(getByTestId(wrapper, 'numeric-input').prop('value')).toBe('');
+    });
+
+    test('should display error message on invalid value', () => {
+        const wrapper = mountWithTheme(<NumericInput value="2" min={100} />);
+        // eslint-disable-next-line no-console
+        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(true);
+    });
+
+    test('should display error message on invalid defaultValue', () => {
+        const wrapper = mountWithTheme(<NumericInput defaultValue="2" min={100} />);
+        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(true);
+    });
+
+    test('should not have error message on required when value is empty', () => {
+        const wrapper = mountWithTheme(<NumericInput value="" required />);
+        // eslint-disable-next-line no-console
+        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(false);
+    });
+
+    test('should not have error message on required when defaultValue is empty', () => {
+        const wrapper = mountWithTheme(<NumericInput defaultValue="" required />);
+        expect(getByTestId(wrapper, 'invalid-error-message').exists()).toBe(false);
     });
 });

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
@@ -333,6 +333,7 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   <span
     aria-live="polite"
     class="c1"
+    data-testid="invalid-error-message"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   <span
     aria-live="polite"
     class="c1"
-    data-testid="invalid-error-message"
+    data-testid="invalid-field"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/numeric-input/use-numeric-input.tsx
+++ b/packages/react/src/components/numeric-input/use-numeric-input.tsx
@@ -6,7 +6,6 @@ import {
     FocusEvent,
     FocusEventHandler,
     useCallback,
-    useEffect,
     useState,
 } from 'react';
 import { isNumber, isWithinPrecision, truncateAtPrecision } from '../../utils/math';
@@ -60,6 +59,32 @@ function validateProvidedValue(newValue: number | string): string {
     return '';
 }
 
+type ValidationErrorType = 'required' | 'max' | 'min';
+
+interface GetValidationErrorTypeOptions {
+    max?: number;
+    min?: number;
+    required?: boolean;
+    skipRequired?: boolean;
+}
+
+function getValidationErrorType(value: string, {
+    max, min, required, skipRequired,
+}: GetValidationErrorTypeOptions): ValidationErrorType | undefined {
+    if (required && value === '') {
+        if (!skipRequired) {
+            return 'required';
+        }
+    } if (value !== '') {
+        if (max !== undefined && Number(value) > max) {
+            return 'max';
+        } if (min !== undefined && Number(value) < min) {
+            return 'min';
+        }
+    }
+    return undefined;
+}
+
 const createCallbackData = (inputValue: string): NumericInputCallbackData => ({
     value: inputValue,
     valueAsNumber: inputValue === '' ? null : Number(inputValue),
@@ -81,23 +106,17 @@ export function useNumericInput({
     const [inputValue, setInputValue] = useState(
         validateProvidedValue(providedValue ?? defaultValue ?? ''),
     );
-    const [validationErrorMessage, setValidationErrorMessage] = useState<string | undefined>();
+
+    const [validationErrorType, setValidationErrorType] = useState<ValidationErrorType | undefined>(
+        getValidationErrorType(inputValue, {
+            max, min, required, skipRequired: true,
+        }),
+    );
 
     const validate = useCallback((value: string): void => {
-        let error: string | undefined;
-
-        if (required && value === '') {
-            error = t('requiredValidationErrorMessage');
-        } else if (value !== '') {
-            if (max !== undefined && Number(value) > max) {
-                error = t('maxValidationErrorMessage', { max });
-            } else if (min !== undefined && Number(value) < min) {
-                error = t('minValidationErrorMessage', { min });
-            }
-        }
-
-        setValidationErrorMessage(error);
-    }, [max, min, required, t]);
+        const errorType = getValidationErrorType(value, { max, min, required });
+        setValidationErrorType(errorType);
+    }, [max, min, required]);
 
     const handlePaste = useCallback((event: ClipboardEvent<HTMLInputElement>): void => {
         event.preventDefault();
@@ -139,13 +158,6 @@ export function useNumericInput({
         onBlur?.(event, createCallbackData(value));
     }, [onBlur, validate]);
 
-    useEffect(() => {
-        if (inputValue !== '') {
-            validate(inputValue);
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
     if (providedValue !== undefined) {
         const validatedProvidedValue = validateProvidedValue(providedValue);
         if (validatedProvidedValue !== inputValue) {
@@ -154,8 +166,21 @@ export function useNumericInput({
         }
     }
 
-    const isInvalid = invalid ?? (providedValidationErrorMessage !== undefined || validationErrorMessage !== undefined);
-    const errorMessage = (providedValidationErrorMessage ?? validationErrorMessage);
+    const getErrorMessage = (): string | undefined => {
+        switch (validationErrorType) {
+            case 'required':
+                return t('requiredValidationErrorMessage');
+            case 'max':
+                return t('maxValidationErrorMessage', { max });
+            case 'min':
+                return t('minValidationErrorMessage', { min });
+            default:
+                return undefined;
+        }
+    };
+
+    const isInvalid = invalid ?? (providedValidationErrorMessage !== undefined || validationErrorType !== undefined);
+    const errorMessage = (providedValidationErrorMessage ?? getErrorMessage());
 
     return {
         max,

--- a/packages/react/src/components/numeric-input/use-numeric-input.tsx
+++ b/packages/react/src/components/numeric-input/use-numeric-input.tsx
@@ -6,6 +6,7 @@ import {
     FocusEvent,
     FocusEventHandler,
     useCallback,
+    useEffect,
     useState,
 } from 'react';
 import { isNumber, isWithinPrecision, truncateAtPrecision } from '../../utils/math';
@@ -82,16 +83,6 @@ export function useNumericInput({
     );
     const [validationErrorMessage, setValidationErrorMessage] = useState<string | undefined>();
 
-    if (providedValue !== undefined) {
-        const validatedProvidedValue = validateProvidedValue(providedValue);
-        if (validatedProvidedValue !== inputValue) {
-            setInputValue(validatedProvidedValue);
-        }
-    }
-
-    const isInvalid = invalid ?? (providedValidationErrorMessage !== undefined || validationErrorMessage !== undefined);
-    const errorMessage = (providedValidationErrorMessage ?? validationErrorMessage);
-
     const validate = useCallback((value: string): void => {
         let error: string | undefined;
 
@@ -147,6 +138,24 @@ export function useNumericInput({
         validate(value);
         onBlur?.(event, createCallbackData(value));
     }, [onBlur, validate]);
+
+    useEffect(() => {
+        if (inputValue !== '') {
+            validate(inputValue);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    if (providedValue !== undefined) {
+        const validatedProvidedValue = validateProvidedValue(providedValue);
+        if (validatedProvidedValue !== inputValue) {
+            setInputValue(validatedProvidedValue);
+            validate(validatedProvidedValue);
+        }
+    }
+
+    const isInvalid = invalid ?? (providedValidationErrorMessage !== undefined || validationErrorMessage !== undefined);
+    const errorMessage = (providedValidationErrorMessage ?? validationErrorMessage);
 
     return {
         max,

--- a/packages/react/src/components/numeric-input/use-numeric-input.tsx
+++ b/packages/react/src/components/numeric-input/use-numeric-input.tsx
@@ -71,11 +71,10 @@ interface GetValidationErrorTypeOptions {
 function getValidationErrorType(value: string, {
     max, min, required, skipRequired,
 }: GetValidationErrorTypeOptions): ValidationErrorType | undefined {
-    if (required && value === '') {
-        if (!skipRequired) {
-            return 'required';
-        }
-    } if (value !== '') {
+    if (value === '' && required && !skipRequired) {
+        return 'required';
+    }
+    if (value !== '') {
         if (max !== undefined && Number(value) > max) {
             return 'max';
         } if (min !== undefined && Number(value) < min) {

--- a/packages/react/src/components/password-input/password-input.test.tsx.snap
+++ b/packages/react/src/components/password-input/password-input.test.tsx.snap
@@ -921,7 +921,7 @@ exports[`PasswordInput matches the snapshot (Invalid) 1`] = `
   <span
     aria-live="polite"
     class="c1"
-    data-testid="invalid-error-message"
+    data-testid="invalid-field"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/password-input/password-input.test.tsx.snap
+++ b/packages/react/src/components/password-input/password-input.test.tsx.snap
@@ -921,6 +921,7 @@ exports[`PasswordInput matches the snapshot (Invalid) 1`] = `
   <span
     aria-live="polite"
     class="c1"
+    data-testid="invalid-error-message"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
+++ b/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
@@ -558,6 +558,7 @@ input + .c1 {
   <span
     aria-live="polite"
     class="c3"
+    data-testid="invalid-error-message"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
+++ b/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
@@ -558,7 +558,7 @@ input + .c1 {
   <span
     aria-live="polite"
     class="c3"
-    data-testid="invalid-error-message"
+    data-testid="invalid-field"
     id="uuid1_invalid"
     role="alert"
   >

--- a/packages/storybook/stories/numeric-input.stories.tsx
+++ b/packages/storybook/stories/numeric-input.stories.tsx
@@ -87,6 +87,8 @@ export const ControlledValue: Story = () => {
     return (
         <NumericInput
             label="Label"
+            min={0}
+            max={100}
             onChange={(_event, { value, valueAsNumber }) => {
                 setInputValue(value);
                 console.info(`NumericInput onChange value: ${value}`);
@@ -110,7 +112,7 @@ export const Disabled: Story = () => (
     />
 );
 
-export const ExplicitInvalid: Story = () => (
+export const ControlledInvalid: Story = () => (
     <>
         <NumericInput
             label="Label"

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,6 +170,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-define-polyfill-provider@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@babel/helper-define-polyfill-provider@npm:0.5.0"
+  dependencies:
+    "@babel/helper-compilation-targets": "npm:^7.22.6"
+    "@babel/helper-plugin-utils": "npm:^7.22.5"
+    debug: "npm:^4.1.1"
+    lodash.debounce: "npm:^4.0.8"
+    resolve: "npm:^1.14.2"
+  peerDependencies:
+    "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
+  checksum: 2b053b96a0c604a7e0f5c7d13a8a55f4451d938f7af42bd40f62a87df15e6c87a0b1dbd893a0f0bb51077b54dc3ba00a58b166531a5940ad286ab685dd8979ec
+  languageName: node
+  linkType: hard
+
 "@babel/helper-environment-visitor@npm:^7.22.20":
   version: 7.22.20
   resolution: "@babel/helper-environment-visitor@npm:7.22.20"
@@ -2123,14 +2138,14 @@ __metadata:
   linkType: hard
 
 "@floating-ui/react-dom@npm:^2.0.0":
-  version: 2.0.5
-  resolution: "@floating-ui/react-dom@npm:2.0.5"
+  version: 2.0.6
+  resolution: "@floating-ui/react-dom@npm:2.0.6"
   dependencies:
     "@floating-ui/dom": "npm:^1.5.4"
   peerDependencies:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
-  checksum: cb72564ea6d6f65161fcc5c04005206e09b17513fded78906a737f01fb1d4aaef550da7109cff4c4373b3d251645ba5a102af116b797456d1e81749ffc05fa67
+  checksum: 33bdeb70487837a4b21b537c4c10874d7c86d661f7748eedee877a45bd65f61a59dc3cf10a30a193c913fb758feaaf33ddb7f2df9d898f96506dfe22eaa8e4fb
   languageName: node
   linkType: hard
 
@@ -2487,12 +2502,12 @@ __metadata:
   linkType: hard
 
 "@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.20, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.21
-  resolution: "@jridgewell/trace-mapping@npm:0.3.21"
+  version: 0.3.22
+  resolution: "@jridgewell/trace-mapping@npm:0.3.22"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 4ae1c862ca0a12e1fb08ee48bb2fd65667a5258a97cc37a8708ff1e1d6a351e6a1166f2f806a9d9b9680f841da9fbde35fe6bd971eee3bdf1c10ea669ba5707a
+  checksum: 18cf19f88e2792c1c91515f2b629aae05f3cdbb2e60c3886e16e80725234ce26dd10144c4981c05d9366e7094498c0b4fe5c1a89f4a730d7376a4ba4af448149
   languageName: node
   linkType: hard
 
@@ -3275,11 +3290,11 @@ __metadata:
   linkType: hard
 
 "@sinonjs/commons@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@sinonjs/commons@npm:3.0.0"
+  version: 3.0.1
+  resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
     type-detect: "npm:4.0.8"
-  checksum: 1df9cd257942f4e4960dfb9fd339d9e97b6a3da135f3d5b8646562918e863809cb8e00268535f4f4723535d2097881c8fc03d545c414d8555183376cfc54ee84
+  checksum: 1227a7b5bd6c6f9584274db996d7f8cee2c8c350534b9d0141fc662eaf1f292ea0ae3ed19e5e5271c8fd390d27e492ca2803acd31a1978be2cdc6be0da711403
   languageName: node
   linkType: hard
 
@@ -4190,90 +4205,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-darwin-arm64@npm:1.3.103"
+"@swc/core-darwin-arm64@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-darwin-arm64@npm:1.3.105"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-darwin-x64@npm:1.3.103"
+"@swc/core-darwin-x64@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-darwin-x64@npm:1.3.105"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.103"
+"@swc/core-linux-arm-gnueabihf@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.3.105"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.103"
+"@swc/core-linux-arm64-gnu@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.3.105"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-linux-arm64-musl@npm:1.3.103"
+"@swc/core-linux-arm64-musl@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-linux-arm64-musl@npm:1.3.105"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-linux-x64-gnu@npm:1.3.103"
+"@swc/core-linux-x64-gnu@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-linux-x64-gnu@npm:1.3.105"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-linux-x64-musl@npm:1.3.103"
+"@swc/core-linux-x64-musl@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-linux-x64-musl@npm:1.3.105"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.103"
+"@swc/core-win32-arm64-msvc@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.3.105"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.103"
+"@swc/core-win32-ia32-msvc@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.3.105"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.3.103":
-  version: 1.3.103
-  resolution: "@swc/core-win32-x64-msvc@npm:1.3.103"
+"@swc/core-win32-x64-msvc@npm:1.3.105":
+  version: 1.3.105
+  resolution: "@swc/core-win32-x64-msvc@npm:1.3.105"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@swc/core@npm:^1.3.82":
-  version: 1.3.103
-  resolution: "@swc/core@npm:1.3.103"
+  version: 1.3.105
+  resolution: "@swc/core@npm:1.3.105"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.3.103"
-    "@swc/core-darwin-x64": "npm:1.3.103"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.3.103"
-    "@swc/core-linux-arm64-gnu": "npm:1.3.103"
-    "@swc/core-linux-arm64-musl": "npm:1.3.103"
-    "@swc/core-linux-x64-gnu": "npm:1.3.103"
-    "@swc/core-linux-x64-musl": "npm:1.3.103"
-    "@swc/core-win32-arm64-msvc": "npm:1.3.103"
-    "@swc/core-win32-ia32-msvc": "npm:1.3.103"
-    "@swc/core-win32-x64-msvc": "npm:1.3.103"
+    "@swc/core-darwin-arm64": "npm:1.3.105"
+    "@swc/core-darwin-x64": "npm:1.3.105"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.3.105"
+    "@swc/core-linux-arm64-gnu": "npm:1.3.105"
+    "@swc/core-linux-arm64-musl": "npm:1.3.105"
+    "@swc/core-linux-x64-gnu": "npm:1.3.105"
+    "@swc/core-linux-x64-musl": "npm:1.3.105"
+    "@swc/core-win32-arm64-msvc": "npm:1.3.105"
+    "@swc/core-win32-ia32-msvc": "npm:1.3.105"
+    "@swc/core-win32-x64-msvc": "npm:1.3.105"
     "@swc/counter": "npm:^0.1.1"
     "@swc/types": "npm:^0.1.5"
   peerDependencies:
@@ -4302,7 +4317,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: a5740e5ed68120f041e0a1f92385659b1cbc0315d566ee0d5141a4a51880a40e10cd391f25e6dfb2ce6d8a5a2a89be35b9af523e2d2db84d96310be31950a865
+  checksum: 719283fa1bb7e25a9e3bfb4bb2fca8dec98a1cbbcd53cdd6a8cc9d9e2ac701d0fe409b2f3f9b6ddd466b2c1592cdae9c2302a114036bb5adc08e8f95549543e0
   languageName: node
   linkType: hard
 
@@ -4738,12 +4753,12 @@ __metadata:
   linkType: hard
 
 "@types/node-fetch@npm:^2.6.4":
-  version: 2.6.10
-  resolution: "@types/node-fetch@npm:2.6.10"
+  version: 2.6.11
+  resolution: "@types/node-fetch@npm:2.6.11"
   dependencies:
     "@types/node": "npm:*"
     form-data: "npm:^4.0.0"
-  checksum: beeadfb31eb097c49a63cb2be21dcb83aa2e988f36b411edfa879a32f0497b509d65eec19d76f869895b3ef87199b21d4e13e9139d3ee38a70b437dc65ba1075
+  checksum: 5283d4e0bcc37a5b6d8e629aee880a4ffcfb33e089f4b903b2981b19c623972d1e64af7c3f9540ab990f0f5c89b9b5dda19c5bcb37a8e177079e93683bfd2f49
   languageName: node
   linkType: hard
 
@@ -6098,15 +6113,15 @@ __metadata:
   linkType: hard
 
 "babel-plugin-polyfill-corejs2@npm:^0.4.7":
-  version: 0.4.7
-  resolution: "babel-plugin-polyfill-corejs2@npm:0.4.7"
+  version: 0.4.8
+  resolution: "babel-plugin-polyfill-corejs2@npm:0.4.8"
   dependencies:
     "@babel/compat-data": "npm:^7.22.6"
-    "@babel/helper-define-polyfill-provider": "npm:^0.4.4"
+    "@babel/helper-define-polyfill-provider": "npm:^0.5.0"
     semver: "npm:^6.3.1"
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: f80f7284ec72c63e7dd751e0bdf25e9978df195a79e0887470603bfdea13ee518d62573cf360bb1bc01b80819e54915dd5edce9cff14c52d0af5f984aa3d36a3
+  checksum: 843e7528de0e03a31a6f3837896a95f75b0b24b0294a077246282372279e974400b0bdd82399e8f9cbfe42c87ed56540fd71c33eafb7c8e8b9adac546ecc5fe5
   languageName: node
   linkType: hard
 
@@ -6123,13 +6138,13 @@ __metadata:
   linkType: hard
 
 "babel-plugin-polyfill-regenerator@npm:^0.5.4":
-  version: 0.5.4
-  resolution: "babel-plugin-polyfill-regenerator@npm:0.5.4"
+  version: 0.5.5
+  resolution: "babel-plugin-polyfill-regenerator@npm:0.5.5"
   dependencies:
-    "@babel/helper-define-polyfill-provider": "npm:^0.4.4"
+    "@babel/helper-define-polyfill-provider": "npm:^0.5.0"
   peerDependencies:
     "@babel/core": ^7.4.0 || ^8.0.0-0 <8.0.0
-  checksum: 0b903f5fe2f8c487b4260935dfe60bd9a95bcaee7ae63958f063045093b16d4e8288c232199d411261300aa21f6b106a3cb83c42cc996de013b337f5825a79fe
+  checksum: 2aab692582082d54e0df9f9373dca1b223e65b4e7e96440160f27ed8803d417a1fa08da550f08aa3820d2010329ca91b68e2b6e9bd7aed51c93d46dfe79629bb
   languageName: node
   linkType: hard
 
@@ -6539,9 +6554,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001565":
-  version: 1.0.30001576
-  resolution: "caniuse-lite@npm:1.0.30001576"
-  checksum: 79cf666f9139c542bdf75eab76171534dc638d2f8efacd325649c8ec6be59de400f0e9d6dc02504f12125626b306c0a848fe86904c01722218b2a479be82a9c1
+  version: 1.0.30001579
+  resolution: "caniuse-lite@npm:1.0.30001579"
+  checksum: 4003970f8d01a5fa314e39f4a21751dc750a530f3d19aed225e18e8e02892b590b8b0debfa0961eae9bc0e49b77bfb17cf30d2469540e428a8305e3cc9164fb8
   languageName: node
   linkType: hard
 
@@ -7163,18 +7178,18 @@ __metadata:
   linkType: hard
 
 "core-js-compat@npm:^3.31.0, core-js-compat@npm:^3.33.1":
-  version: 3.35.0
-  resolution: "core-js-compat@npm:3.35.0"
+  version: 3.35.1
+  resolution: "core-js-compat@npm:3.35.1"
   dependencies:
     browserslist: "npm:^4.22.2"
-  checksum: 8c4379240b8decb94b21e81d5ba6f768418721061923b28c9dfc97574680c35d778d39c010207402fc7c8308a68a4cf6d5e02bcbcb96e931c52e6e0dce29a68c
+  checksum: c3b872e1f9703aa9554cce816207d85730da4703f1776c540b4da11bbbef6d9a1e6041625b5c1f58d2ada3d05f4a2b92897b7de5315c5ecd5d33d50dec86cca7
   languageName: node
   linkType: hard
 
 "core-js-pure@npm:^3.23.3":
-  version: 3.35.0
-  resolution: "core-js-pure@npm:3.35.0"
-  checksum: 4e58b6b2b3759ffbfe3f904beafd547751aaefa87b94245136aced963120bc2cefc8787c7a980cd397c2c408eca141e0993fcda7ed2383c93ce53bc421acfec4
+  version: 3.35.1
+  resolution: "core-js-pure@npm:3.35.1"
+  checksum: 1e3154d47be12ba82dd927b0af87fac4c6011d36772bc03e3690b1e70d9fc16f31af058f5cff647e82f8500bf08c58e1261e63dcc797faea568ebc6fc50331a7
   languageName: node
   linkType: hard
 
@@ -7885,9 +7900,9 @@ __metadata:
   linkType: hard
 
 "dotenv@npm:^16.0.0":
-  version: 16.3.1
-  resolution: "dotenv@npm:16.3.1"
-  checksum: b95ff1bbe624ead85a3cd70dbd827e8e06d5f05f716f2d0cbc476532d54c7c9469c3bc4dd93ea519f6ad711cb522c00ac9a62b6eb340d5affae8008facc3fbd7
+  version: 16.3.2
+  resolution: "dotenv@npm:16.3.2"
+  checksum: a87d62cef0810b670cb477db1a24a42a093b6b428c9e65c185ce1d6368ad7175234b13547718ba08da18df43faae4f814180cc0366e11be1ded2277abc4dd22e
   languageName: node
   linkType: hard
 
@@ -7929,9 +7944,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.601":
-  version: 1.4.630
-  resolution: "electron-to-chromium@npm:1.4.630"
-  checksum: dbe3b3437b00f978aa261e1ee9c80eebaba70dea601866b0d64e36f7146328c79bce8416652e4713cfeb0e22428cc7ec1751881860ec892fa32ec8de015d1a9e
+  version: 1.4.640
+  resolution: "electron-to-chromium@npm:1.4.640"
+  checksum: fe5e2eaf3bdd73c1628ed0a7856a1d6afad99bdcceec6cacf87e7bac31db8514a52084d040b95b956ceba4f95723a6f3cf40a91f21b0061e6490328c9099dc4a
   languageName: node
   linkType: hard
 
@@ -9100,9 +9115,9 @@ __metadata:
   linkType: hard
 
 "flow-parser@npm:0.*":
-  version: 0.226.0
-  resolution: "flow-parser@npm:0.226.0"
-  checksum: 668d39f88597600b6411096cfb514f87e8909d53dad4279534baa43f5037a50b23a04e83da4996b3d6c6673a8ac953efd26b2481b7c64f0309e3a453ac32d530
+  version: 0.227.0
+  resolution: "flow-parser@npm:0.227.0"
+  checksum: 4f22f6f45b96effcfaede2c2c7891e2b9062bdb7aa2bc75f7813b840b468e2a7dfc7dfc89c954e9942b5a9f23d1835605cbc6a7c7a35ee1432360fe568a98ff1
   languageName: node
   linkType: hard
 
@@ -14481,14 +14496,14 @@ __metadata:
   linkType: hard
 
 "safe-array-concat@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "safe-array-concat@npm:1.0.1"
+  version: 1.1.0
+  resolution: "safe-array-concat@npm:1.1.0"
   dependencies:
-    call-bind: "npm:^1.0.2"
-    get-intrinsic: "npm:^1.2.1"
+    call-bind: "npm:^1.0.5"
+    get-intrinsic: "npm:^1.2.2"
     has-symbols: "npm:^1.0.3"
     isarray: "npm:^2.0.5"
-  checksum: 4b15ce5fce5ce4d7e744a63592cded88d2f27806ed229eadb2e42629cbcd40e770f7478608e75f455e7fe341acd8c0a01bdcd7146b10645ea7411c5e3c1d1dd8
+  checksum: 833d3d950fc7507a60075f9bfaf41ec6dac7c50c7a9d62b1e6b071ecc162185881f92e594ff95c1a18301c881352dd6fd236d56999d5819559db7b92da9c28af
   languageName: node
   linkType: hard
 
@@ -15069,9 +15084,9 @@ __metadata:
   linkType: hard
 
 "stream-shift@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "stream-shift@npm:1.0.2"
-  checksum: 4374e796ba4169cdd90d9fdd44f22e4687ffb663c6d29dd57a20335c4c32fc68d8e9c91c18caf92988178fdeb22c8878c97ae82a7f808b2179b1ea3eb45d737c
+  version: 1.0.3
+  resolution: "stream-shift@npm:1.0.3"
+  checksum: 939cd1051ca750d240a0625b106a2b988c45fb5a3be0cebe9a9858cb01bc1955e8c7b9fac17a9462976bea4a7b704e317c5c2200c70f0ca715a3363b9aa4fd3b
   languageName: node
   linkType: hard
 
@@ -15682,8 +15697,8 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.10.0, terser@npm:^5.26.0":
-  version: 5.26.0
-  resolution: "terser@npm:5.26.0"
+  version: 5.27.0
+  resolution: "terser@npm:5.27.0"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
     acorn: "npm:^8.8.2"
@@ -15691,7 +15706,7 @@ __metadata:
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 3906289c6bacd75804a47a583cdafefbd76c5edb39435369755c7b1592e57586fb2f4bddf6eb37a807d6e782171dbf0aa7bbdc80fd5b77b2f2b62196cac49b62
+  checksum: bed0d39d9a7f2b82c87173e48081c46426a8820ba1dcb864bbfccd2df2b7fb8498a7ea4c8ef045ccce5713b23a6b4c3a784967f1b9f3115adaa7f51712f6e6ae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Afficher les messages d'erreurs au debut lorsqu'on a un value ou defaultValue qui n'est pas valide, a l'exception pour un string vide on ne valide pas le required.

J'ai aussi fixe un bug en fesant mes tests: 
- data-testid pour les message d'erreurs dans FieldContainer n'etait pas render.