### PR TITLE
fix(storybook): add explicitly docs container to fix defective 'show code' button

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import { DesignSystem, injectMainCss } from '@equisoft/design-elements-react';
 import { Decorator, Preview } from '@storybook/react';
+import { DocsContainer } from "@storybook/blocks";
 
 injectMainCss();
 
@@ -20,6 +21,11 @@ const preview: Preview = {
             sort: 'alpha',
         },
         docs: {
+            /*
+             * The default container is set explicitly to prevent a bug that causes the "Show code/Hide code"
+             * button of stories in the .mdx file to do nothing. It can be removed once the bug is fixed.
+             */
+            container: DocsContainer,
             source: {
                 type: 'dynamic',
                 excludeDecorators: true,


### PR DESCRIPTION
## Contexte

J'ai remarqué que le bouton "Show code/Hide code" ne fonctionne plus actuellement dans storybook pour certaines stories.
![Screen Recording 2024-06-12 at 10 56 56 AM](https://github.com/kronostechnologies/design-elements/assets/106986557/6ebdbca8-e4f6-46ca-9038-e45c2d81624e)

En comparant avec [la PR de migration de storybook v8](https://github.com/kronostechnologies/design-elements/pull/882), je me suis rendu compte que rajouter `DocsContainer` explicitement fixait le problème.
J'ai fait quelques tests et je n'ai pas vu d'autres impacts. 

## Note
Dans cette issue sur storybook, on pointe que la problématique serait spécifique aux stories dans des `.mdx`. 
J'ai testé le repos fournit et ça semble effectivement être le cas. 
https://github.com/storybookjs/storybook/issues/26505