### PR TITLE
fix(Pagination): replace totalPages with resultsPerPage

### DIFF
--- a/packages/react/src/components/pagination/pagination.test.tsx
+++ b/packages/react/src/components/pagination/pagination.test.tsx
@@ -6,7 +6,7 @@ import { Pagination } from './pagination';
 describe('Pagination', () => {
     test('Matches the mobile snapshot', () => {
         const tree = renderWithProviders(
-            <Pagination totalPages={12} />,
+            <Pagination resultsPerPage={12} />,
             'mobile',
         );
 
@@ -15,7 +15,7 @@ describe('Pagination', () => {
 
     test('Matches the desktop snapshot', () => {
         const tree = renderWithProviders(
-            <Pagination totalPages={12} />,
+            <Pagination resultsPerPage={12} />,
             'desktop',
         );
 
@@ -24,7 +24,7 @@ describe('Pagination', () => {
 
     test('Matches the mobile snapshot with multiples digits page numbers', () => {
         const tree = renderWithProviders(
-            <Pagination totalPages={1000} />,
+            <Pagination resultsPerPage={1000} />,
             'mobile',
         );
 
@@ -33,7 +33,7 @@ describe('Pagination', () => {
 
     test('Matches the desktop snapshot with multiples digits page numbers', () => {
         const tree = renderWithProviders(
-            <Pagination totalPages={1000} />,
+            <Pagination resultsPerPage={1000} />,
             'desktop',
         );
 
@@ -42,7 +42,7 @@ describe('Pagination', () => {
 
     describe('pages list', () => {
         test('should display pages', () => {
-            const wrapper = shallow(<Pagination totalPages={5} pagesShown={5} />);
+            const wrapper = shallow(<Pagination resultsPerPage={5} numberOfResults={25} pagesShown={5} />);
             const pages = findByTestId(wrapper, 'page-', '^');
 
             expect(pages).toHaveLength(5);
@@ -50,7 +50,9 @@ describe('Pagination', () => {
 
         test('should go to page 2 when clicking on page 2', () => {
             const callback = jest.fn();
-            const wrapper = shallow(<Pagination totalPages={3} defaultActivePage={1} onPageChange={callback} />);
+            const wrapper = shallow(
+                <Pagination resultsPerPage={3} numberOfResults={6} defaultActivePage={1} onPageChange={callback} />,
+            );
             const pageButton = findByTestId(wrapper, 'page-2');
 
             pageButton.simulate('click');
@@ -59,7 +61,7 @@ describe('Pagination', () => {
         });
 
         test('should highlight selected page', () => {
-            const wrapper = shallow(<Pagination totalPages={3} defaultActivePage={3} />);
+            const wrapper = shallow(<Pagination resultsPerPage={3} numberOfResults={9} defaultActivePage={3} />);
             const pageButton = findByTestId(wrapper, 'page-3');
 
             expect(pageButton.prop('isSelected')).toBe(true);
@@ -68,71 +70,71 @@ describe('Pagination', () => {
 
     describe('results label', () => {
         test('should display zero results when number of results is undefined', () => {
-            const wrapper = shallow(<Pagination totalPages={0} numberOfResults={undefined} />);
+            const wrapper = shallow(<Pagination resultsPerPage={0} numberOfResults={undefined} />);
             const label = findByTestId(wrapper, 'resultsLabel');
 
             expect(label.text()).toEqual('<ScreenReaderOnlyText />0–0 of 0 results');
         });
 
         test('should display the number of results when provided', () => {
-            const wrapper = shallow(<Pagination totalPages={3} numberOfResults={12345} />);
+            const wrapper = shallow(<Pagination resultsPerPage={3} numberOfResults={12345} />);
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />1–4115 of 12345 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />1–3 of 12345 results');
         });
 
         test('should display first page results label when number of results is even', () => {
             const wrapper = shallow(
-                <Pagination totalPages={6} numberOfResults={30} activePage={1} />,
+                <Pagination resultsPerPage={6} numberOfResults={30} activePage={1} />,
             );
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />1–5 of 30 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />1–6 of 30 results');
         });
 
         test('should display second page results label when number of results is uneven', () => {
             const wrapper = shallow(
-                <Pagination totalPages={6} numberOfResults={30} activePage={2} />,
+                <Pagination resultsPerPage={6} numberOfResults={30} activePage={2} />,
             );
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />6–10 of 30 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />7–12 of 30 results');
         });
 
         test('should display last page results label when number of results is uneven', () => {
             const wrapper = shallow(
-                <Pagination totalPages={6} numberOfResults={30} activePage={6} />,
+                <Pagination resultsPerPage={6} numberOfResults={30} activePage={6} />,
             );
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />26–30 of 30 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />25–30 of 30 results');
         });
 
         test('should display first page results label when number of results is uneven', () => {
             const wrapper = shallow(
-                <Pagination totalPages={50} numberOfResults={1530} activePage={1} />,
+                <Pagination resultsPerPage={50} numberOfResults={1530} activePage={1} />,
             );
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />1–31 of 1530 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />1–50 of 1530 results');
         });
 
         test('should display second page results label when number of results is uneven', () => {
             const wrapper = shallow(
-                <Pagination totalPages={50} numberOfResults={1530} activePage={2} />,
+                <Pagination resultsPerPage={50} numberOfResults={1530} activePage={2} />,
             );
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />32–62 of 1530 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />51–100 of 1530 results');
         });
 
         test('should display last page results label when number of results is uneven', () => {
             const wrapper = shallow(
-                <Pagination totalPages={50} numberOfResults={1530} activePage={50} />,
+                <Pagination resultsPerPage={50} numberOfResults={1530} activePage={31} />,
             );
             const label = findByTestId(wrapper, 'resultsLabel');
 
-            expect(label.text()).toEqual('<ScreenReaderOnlyText />1520–1530 of 1530 results');
+            expect(label.text()).toEqual('<ScreenReaderOnlyText />1501–1530 of 1530 results');
         });
     });
 
@@ -151,7 +153,12 @@ describe('Pagination', () => {
                 test(`should go to page ${testCase.goesToPage} when clicked`, () => {
                     const callback = jest.fn();
                     const wrapper = shallow(
-                        <Pagination totalPages={11} defaultActivePage={3} onPageChange={callback} />,
+                        <Pagination
+                            resultsPerPage={11}
+                            numberOfResults={121}
+                            defaultActivePage={3}
+                            onPageChange={callback}
+                        />,
                     );
                     const button = findByTestId(wrapper, testCase.id);
 
@@ -162,7 +169,11 @@ describe('Pagination', () => {
 
                 test(`should be disabled when on page ${testCase.disabledWhenOnPage}`, () => {
                     const wrapper = shallow(
-                        <Pagination totalPages={11} defaultActivePage={testCase.disabledWhenOnPage} />,
+                        <Pagination
+                            resultsPerPage={11}
+                            numberOfResults={121}
+                            defaultActivePage={testCase.disabledWhenOnPage}
+                        />,
                     );
                     const button = findByTestId(wrapper, testCase.id);
 
@@ -171,7 +182,11 @@ describe('Pagination', () => {
 
                 test(`should be enabled when on page ${testCase.enabledWhenOnPage}`, () => {
                     const wrapper = shallow(
-                        <Pagination totalPages={11} defaultActivePage={testCase.enabledWhenOnPage} />,
+                        <Pagination
+                            resultsPerPage={11}
+                            numberOfResults={121}
+                            defaultActivePage={testCase.enabledWhenOnPage}
+                        />,
                     );
                     const button = findByTestId(wrapper, testCase.id);
 
@@ -179,7 +194,7 @@ describe('Pagination', () => {
                 });
 
                 test(`should not be rendered when there's less than ${testCase.stopRenderAt} page`, () => {
-                    const wrapper = shallow(<Pagination totalPages={testCase.stopRenderAt - 1} />);
+                    const wrapper = shallow(<Pagination resultsPerPage={testCase.stopRenderAt - 1} />);
                     const button = findByTestId(wrapper, testCase.id);
 
                     expect(button.exists()).toBe(false);

--- a/packages/react/src/components/pagination/pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/pagination.test.tsx.snap
@@ -1,96 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pagination Matches the desktop snapshot 1`] = `
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background: inherit;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  box-sizing: border-box;
-  color: inherit;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: inherit;
-  font-size: 0.75rem;
-  font-weight: var(--font-bold);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  line-height: 1rem;
-  min-height: var(--size-2x);
-  min-width: 2rem;
-  outline: none;
-  padding: 0 var(--spacing-2x);
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c5:focus {
-  outline: none;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c5 > svg {
-  color: inherit;
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
-.c6 {
-  background-color: transparent;
-  border-color: transparent;
-  color: #60666E;
-  padding: 0;
-  width: var(--size-2x);
-}
-
-.c6:focus {
-  outline: none;
-}
-
-.c6:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c6:hover,
-.c6[aria-expanded='true'] {
-  background-color: #DBDEE1;
-  color: #1B1C1E;
-}
-
-.c6:disabled {
-  background-color: transparent;
-  color: #B7BBC2;
-}
-
-.c6 > svg {
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
 .c4 {
   border: 0;
   -webkit-clip: rect(0,0,0,0);
@@ -103,99 +13,13 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
   width: 1px;
 }
 
-.c7 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin: 0 var(--spacing-half);
   padding: 0;
-}
-
-.c8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #E0F0F9;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #003A5A;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 0.9rem;
-  font-weight: var(--font-normal);
-  height: var(--size-1halfx);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1.5rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-1halfx);
-  outline: 1px solid #006296;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c8:focus {
-  outline: none;
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c8:hover {
-  background-color: #E0F0F9;
-  cursor: default;
-}
-
-.c9 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #FFFFFF;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #60666E;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 0.9rem;
-  font-weight: var(--font-normal);
-  height: var(--size-1halfx);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1.5rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-1halfx);
-  outline: 0;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c9:focus {
-  outline: none;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c9:hover {
-  background-color: #DBDEE1;
-  cursor: pointer;
 }
 
 .c0 {
@@ -266,170 +90,14 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
         </span>
       </h3>
     </span>
-    <button
-      aria-disabled="true"
-      aria-label="previous page"
-      class="c5 c6"
-      data-testid="previousPageButton"
-      disabled=""
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
     <ol
-      class="c7"
-    >
-      <li
-        class="c8"
-        data-testid="page-1"
-        tabindex="0"
-      >
-        <a
-          aria-current="page"
-          aria-label="go to page 1"
-        >
-          1
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-2"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 2"
-        >
-          2
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-3"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 3"
-        >
-          3
-        </a>
-      </li>
-    </ol>
-    <button
-      aria-disabled="false"
-      aria-label="next page"
-      class="c5 c6"
-      data-testid="nextPageButton"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
+      class="c5"
+    />
   </nav>
 </div>
 `;
 
 exports[`Pagination Matches the desktop snapshot with multiples digits page numbers 1`] = `
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background: inherit;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  box-sizing: border-box;
-  color: inherit;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: inherit;
-  font-size: 0.75rem;
-  font-weight: var(--font-bold);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  line-height: 1rem;
-  min-height: var(--size-2x);
-  min-width: 2rem;
-  outline: none;
-  padding: 0 var(--spacing-2x);
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c5:focus {
-  outline: none;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c5 > svg {
-  color: inherit;
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
-.c6 {
-  background-color: transparent;
-  border-color: transparent;
-  color: #60666E;
-  padding: 0;
-  width: var(--size-2x);
-}
-
-.c6:focus {
-  outline: none;
-}
-
-.c6:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c6:hover,
-.c6[aria-expanded='true'] {
-  background-color: #DBDEE1;
-  color: #1B1C1E;
-}
-
-.c6:disabled {
-  background-color: transparent;
-  color: #B7BBC2;
-}
-
-.c6 > svg {
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
 .c4 {
   border: 0;
   -webkit-clip: rect(0,0,0,0);
@@ -442,99 +110,13 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
   width: 1px;
 }
 
-.c7 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin: 0 var(--spacing-half);
   padding: 0;
-}
-
-.c8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #E0F0F9;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #003A5A;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 0.9rem;
-  font-weight: var(--font-normal);
-  height: var(--size-1halfx);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1.5rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-1halfx);
-  outline: 1px solid #006296;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c8:focus {
-  outline: none;
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c8:hover {
-  background-color: #E0F0F9;
-  cursor: default;
-}
-
-.c9 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #FFFFFF;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #60666E;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 0.9rem;
-  font-weight: var(--font-normal);
-  height: var(--size-1halfx);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 1.5rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-1halfx);
-  outline: 0;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c9:focus {
-  outline: none;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c9:hover {
-  background-color: #DBDEE1;
-  cursor: pointer;
 }
 
 .c0 {
@@ -605,170 +187,14 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
         </span>
       </h3>
     </span>
-    <button
-      aria-disabled="true"
-      aria-label="previous page"
-      class="c5 c6"
-      data-testid="previousPageButton"
-      disabled=""
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
     <ol
-      class="c7"
-    >
-      <li
-        class="c8"
-        data-testid="page-1"
-        tabindex="0"
-      >
-        <a
-          aria-current="page"
-          aria-label="go to page 1"
-        >
-          1
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-2"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 2"
-        >
-          2
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-3"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 3"
-        >
-          3
-        </a>
-      </li>
-    </ol>
-    <button
-      aria-disabled="false"
-      aria-label="next page"
-      class="c5 c6"
-      data-testid="nextPageButton"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
+      class="c5"
+    />
   </nav>
 </div>
 `;
 
 exports[`Pagination Matches the mobile snapshot 1`] = `
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background: inherit;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  box-sizing: border-box;
-  color: inherit;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: inherit;
-  font-size: 0.875rem;
-  font-weight: var(--font-bold);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0.033125rem;
-  -moz-letter-spacing: 0.033125rem;
-  -ms-letter-spacing: 0.033125rem;
-  letter-spacing: 0.033125rem;
-  line-height: 1.5rem;
-  min-height: var(--size-3x);
-  min-width: 2rem;
-  outline: none;
-  padding: 0 var(--spacing-3x);
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c5:focus {
-  outline: none;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c5 > svg {
-  color: inherit;
-  height: var(--size-1halfx);
-  width: var(--size-1halfx);
-}
-
-.c6 {
-  background-color: transparent;
-  border-color: transparent;
-  color: #60666E;
-  padding: 0;
-  width: var(--size-3x);
-}
-
-.c6:focus {
-  outline: none;
-}
-
-.c6:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c6:hover,
-.c6[aria-expanded='true'] {
-  background-color: #DBDEE1;
-  color: #1B1C1E;
-}
-
-.c6:disabled {
-  background-color: transparent;
-  color: #B7BBC2;
-}
-
-.c6 > svg {
-  height: var(--size-1halfx);
-  width: var(--size-1halfx);
-}
-
 .c4 {
   border: 0;
   -webkit-clip: rect(0,0,0,0);
@@ -781,99 +207,13 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
   width: 1px;
 }
 
-.c7 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin: 0 var(--spacing-half);
   padding: 0;
-}
-
-.c8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #E0F0F9;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #003A5A;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: var(--font-normal);
-  height: var(--size-2x);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 2rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-2x);
-  outline: 1px solid #006296;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c8:focus {
-  outline: none;
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c8:hover {
-  background-color: #E0F0F9;
-  cursor: default;
-}
-
-.c9 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #FFFFFF;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #60666E;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: var(--font-normal);
-  height: var(--size-2x);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 2rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-2x);
-  outline: 0;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c9:focus {
-  outline: none;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c9:hover {
-  background-color: #DBDEE1;
-  cursor: pointer;
 }
 
 .c0 {
@@ -944,170 +284,14 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
         </span>
       </h3>
     </span>
-    <button
-      aria-disabled="true"
-      aria-label="previous page"
-      class="c5 c6"
-      data-testid="previousPageButton"
-      disabled=""
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
     <ol
-      class="c7"
-    >
-      <li
-        class="c8"
-        data-testid="page-1"
-        tabindex="0"
-      >
-        <a
-          aria-current="page"
-          aria-label="go to page 1"
-        >
-          1
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-2"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 2"
-        >
-          2
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-3"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 3"
-        >
-          3
-        </a>
-      </li>
-    </ol>
-    <button
-      aria-disabled="false"
-      aria-label="next page"
-      class="c5 c6"
-      data-testid="nextPageButton"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
+      class="c5"
+    />
   </nav>
 </div>
 `;
 
 exports[`Pagination Matches the mobile snapshot with multiples digits page numbers 1`] = `
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background: inherit;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  box-sizing: border-box;
-  color: inherit;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: inherit;
-  font-size: 0.875rem;
-  font-weight: var(--font-bold);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0.033125rem;
-  -moz-letter-spacing: 0.033125rem;
-  -ms-letter-spacing: 0.033125rem;
-  letter-spacing: 0.033125rem;
-  line-height: 1.5rem;
-  min-height: var(--size-3x);
-  min-width: 2rem;
-  outline: none;
-  padding: 0 var(--spacing-3x);
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c5:focus {
-  outline: none;
-}
-
-.c5:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c5 > svg {
-  color: inherit;
-  height: var(--size-1halfx);
-  width: var(--size-1halfx);
-}
-
-.c6 {
-  background-color: transparent;
-  border-color: transparent;
-  color: #60666E;
-  padding: 0;
-  width: var(--size-3x);
-}
-
-.c6:focus {
-  outline: none;
-}
-
-.c6:focus {
-  outline: none;
-  border-color: #006296;
-  box-shadow: 0 0 0 2px #84C6EA;
-}
-
-.c6:hover,
-.c6[aria-expanded='true'] {
-  background-color: #DBDEE1;
-  color: #1B1C1E;
-}
-
-.c6:disabled {
-  background-color: transparent;
-  color: #B7BBC2;
-}
-
-.c6 > svg {
-  height: var(--size-1halfx);
-  width: var(--size-1halfx);
-}
-
 .c4 {
   border: 0;
   -webkit-clip: rect(0,0,0,0);
@@ -1120,99 +304,13 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
   width: 1px;
 }
 
-.c7 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin: 0 var(--spacing-half);
   padding: 0;
-}
-
-.c8 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #E0F0F9;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #003A5A;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: var(--font-normal);
-  height: var(--size-2x);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 2rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-2x);
-  outline: 1px solid #006296;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c8:focus {
-  outline: none;
-}
-
-.c8:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c8:hover {
-  background-color: #E0F0F9;
-  cursor: default;
-}
-
-.c9 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: #FFFFFF;
-  border-radius: 1rem;
-  box-sizing: border-box;
-  color: #60666E;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-size: 1rem;
-  font-weight: var(--font-normal);
-  height: var(--size-2x);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  line-height: 2rem;
-  margin: 0 var(--spacing-half);
-  min-width: var(--size-2x);
-  outline: 0;
-  padding: 0 var(--spacing-1x);
-  text-align: center;
-}
-
-.c9:focus {
-  outline: none;
-}
-
-.c9:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px #84C6EA;
-  box-shadow: 0 0 0 1px #006296,0 0 0 3px #84C6EA;
-}
-
-.c9:hover {
-  background-color: #DBDEE1;
-  cursor: pointer;
 }
 
 .c0 {
@@ -1283,75 +381,9 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
         </span>
       </h3>
     </span>
-    <button
-      aria-disabled="true"
-      aria-label="previous page"
-      class="c5 c6"
-      data-testid="previousPageButton"
-      disabled=""
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
     <ol
-      class="c7"
-    >
-      <li
-        class="c8"
-        data-testid="page-1"
-        tabindex="0"
-      >
-        <a
-          aria-current="page"
-          aria-label="go to page 1"
-        >
-          1
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-2"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 2"
-        >
-          2
-        </a>
-      </li>
-      <li
-        class="c9"
-        data-testid="page-3"
-        tabindex="0"
-      >
-        <a
-          aria-label="go to page 3"
-        >
-          3
-        </a>
-      </li>
-    </ol>
-    <button
-      aria-disabled="false"
-      aria-label="next page"
-      class="c5 c6"
-      data-testid="nextPageButton"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
+      class="c5"
+    />
   </nav>
 </div>
 `;

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -97,10 +97,9 @@ const Navigation = styled.nav`
 interface PaginationProps {
     className?: string;
     /**
-     * Total number of pages
-     * @default desktop
+     * Number of results to display per page
      */
-    totalPages: number;
+    resultsPerPage: number;
     /**
      * Displays the total number of results when provided
      */
@@ -129,7 +128,7 @@ interface PaginationProps {
 
 export const Pagination: VoidFunctionComponent<PaginationProps> = ({
     className,
-    totalPages,
+    resultsPerPage,
     numberOfResults,
     defaultActivePage = 1,
     pagesShown = 3,
@@ -139,9 +138,10 @@ export const Pagination: VoidFunctionComponent<PaginationProps> = ({
     const { t } = useTranslation('pagination');
     const { isMobile } = useDeviceContext();
     const headingId = useId();
+    const currentNumberOfResults = numberOfResults === undefined ? 0 : numberOfResults;
+    const totalPages = currentNumberOfResults === 0 ? 0 : Math.ceil(currentNumberOfResults / resultsPerPage);
     const pagesDisplayed = Math.min(pagesShown, totalPages);
     const [currentPage, setCurrentPage] = useState(clamp(activePage || defaultActivePage, 1, totalPages));
-    const currentNumberOfResults = numberOfResults === undefined ? 0 : numberOfResults;
     const canNavigatePrevious = currentPage > 1;
     const canNavigateNext = currentPage < totalPages;
     const forwardBackwardNavActive = totalPages > 3 || pagesDisplayed < totalPages;
@@ -186,10 +186,10 @@ export const Pagination: VoidFunctionComponent<PaginationProps> = ({
     const ariaLabelledby = headingId;
     let pageStartIndex;
     let pageEndIndex;
-    const pageSize = currentNumberOfResults !== 0 ? Math.ceil(currentNumberOfResults / totalPages) : 0;
-    if (pageSize !== 0 && currentNumberOfResults !== 0) {
-        pageStartIndex = (pageSize * (currentPage - 1)) + 1;
-        pageEndIndex = Math.min(currentNumberOfResults, (pageSize * currentPage));
+
+    if (resultsPerPage !== 0 && currentNumberOfResults !== 0) {
+        pageStartIndex = (resultsPerPage * (currentPage - 1)) + 1;
+        pageEndIndex = Math.min(currentNumberOfResults, (resultsPerPage * currentPage));
     } else {
         pageStartIndex = 0;
         pageEndIndex = 0;

--- a/packages/storybook/stories/pagination.stories.tsx
+++ b/packages/storybook/stories/pagination.stories.tsx
@@ -12,7 +12,6 @@ export default {
 
 export const Normal: Story = () => (
     <>
-        <Pagination resultsPerPage={0} numberOfResults={undefined} />
         <Pagination resultsPerPage={10} numberOfResults={30} />
         <Pagination resultsPerPage={50} numberOfResults={100} />
         <Pagination resultsPerPage={75} numberOfResults={1530} />

--- a/packages/storybook/stories/pagination.stories.tsx
+++ b/packages/storybook/stories/pagination.stories.tsx
@@ -12,19 +12,19 @@ export default {
 
 export const Normal: Story = () => (
     <>
-        <Pagination totalPages={0} numberOfResults={undefined} />
-        <Pagination totalPages={3} numberOfResults={30} />
-        <Pagination totalPages={5} numberOfResults={100} />
-        <Pagination totalPages={50} numberOfResults={1530} />
+        <Pagination resultsPerPage={0} numberOfResults={undefined} />
+        <Pagination resultsPerPage={10} numberOfResults={30} />
+        <Pagination resultsPerPage={50} numberOfResults={100} />
+        <Pagination resultsPerPage={75} numberOfResults={1530} />
     </>
 );
 
 export const ControlledPagination: Story = () => {
-    const [currentPage, setCurrentPage] = useState(1);
+    const [currentPage, setCurrentPage] = useState(18);
 
     return (
         <Pagination
-            totalPages={5}
+            resultsPerPage={5}
             numberOfResults={100}
             onPageChange={setCurrentPage}
             activePage={currentPage}
@@ -34,9 +34,9 @@ export const ControlledPagination: Story = () => {
 ControlledPagination.parameters = rawCodeParameters;
 
 export const WithoutResults: Story = () => (
-    <Pagination totalPages={11} />
+    <Pagination resultsPerPage={11} />
 );
 
 export const With4DigitsNumberOfPages: Story = () => (
-    <Pagination totalPages={1000} />
+    <Pagination resultsPerPage={2} numberOfResults={2000} />
 );


### PR DESCRIPTION
https://equisoft.atlassian.net/browse/DS-965

Dans la composante de Pagination, retirer l'assignation d'un nombre de page précis à afficher (prop `totalPages`) et le remplacer par le nombre de résultats à afficher par page. 

Cela a pour effet de dynamiquement calculer le nombre de pages à afficher, en fonction de la valeur d'entrée de la prop `resultsPerPage`, et du nombre total de résultats. 

![image](https://github.com/kronostechnologies/design-elements/assets/6412423/1db9b8ee-0e6e-4fb8-94c4-82b2f2492fe1)
