### PR TITLE
fix(Pagination): change span for div

### DIFF
--- a/packages/react/src/components/pagination/pagination.test.tsx.snap
+++ b/packages/react/src/components/pagination/pagination.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
     aria-labelledby="uuid1"
     class="c1"
   >
-    <span
+    <div
       aria-live="off"
       role="status"
     >
@@ -89,7 +89,7 @@ exports[`Pagination Matches the desktop snapshot 1`] = `
           0–0 of 0 results
         </span>
       </h3>
-    </span>
+    </div>
     <ol
       class="c5"
     />
@@ -165,7 +165,7 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
     aria-labelledby="uuid1"
     class="c1"
   >
-    <span
+    <div
       aria-live="off"
       role="status"
     >
@@ -186,7 +186,7 @@ exports[`Pagination Matches the desktop snapshot with multiples digits page numb
           0–0 of 0 results
         </span>
       </h3>
-    </span>
+    </div>
     <ol
       class="c5"
     />
@@ -262,7 +262,7 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
     aria-labelledby="uuid1"
     class="c1"
   >
-    <span
+    <div
       aria-live="off"
       role="status"
     >
@@ -283,7 +283,7 @@ exports[`Pagination Matches the mobile snapshot 1`] = `
           0–0 of 0 results
         </span>
       </h3>
-    </span>
+    </div>
     <ol
       class="c5"
     />
@@ -359,7 +359,7 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
     aria-labelledby="uuid1"
     class="c1"
   >
-    <span
+    <div
       aria-live="off"
       role="status"
     >
@@ -380,7 +380,7 @@ exports[`Pagination Matches the mobile snapshot with multiples digits page numbe
           0–0 of 0 results
         </span>
       </h3>
-    </span>
+    </div>
     <ol
       class="c5"
     />

--- a/packages/react/src/components/pagination/pagination.tsx
+++ b/packages/react/src/components/pagination/pagination.tsx
@@ -204,7 +204,7 @@ export const Pagination: VoidFunctionComponent<PaginationProps> = ({
     return (
         <Container className={className} isMobile={isMobile}>
             <Navigation aria-labelledby={ariaLabelledby}>
-                <span aria-live='off' role='status'>
+                <div aria-live='off' role='status'>
                     <CurrentPageLabelHeading id={headingId} data-testid="currentPageLabelHeading">
                         <ResultsLabel isMobile={isMobile} data-testid="resultsLabel">
                             <ScreenReaderOnlyText label={`${t('pagination')} - `} />
@@ -215,7 +215,7 @@ export const Pagination: VoidFunctionComponent<PaginationProps> = ({
                             })}
                         </ResultsLabel>
                     </CurrentPageLabelHeading>
-                </span>
+                </div>
                 {forwardBackwardNavActive && (
                     <NavButton
                         data-testid="previousPageButton"


### PR DESCRIPTION
Remplacer le `span` par un `div` vient fixer une failure de validation HTML:
`Element [h3] not allowed as child of element [span] in this context.`