### PR TITLE
feat(Console): provide a mean to log only in dev

### DIFF
--- a/packages/react/src/hooks/use-dev-console.ts
+++ b/packages/react/src/hooks/use-dev-console.ts
@@ -1,0 +1,17 @@
+type DevConsole = Pick<Console, 'log' | 'info' | 'warn' | 'error'>;
+
+// eslint-disable-next-line no-underscore-dangle
+const inDevMode = globalThis.__DS_DEV__;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
+/* eslint-disable no-console */
+export function useDevConsole(): DevConsole {
+    return {
+        log: inDevMode ? console.log : noop,
+        info: inDevMode ? console.info : noop,
+        warn: inDevMode ? console.warn : noop,
+        error: inDevMode ? console.error : noop,
+    };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,8 @@
+// eslint-disable-next-line no-underscore-dangle, no-var, vars-on-top
+declare global { var __DS_DEV__: boolean; }
+// eslint-disable-next-line no-underscore-dangle
+global.__DS_DEV__ = process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
+
 // Buttons
 export { Button } from './components/buttons/button';
 export { IconButton } from './components/buttons/icon-button';

--- a/packages/react/src/utils/dev-console.ts
+++ b/packages/react/src/utils/dev-console.ts
@@ -7,11 +7,9 @@ const inDevMode = globalThis.__DS_DEV__;
 function noop(): void {}
 
 /* eslint-disable no-console */
-export function useDevConsole(): DevConsole {
-    return {
-        log: inDevMode ? console.log : noop,
-        info: inDevMode ? console.info : noop,
-        warn: inDevMode ? console.warn : noop,
-        error: inDevMode ? console.error : noop,
-    };
-}
+export const devConsole: DevConsole = {
+    log: inDevMode ? console.log : noop,
+    info: inDevMode ? console.info : noop,
+    warn: inDevMode ? console.warn : noop,
+    error: inDevMode ? console.error : noop,
+};


### PR DESCRIPTION
DS-1092

Wrapper pour l'objet global `console` qui permet de logger seulement en dev. Rien n'est affiché dans la console dans le build pour la production ni dans les tests.

Usage:
```ts
import { devConsole } from '../utils/dev-console';

devConsole.warn('WARNING (only for devs)');
```

Évidemment, pour logger en tout temps, `console.log` et autres continuent de fonctionner tel quel.