### PR TITLE
fix: allow secondary action in alert banner

### DIFF
--- a/packages/react/src/components/global-banner/global-banner.tsx
+++ b/packages/react/src/components/global-banner/global-banner.tsx
@@ -218,7 +218,7 @@ export const GlobalBanner = forwardRef(({
                         </ActionButton>
                     )}
 
-                    {secondaryActionButton && type !== 'alert' && (
+                    {secondaryActionButton && (
                         <StyledButton
                             data-testid="secondary-action-button"
                             buttonType="tertiary"


### PR DESCRIPTION
DS-1189

Permettre un bouton d'action secondaire même dans les bannières de type 'alerte'.