### PR TITLE
fix(datepicker): call calendar open/close events in calendarbutton on mousedown callback

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -437,10 +437,7 @@ export const Datepicker = forwardRef(({
                 if (dateInputRef.current?.isCalendarOpen()) {
                     event.stopPropagation();
                     dateInputRef.current?.setOpen(false);
-
-                    if (onCalendarClose) {
-                        onCalendarClose();
-                    }
+                    onCalendarClose?.();
                 }
                 break;
         }
@@ -453,17 +450,10 @@ export const Datepicker = forwardRef(({
     function handleCalendarButtonMouseDown(): void {
         if (dateInputRef.current?.isCalendarOpen()) {
             dateInputRef.current?.setOpen(false);
-
-            if (onCalendarClose) {
-                onCalendarClose();
-            }
+            onCalendarClose?.();
         } else {
             dateInputRef.current?.setOpen(true);
-
-            if (onCalendarOpen) {
-                onCalendarOpen();
-            }
-
+            onCalendarOpen?.();
             focusCalendarDate();
         }
     }
@@ -471,11 +461,7 @@ export const Datepicker = forwardRef(({
     function handleCalendarButtonKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
         if (event.key === 'Enter' || event.key === ' ' /* Space bar */) {
             dateInputRef.current?.setOpen(true);
-
-            if (onCalendarOpen) {
-                onCalendarOpen();
-            }
-
+            onCalendarOpen?.();
             focusCalendarDate();
         }
     }

--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -432,6 +432,17 @@ export const Datepicker = forwardRef(({
                 dateInputRef.current?.setOpen(false);
                 calendarButtonRef.current?.focus();
                 break;
+            case 'Enter':
+            case ' ':
+                event.stopPropagation();
+                if (dateInputRef.current?.isCalendarOpen()) {
+                    dateInputRef.current?.setOpen(false);
+
+                    if (onCalendarClose) {
+                        onCalendarClose();
+                    }
+                }
+                break;
         }
     }
 
@@ -460,6 +471,11 @@ export const Datepicker = forwardRef(({
     function handleCalendarButtonKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
         if (event.key === 'Enter' || event.key === ' ' /* Space bar */) {
             dateInputRef.current?.setOpen(true);
+
+            if (onCalendarOpen) {
+                onCalendarOpen();
+            }
+
             focusCalendarDate();
         }
     }

--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -434,8 +434,8 @@ export const Datepicker = forwardRef(({
                 break;
             case 'Enter':
             case ' ':
-                event.stopPropagation();
                 if (dateInputRef.current?.isCalendarOpen()) {
+                    event.stopPropagation();
                     dateInputRef.current?.setOpen(false);
 
                     if (onCalendarClose) {

--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -442,8 +442,17 @@ export const Datepicker = forwardRef(({
     function handleCalendarButtonMouseDown(): void {
         if (dateInputRef.current?.isCalendarOpen()) {
             dateInputRef.current?.setOpen(false);
+
+            if (onCalendarClose) {
+                onCalendarClose();
+            }
         } else {
             dateInputRef.current?.setOpen(true);
+
+            if (onCalendarOpen) {
+                onCalendarOpen();
+            }
+
             focusCalendarDate();
         }
     }
@@ -573,8 +582,6 @@ export const Datepicker = forwardRef(({
                         onChange={handleInputChange}
                         onSelect={handleCalendarSelect}
                         onBlur={handleInputBlur}
-                        onCalendarClose={onCalendarClose}
-                        onCalendarOpen={onCalendarOpen}
                         onFocus={onFocus}
                         onClickOutside={handleClickOutside}
                         onInputClick={handleInputClick}


### PR DESCRIPTION
https://equisoft.atlassian.net/browse/DS-990

Le callback `handleCalendarButtonMouseDown` du component `CalendarButton` change le state open/close du calendrier et causait des problèmes avec les callbacks `onCalendarOpen/onCalendarClose` du component `DatePicker`

La solution est de caller ces callbacks dans le `handleCalendarButtonMouseDown` pour éviter de les caller aux moments où ils devraient pas.

Avant (clic pour ouverture du calendrier):
![image](https://github.com/kronostechnologies/design-elements/assets/6412423/373bba79-6592-4884-ada9-7d0918fb9640)

Après (idem)
![image](https://github.com/kronostechnologies/design-elements/assets/6412423/867bfab2-ef70-4b63-99c6-a2748f985133)
