### PR TITLE
fix(skip-link): add bg-color

### DIFF
--- a/packages/react/src/components/global-header/global-header.tsx
+++ b/packages/react/src/components/global-header/global-header.tsx
@@ -64,7 +64,6 @@ const StyledSpan = styled.span`
 `;
 
 const StyledSkipLink = styled(SkipLink)<ComponentProps<typeof SkipLink> & { isMobile?: boolean }>`
-    background-color: ${({ theme }) => theme.component['global-header-skiplink-background-color']};
     transform: translateY(-50%);
     transition: top 0.2s cubic-bezier(0.5, 1, 0, 1);
 

--- a/packages/react/src/components/skip-link/skip-link.test.tsx.snap
+++ b/packages/react/src/components/skip-link/skip-link.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`SkipLink Matches Snapshot (Desktop) 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  background: #FFFFFF;
   color: #006296;
   font-size: 0.875rem;
   font-weight: var(--font-normal);
@@ -76,7 +77,6 @@ exports[`SkipLink Matches Snapshot (Desktop) 1`] = `
 }
 
 .c0:focus {
-  background-color: #FFFFFF;
   position: absolute;
 }
 
@@ -127,6 +127,7 @@ exports[`SkipLink Matches Snapshot (Mobile) 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+  background: #FFFFFF;
   color: #006296;
   font-size: 1rem;
   font-weight: var(--font-normal);
@@ -164,7 +165,6 @@ exports[`SkipLink Matches Snapshot (Mobile) 1`] = `
 }
 
 .c0:focus {
-  background-color: #FFFFFF;
   position: absolute;
 }
 

--- a/packages/react/src/components/skip-link/skip-link.tsx
+++ b/packages/react/src/components/skip-link/skip-link.tsx
@@ -7,6 +7,7 @@ import { useDeviceContext } from '../device-context-provider/device-context-prov
 const StyledLink = styled.a<{ isMobile: boolean }>`
     ${defaultButtonStyles}
 
+    background: ${({ theme }) => theme.component['skip-link-background-color']};
     color: ${({ theme }) => theme.component['skip-link-text-color']};
     font-size: ${({ isMobile }) => (isMobile ? 1 : 0.875)}rem;
     font-weight: var(--font-normal);
@@ -23,7 +24,6 @@ const StyledLink = styled.a<{ isMobile: boolean }>`
     }
 
     &:focus {
-        background-color: ${({ theme }) => theme.component['skip-link-focus-background-color']};
         position: absolute;
     }
 `;

--- a/packages/react/src/themes/tokens/component/global-header-tokens.ts
+++ b/packages/react/src/themes/tokens/component/global-header-tokens.ts
@@ -3,7 +3,6 @@ import { RefTokens } from '../ref-tokens';
 
 export type GlobalHeaderTokens =
     'global-header-background-color' |
-    'global-header-skiplink-background-color' |
     'global-header-logo-title-separator-color' |
     'global-header-content-text-color' |
     'global-header-logo-content-text-color';
@@ -18,6 +17,5 @@ export const defaultGlobalHeaderTokens : GlobalHeaderTokensMap = {
     'global-header-background-color': 'color-brand-80',
     'global-header-logo-title-separator-color': 'color-brand-70',
     'global-header-content-text-color': 'color-white',
-    'global-header-skiplink-background-color': 'color-white',
     'global-header-logo-content-text-color': 'color-white',
 };

--- a/packages/react/src/themes/tokens/component/skip-link-tokens.ts
+++ b/packages/react/src/themes/tokens/component/skip-link-tokens.ts
@@ -2,8 +2,8 @@ import { AliasTokens } from '../alias-tokens';
 import { RefTokens } from '../ref-tokens';
 
 export type SkipLinkTokens =
+    | 'skip-link-background-color'
     | 'skip-link-text-color'
-    | 'skip-link-focus-background-color'
 
 export type SkipLinkTokenValue = AliasTokens | RefTokens;
 
@@ -12,6 +12,6 @@ export type SkipLinkTokenMap = {
 };
 
 export const defaultSkipLinkTokens: SkipLinkTokenMap = {
+    'skip-link-background-color': 'color-white',
     'skip-link-text-color': 'color-informative-50',
-    'skip-link-focus-background-color': 'color-white',
 };


### PR DESCRIPTION
Le skip-link n'avait pas de couleur background prédéfinie autre qu'une valeur `inherit` du `defaultButtonStyles` mais sa couleur était définie dans le composant `global-header`.
J'ai ajouté un `background-color` directement dans le composant et supprimé ce qui était dans le global-header.

https://equisoft.atlassian.net/browse/DS-1077