### PR TITLE
fix(dropdown-list): prevents error when explicit value is not in options

### DIFF
--- a/packages/react/src/components/dropdown-list/dropdown-list.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.tsx
@@ -516,7 +516,7 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps<boolean | und
                 <input type="hidden" name={name} value={getValues()} data-testid="input" />
                 {multiselect
                     ? <TagWrapper data-testid="tag-wrapper">{renderSelectedOptionsTags()}</TagWrapper>
-                    : <TextWrapper>{selectedOptions?.[0].label ?? ''}</TextWrapper>}
+                    : <TextWrapper>{selectedOptions?.[0]?.label ?? ''}</TextWrapper>}
                 <Arrow
                     aria-hidden="true"
                     data-testid="arrow"

--- a/packages/react/src/components/dropdown-list/dropdown-list.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.tsx
@@ -469,6 +469,8 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps<boolean | und
         ],
     );
 
+    const firstSelectedOption = selectedOptions?.[0];
+
     return (
         <StyledFieldContainer
             className={className}
@@ -516,7 +518,7 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps<boolean | und
                 <input type="hidden" name={name} value={getValues()} data-testid="input" />
                 {multiselect
                     ? <TagWrapper data-testid="tag-wrapper">{renderSelectedOptionsTags()}</TagWrapper>
-                    : <TextWrapper>{selectedOptions?.[0]?.label ?? ''}</TextWrapper>}
+                    : <TextWrapper>{firstSelectedOption?.label ?? ''}</TextWrapper>}
                 <Arrow
                     aria-hidden="true"
                     data-testid="arrow"


### PR DESCRIPTION
https://equisoft.atlassian.net/browse/DS-1158

Lors de l'implémentation du `dropdown-list` dans le CRM, on a trouvé un bug qui fait planter le component si la valeur de la prop `value` n'est pas comprise dans l'array d'options. 

Normalement, il devrait simplement afficher aucune option, et non planter.

Facilement reproductible dans le Storybook:

```
export const WithoutSelectedOptions: Story = () => (
    <DropdownList
        data-testid="blip-bloop"
        options={[]}
        value={'test'}
    />
);
```