### PR TITLE
chore(Listbox): mark styling props as transient

### DIFF
--- a/packages/react/src/components/combobox/combobox.test.tsx
+++ b/packages/react/src/components/combobox/combobox.test.tsx
@@ -103,8 +103,8 @@ describe('Combobox', () => {
 
             getByTestId(wrapper, 'arrow').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-Quebec').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-Quebec').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-Quebec').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-Quebec').prop('$focused')).toBe(true);
         });
     });
 
@@ -123,8 +123,8 @@ describe('Combobox', () => {
             getByTestId(wrapper, 'listitem-Quebec').simulate('click');
             getByTestId(wrapper, 'textbox').simulate('focus');
 
-            expect(getByTestId(wrapper, 'listitem-Quebec').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-Quebec').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-Quebec').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-Quebec').prop('$focused')).toBe(true);
         });
 
         test('the focused option is selected when clicking outside', () => {

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx
@@ -82,8 +82,8 @@ describe('Dropdown list', () => {
 
             getByTestId(wrapper, 'textbox').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-qc').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-qc').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-qc').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-qc').prop('$focused')).toBe(true);
         });
 
         test('defaultValue can select an empty value', () => {
@@ -111,8 +111,8 @@ describe('Dropdown list', () => {
             getByTestId(wrapper, 'listitem-qc').simulate('click');
             getByTestId(wrapper, 'textbox').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-qc').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-qc').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-qc').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-qc').prop('$focused')).toBe(true);
         });
 
         test('the focused option is selected when clicking outside', () => {

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
@@ -265,7 +265,6 @@ input + .c2 {
         data-testid="listitem-ab"
         id="uuid1_listbox_ab"
         role="option"
-        selected=""
       >
         <span
           class="c11"
@@ -729,7 +728,6 @@ input + .c2 {
         data-testid="listitem-ab"
         id="uuid1_listbox_ab"
         role="option"
-        selected=""
       >
         <span
           class="c13"
@@ -1122,7 +1120,6 @@ exports[`Dropdown list matches the snapshot (mobile) 1`] = `
         data-testid="listitem-ab"
         id="uuid1_listbox_ab"
         role="option"
-        selected=""
       >
         <span
           class="c9"
@@ -1562,7 +1559,6 @@ input + .c2 {
         data-testid="listitem-ab"
         id="uuid1_listbox_ab"
         role="option"
-        selected=""
       >
         <span
           class="c12"

--- a/packages/react/src/components/listbox/listbox.test.tsx
+++ b/packages/react/src/components/listbox/listbox.test.tsx
@@ -16,7 +16,7 @@ describe('Listbox', () => {
         test('single value selects the corresponding option', () => {
             const wrapper = shallow(<Listbox options={options} defaultValue="optionB" />);
 
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toEqual(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toEqual(true);
         });
 
         test('array without multiselect only selects the option corresponding to the first value', () => {
@@ -24,8 +24,8 @@ describe('Listbox', () => {
                 <Listbox options={options} defaultValue={['optionA', 'optionB']} multiselect={false} />,
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toEqual(true);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toEqual(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toEqual(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toEqual(false);
         });
 
         test('array with multiselect selects all corresponding options', () => {
@@ -33,17 +33,17 @@ describe('Listbox', () => {
                 <Listbox options={options} defaultValue={['optionA', 'optionB']} multiselect />,
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toEqual(true);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toEqual(true);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toEqual(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toEqual(true);
         });
 
         test('no option is selected when no defaultValue is provided', () => {
             const wrapper = shallow(<Listbox options={options} />);
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(false);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(false);
-            expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(false);
-            expect(getByTestId(wrapper, 'listitem-optionD').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionD').prop('$selected')).toBe(false);
         });
     });
 
@@ -53,7 +53,7 @@ describe('Listbox', () => {
 
             getByTestId(wrapper, 'listitem-optionB').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toEqual(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toEqual(true);
         });
 
         test('multiple options can be selected with multiselect', () => {
@@ -61,8 +61,8 @@ describe('Listbox', () => {
 
             getByTestId(wrapper, 'listitem-optionC').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
         });
 
         test('selected options can be unselected with multiselect', () => {
@@ -70,7 +70,7 @@ describe('Listbox', () => {
 
             getByTestId(wrapper, 'listitem-optionA').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(false);
         });
 
         test('disabled option is not selectable', () => {
@@ -78,7 +78,7 @@ describe('Listbox', () => {
 
             getByTestId(wrapper, 'listitem-optionD').simulate('click');
 
-            expect(getByTestId(wrapper, 'listitem-optionD').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionD').prop('$selected')).toBe(false);
         });
 
         test('the selected option is focused when the listbox gets the focus', () => {
@@ -86,7 +86,7 @@ describe('Listbox', () => {
 
             getByTestId(wrapper, 'listbox-container').simulate('focus');
 
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$focused')).toBe(true);
         });
 
         test('the focused option is not focused when the listbox looses the focus', () => {
@@ -94,7 +94,7 @@ describe('Listbox', () => {
 
             getByTestId(wrapper, 'listbox-container').simulate('blur');
 
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('focused')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$focused')).toBe(false);
         });
     });
 
@@ -107,7 +107,7 @@ describe('Listbox', () => {
                 { key: 'ArrowDown', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$focused')).toBe(true);
         });
 
         test('ArrowUp focuses the previous option', () => {
@@ -118,7 +118,7 @@ describe('Listbox', () => {
                 { key: 'ArrowUp', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$focused')).toBe(true);
         });
 
         test('Home focuses the first option', () => {
@@ -129,7 +129,7 @@ describe('Listbox', () => {
                 { key: 'Home', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$focused')).toBe(true);
         });
 
         test('End focuses the last option', () => {
@@ -140,7 +140,7 @@ describe('Listbox', () => {
                 { key: 'End', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionE').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionE').prop('$focused')).toBe(true);
         });
 
         test('focused option gets selected', () => {
@@ -151,7 +151,7 @@ describe('Listbox', () => {
                 { key: 'ArrowDown', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
         });
 
         test('disabled options are skipped (ArrowDown)', () => {
@@ -164,8 +164,8 @@ describe('Listbox', () => {
                 { key: 'ArrowDown', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionE').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-optionD').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionE').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionD').prop('$selected')).toBe(false);
         });
 
         test('disabled options are skipped (ArrowUp)', () => {
@@ -177,8 +177,8 @@ describe('Listbox', () => {
                 { key: 'ArrowUp', preventDefault: jest.fn() },
             );
 
-            expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-optionD').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionD').prop('$selected')).toBe(false);
         });
 
         describe('with multiselect', () => {
@@ -190,14 +190,14 @@ describe('Listbox', () => {
                     { key: ' ', preventDefault: jest.fn() },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(true);
 
                 getByTestId(wrapper, 'listbox-container').simulate(
                     'keydown',
                     { key: ' ', preventDefault: jest.fn() },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(false);
+                expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(false);
             });
 
             test('Ctrl+A selects all options except disabled', () => {
@@ -208,11 +208,11 @@ describe('Listbox', () => {
                     { key: 'a', ctrlKey: true, preventDefault: jest.fn() },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionD').prop('selected')).toBe(false);
-                expect(getByTestId(wrapper, 'listitem-optionE').prop('selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionD').prop('$selected')).toBe(false);
+                expect(getByTestId(wrapper, 'listitem-optionE').prop('$selected')).toBe(true);
             });
 
             test('Ctrl+A deselects all options when all options are selected', () => {
@@ -227,7 +227,7 @@ describe('Listbox', () => {
                 );
 
                 enabledOptionValues.forEach((value) => {
-                    expect(getByTestId(wrapper, `listitem-${value}`).prop('selected')).toBe(false);
+                    expect(getByTestId(wrapper, `listitem-${value}`).prop('$selected')).toBe(false);
                 });
             });
 
@@ -241,8 +241,8 @@ describe('Listbox', () => {
                     { key: 'ArrowUp', shiftKey: true, preventDefault: jest.fn() },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(true);
             });
 
             test('Shift+ArrowDown selects the next option', () => {
@@ -255,8 +255,8 @@ describe('Listbox', () => {
                     { key: 'ArrowDown', shiftKey: true, preventDefault: jest.fn() },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
             });
 
             test('Ctrl+Shift+Home selects all options from the first to the focused option', () => {
@@ -274,9 +274,9 @@ describe('Listbox', () => {
                     },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
             });
 
             test('Ctrl+Shift+End selects all options from focused option to the last', () => {
@@ -294,9 +294,9 @@ describe('Listbox', () => {
                     },
                 );
 
-                expect(getByTestId(wrapper, 'listitem-optionC').prop('selected')).toBe(true);
-                expect(getByTestId(wrapper, 'listitem-optionD').prop('selected')).toBe(false);
-                expect(getByTestId(wrapper, 'listitem-optionE').prop('selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionC').prop('$selected')).toBe(true);
+                expect(getByTestId(wrapper, 'listitem-optionD').prop('$selected')).toBe(false);
+                expect(getByTestId(wrapper, 'listitem-optionE').prop('$selected')).toBe(true);
             });
         });
     });
@@ -307,8 +307,8 @@ describe('Listbox', () => {
 
             wrapper.setProps({ value: 'optionB' }).update();
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(false);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(true);
         });
 
         test('selected option is deselected when the value prop is set to undefined', () => {
@@ -317,7 +317,7 @@ describe('Listbox', () => {
 
             wrapper.setProps({ value: undefined }).update();
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(false);
         });
 
         test('focused option is updated when the focusedValue prop is changed', () => {
@@ -325,8 +325,8 @@ describe('Listbox', () => {
 
             wrapper.setProps({ focusedValue: 'optionB' }).update();
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('focused')).toBe(false);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$focused')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$focused')).toBe(true);
         });
 
         test('focused option looses focus when the focusedValue prop is set to undefined', () => {
@@ -335,7 +335,7 @@ describe('Listbox', () => {
 
             wrapper.setProps({ focusedValue: undefined }).update();
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('focused')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$focused')).toBe(false);
         });
 
         test('focused option is not automatically selected when the focusedValue prop is changed', () => {
@@ -343,10 +343,10 @@ describe('Listbox', () => {
 
             wrapper.setProps({ focusedValue: 'optionB' }).update();
 
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('focused')).toBe(false);
-            expect(getByTestId(wrapper, 'listitem-optionA').prop('selected')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('focused')).toBe(true);
-            expect(getByTestId(wrapper, 'listitem-optionB').prop('selected')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$focused')).toBe(false);
+            expect(getByTestId(wrapper, 'listitem-optionA').prop('$selected')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$focused')).toBe(true);
+            expect(getByTestId(wrapper, 'listitem-optionB').prop('$selected')).toBe(false);
         });
     });
 

--- a/packages/react/src/components/listbox/listbox.test.tsx.snap
+++ b/packages/react/src/components/listbox/listbox.test.tsx.snap
@@ -244,7 +244,6 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
       data-testid="listitem-optionA"
       id="uuid1_optionA"
       role="option"
-      selected=""
     >
       <span
         aria-hidden="true"
@@ -300,7 +299,6 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
       data-testid="listitem-optionC"
       id="uuid1_optionC"
       role="option"
-      selected=""
     >
       <span
         aria-hidden="true"
@@ -325,7 +323,6 @@ exports[`Listbox Matches the snapshot (multiselect) 1`] = `
       aria-disabled="true"
       class="c11"
       data-testid="listitem-optionD"
-      disabled=""
       id="uuid1_optionD"
       role="option"
     >
@@ -538,7 +535,6 @@ exports[`Listbox Matches the snapshot 1`] = `
       data-testid="listitem-optionB"
       id="uuid1_optionB"
       role="option"
-      selected=""
     >
       <span
         class="c3"
@@ -562,7 +558,6 @@ exports[`Listbox Matches the snapshot 1`] = `
       aria-disabled="true"
       class="c6"
       data-testid="listitem-optionD"
-      disabled=""
       id="uuid1_optionD"
       role="option"
     >

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -83,10 +83,10 @@ interface ContainerProps {
 }
 
 interface ListItemProps {
-    disabled?: boolean;
-    isMobile: boolean;
-    selected: boolean;
-    focused: boolean;
+    $disabled?: boolean;
+    $isMobile: boolean;
+    $selected: boolean;
+    $focused: boolean;
 }
 
 const Container = styled.div<ContainerProps>`
@@ -142,30 +142,30 @@ const CustomCheckbox = styled.span<{ checked?: boolean, disabled?: boolean }>`
 
 const ListItem = styled.li<ListItemProps>`
     align-items: center;
-    color: ${({ disabled, theme }) => (disabled ? theme.greys['mid-grey'] : theme.greys.black)};
+    color: ${({ $disabled, theme }) => ($disabled ? theme.greys['mid-grey'] : theme.greys.black)};
     display: flex;
-    font-size: ${({ isMobile }) => (isMobile ? '1rem' : '0.875rem')};
-    font-weight: ${({ selected }) => (selected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
+    font-size: ${({ $isMobile }) => ($isMobile ? '1rem' : '0.875rem')};
+    font-weight: ${({ $selected }) => ($selected ? 'var(--font-semi-bold)' : 'var(--font-normal)')};
     line-height: var(--size-1halfx);
     min-height: var(--size-1halfx);
     padding: var(--spacing-half) var(--spacing-2x);
   
-    ${({ isMobile }) => (!isMobile && css`
+    ${({ $isMobile }) => (!$isMobile && css`
         padding-right: var(--spacing-1x);
     `)}
     
     user-select: none;
 
     &:hover {
-        background-color: ${({ theme, disabled }) => (disabled ? theme.greys.white : theme.greys.grey)};
+        background-color: ${({ theme, $disabled }) => ($disabled ? theme.greys.white : theme.greys.grey)};
     }
   
-    ${({ focused, disabled, theme }) => (focused && css`
-        outline: 2px solid ${disabled ? 'transparent' : theme.main['primary-1.1']};
+    ${({ $focused, $disabled, theme }) => ($focused && css`
+        outline: 2px solid ${$disabled ? 'transparent' : theme.main['primary-1.1']};
         outline-offset: -2px;
     `)}
 
-    ${({ selected }) => (selected && css`
+    ${({ $selected }) => ($selected && css`
         & ${CustomCheckbox} {
             background-color: ${({ theme }) => theme.main['primary-1.1']};
             border: 1px solid ${({ theme }) => theme.main['primary-1.1']};
@@ -178,10 +178,10 @@ const ListItemTextContainer = styled.span`
     flex-direction: column;
 `;
 
-const ListItemCaption = styled.span<{ disabled?: boolean, isMobile: boolean }>`
-    color: ${({ disabled, theme }) => (disabled ? theme.greys.grey : theme.greys['dark-grey'])};
+const ListItemCaption = styled.span<{ $disabled?: boolean, $isMobile: boolean }>`
+    color: ${({ $disabled, theme }) => ($disabled ? theme.greys.grey : theme.greys['dark-grey'])};
     display: block;
-    font-size: ${({ isMobile }) => (isMobile ? '0.875rem' : '0.75rem')};
+    font-size: ${({ $isMobile }) => ($isMobile ? '0.875rem' : '0.75rem')};
 `;
 
 const optionPredicate: (option: ListboxOption) => boolean = (option) => !option.disabled;
@@ -464,10 +464,10 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
                         aria-disabled={option.disabled}
                         aria-selected={multiselect && isOptionSelected(option) ? 'true' : undefined}
                         data-testid={sanitizeId(`listitem-${option.value}`)}
-                        disabled={option.disabled}
-                        focused={isOptionFocused(option)}
+                        $disabled={option.disabled}
+                        $focused={isOptionFocused(option)}
                         id={sanitizeId(`${id}_${option.value}`)}
-                        isMobile={isMobile}
+                        $isMobile={isMobile}
                         key={option.value}
                         onClick={handleListItemClick(option)}
                         onMouseDown={handleListItemMouseDown}
@@ -480,7 +480,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
                             }
                         }}
                         role="option"
-                        selected={isOptionSelected(option)}
+                        $selected={isOptionSelected(option)}
                     >
                         {multiselect ? (
                             <CustomCheckbox
@@ -495,8 +495,8 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
                             {option.label || option.value}
                             {option.caption && (
                                 <ListItemCaption
-                                    disabled={option.disabled}
-                                    isMobile={isMobile}
+                                    $disabled={option.disabled}
+                                    $isMobile={isMobile}
                                 >
                                     {option.caption}
                                 </ListItemCaption>


### PR DESCRIPTION
DS-1093

Marquer les props de styling comme transitives pour éviter qu'elles ne se retrouvent dans le DOM.