### PR TITLE
chore(datepicker): fix navigation buttons form submission

### DIFF
--- a/packages/react/src/components/date-picker/calendar-header.tsx
+++ b/packages/react/src/components/date-picker/calendar-header.tsx
@@ -79,6 +79,7 @@ export const CalendarHeader: VoidFunctionComponent<CalendarHeaderProps> = ({
                 disabled={prevMonthButtonDisabled}
                 buttonType="tertiary"
                 iconName="chevronLeft"
+                type="button"
             />
             <FlexContainer>
                 <DropdownListWrapper isMobile={isMobile} style={{ marginRight: '8px' }}>
@@ -111,6 +112,7 @@ export const CalendarHeader: VoidFunctionComponent<CalendarHeaderProps> = ({
                 disabled={nextMonthButtonDisabled}
                 buttonType="tertiary"
                 iconName="chevronRight"
+                type="button"
             />
         </Wrapper>
     );

--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -2981,7 +2981,7 @@ label + .c3 {
                     aria-label="Go to previous month"
                     class="c7 c8 c9"
                     data-testid="month-previous"
-                    type="submit"
+                    type="button"
                   >
                     <svg
                       aria-hidden="true"
@@ -3085,7 +3085,7 @@ label + .c3 {
                     class="c7 c8 c9"
                     data-testid="month-next"
                     disabled=""
-                    type="submit"
+                    type="button"
                   >
                     <svg
                       aria-hidden="true"
@@ -4274,7 +4274,7 @@ label + .c3 {
                     aria-label="Go to previous month"
                     class="c7 c8 c9"
                     data-testid="month-previous"
-                    type="submit"
+                    type="button"
                   >
                     <svg
                       aria-hidden="true"
@@ -4378,7 +4378,7 @@ label + .c3 {
                     class="c7 c8 c9"
                     data-testid="month-next"
                     disabled=""
-                    type="submit"
+                    type="button"
                   >
                     <svg
                       aria-hidden="true"
@@ -5539,7 +5539,7 @@ label + .c3 {
                       aria-label="Go to previous month"
                       class="c7 c8 c9"
                       data-testid="month-previous"
-                      type="submit"
+                      type="button"
                     >
                       <svg
                         aria-hidden="true"
@@ -5643,7 +5643,7 @@ label + .c3 {
                       class="c7 c8 c9"
                       data-testid="month-next"
                       disabled=""
-                      type="submit"
+                      type="button"
                     >
                       <svg
                         aria-hidden="true"

--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -547,6 +547,7 @@ export const Datepicker = forwardRef(({
                         selected={selectedDate}
                         showPopperArrow={false}
                         startOpen={startOpen}
+                        required={required}
                         valid={valid}
                         withPortal={isMobile}
                         {...props /* eslint-disable-line react/jsx-props-no-spreading */}


### PR DESCRIPTION
[DS-802](https://equisoft.atlassian.net/browse/DS-802)

## Description
Ici on vient update les boutons de month navigation dans le calendar du datepicker pour qu’ils ne trigger pas de form submission. J'en ai profité pour ajouter la prop `required` qui m'a également premis de tester le comportement désiré.

## Tests fonctionnels
- [ ] Valider le bon fonctionnement des month navigation buttons et qu'ils ne trigger plus de form submission

[DS-802]: https://equisoft.atlassian.net/browse/DS-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ