### PR TITLE
fix(RadioButton): not centered when zoomed

### DIFF
--- a/packages/react/src/components/radio-button/radio-button.test.tsx.snap
+++ b/packages/react/src/components/radio-button/radio-button.test.tsx.snap
@@ -65,7 +65,6 @@ exports[`Radio button matches snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
-  margin-top: var(--spacing-1x);
   position: relative;
 }
 

--- a/packages/react/src/components/radio-button/radio-button.test.tsx.snap
+++ b/packages/react/src/components/radio-button/radio-button.test.tsx.snap
@@ -33,21 +33,9 @@ exports[`Radio button matches snapshot 1`] = `
 
 .c1:checked {
   border: 2px solid #006296;
-}
-
-.c1:checked::after {
-  background-color: #006296;
-  border-radius: 50%;
-  content: '';
-  display: block;
-  height: var(--size-half);
-  left: 50%;
-  position: absolute;
-  top: 50%;
-  -webkit-transform: translate(-50%,-50%);
-  -ms-transform: translate(-50%,-50%);
-  transform: translate(-50%,-50%);
-  width: var(--size-half);
+  background-image: url('data:image/svg+xml;utf8,%0A%20%20%20%20%20%20%20%20%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Ccircle%20cx%3D%228%22%20cy%3D%228%22%20r%3D%224%22%20fill%3D%22%23006296%22%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fsvg%3E');
+  background-position: center;
+  background-repeat: no-repeat;
 }
 
 .c1:disabled + label {

--- a/packages/react/src/components/radio-button/radio-button.test.tsx.snap
+++ b/packages/react/src/components/radio-button/radio-button.test.tsx.snap
@@ -32,10 +32,10 @@ exports[`Radio button matches snapshot 1`] = `
 }
 
 .c1:checked {
-  border: 2px solid #006296;
   background-image: url('data:image/svg+xml;utf8,%0A%20%20%20%20%20%20%20%20%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%3Ccircle%20cx%3D%228%22%20cy%3D%228%22%20r%3D%224%22%20fill%3D%22%23006296%22%2F%3E%0A%20%20%20%20%20%20%20%20%3C%2Fsvg%3E');
   background-position: center;
   background-repeat: no-repeat;
+  border: 2px solid #006296;
 }
 
 .c1:disabled + label {

--- a/packages/react/src/components/radio-button/radio-button.tsx
+++ b/packages/react/src/components/radio-button/radio-button.tsx
@@ -28,10 +28,10 @@ const StyledInput = styled.input<{ disabled?: boolean }>`
     ${(theme) => focus(theme, { selector: '+' })}
      
     &:checked {
-        border: 2px solid ${({ theme, disabled }) => (disabled ? theme.component['radio-button-disabled-border-color'] : theme.component['radio-button-checked-border-color'])};
         background-image: ${({ theme, disabled }) => getDotSvgDataUrl(disabled ? theme.component['radio-button-disabled-checked-dot-color'] : theme.component['radio-button-checked-dot-color'])};
         background-position: center;
         background-repeat: no-repeat;
+        border: 2px solid ${({ theme, disabled }) => (disabled ? theme.component['radio-button-disabled-border-color'] : theme.component['radio-button-checked-border-color'])};
     }
     
     &:disabled {

--- a/packages/react/src/components/radio-button/radio-button.tsx
+++ b/packages/react/src/components/radio-button/radio-button.tsx
@@ -60,7 +60,6 @@ const StyledLabel = styled.label`
 const StyledContainer = styled.div`
     align-items: flex-start;
     display: inline-flex;
-    margin-top: var(--spacing-1x);
     position: relative;
 `;
 

--- a/packages/react/src/components/radio-button/radio-button.tsx
+++ b/packages/react/src/components/radio-button/radio-button.tsx
@@ -3,6 +3,14 @@ import styled from 'styled-components';
 import { focus } from '../../utils/css-state';
 import { useId } from '../../hooks/use-id';
 
+const getDotSvgDataUrl = (color: string): string => {
+    const svg = `
+        <svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="8" cy="8" r="4" fill="${color}"/>
+        </svg>`;
+    return `url('data:image/svg+xml;utf8,${encodeURIComponent(svg)}')`;
+};
+
 const StyledInput = styled.input<{ disabled?: boolean }>`
     appearance: none;
     background-color: ${({ theme, disabled }) => (disabled ? theme.component['radio-button-disabled-background-color'] : theme.component['radio-button-background-color'])};
@@ -21,18 +29,9 @@ const StyledInput = styled.input<{ disabled?: boolean }>`
      
     &:checked {
         border: 2px solid ${({ theme, disabled }) => (disabled ? theme.component['radio-button-disabled-border-color'] : theme.component['radio-button-checked-border-color'])};
-        &::after {
-            background-color: ${({ theme, disabled }) => (disabled ? theme.component['radio-button-disabled-border-color'] : theme.component['radio-button-checked-background-color'])};
-            border-radius: 50%;
-            content: '';
-            display: block;
-            height: var(--size-half);
-            left: 50%;
-            position: absolute;
-            top: 50%;
-            transform: translate(-50%, -50%);
-            width: var(--size-half);
-        }
+        background-image: ${({ theme, disabled }) => getDotSvgDataUrl(disabled ? theme.component['radio-button-disabled-checked-dot-color'] : theme.component['radio-button-checked-dot-color'])};
+        background-position: center;
+        background-repeat: no-repeat;
     }
     
     &:disabled {

--- a/packages/react/src/themes/tokens/component/radio-button-group-tokens.ts
+++ b/packages/react/src/themes/tokens/component/radio-button-group-tokens.ts
@@ -11,7 +11,9 @@ export type RadioButtonGroupTokens =
     | 'radio-button-disabled-border-color'
     | 'radio-button-hover-border-color'
     | 'radio-button-disabled-hover-border-color'
-    | 'radio-button-disabled-label-color';
+    | 'radio-button-disabled-label-color'
+    | 'radio-button-checked-dot-color'
+    | 'radio-button-disabled-checked-dot-color';
 
 export type RadioButtonGroupTokenValue = AliasTokens | RefTokens;
 
@@ -32,4 +34,7 @@ export const defaultRadioButtonGroupTokens: RadioButtonGroupTokenMap = {
 
     'radio-button-checked-background-color': 'color-control-background-checked',
     'radio-button-checked-border-color': 'color-control-border-checked',
+
+    'radio-button-checked-dot-color': 'color-control-background-checked',
+    'radio-button-disabled-checked-dot-color': 'color-control-auxiliary-disabled',
 };


### PR DESCRIPTION
Quand on zoomait à 110%, le dot du radio button ne gardait pas ses proportions, il devenait un peu ovale, et il était décalé du centre.
J'ai remplacer le CSS qui formait le dot par un svg.

Avant:
<img width="28" alt="Screenshot 2024-08-06 at 3 05 50 PM" src="https://github.com/user-attachments/assets/b028eadc-06d5-494f-9243-a0e4fb7f4560">

Après:
<img width="27" alt="Screenshot 2024-08-06 at 3 06 23 PM" src="https://github.com/user-attachments/assets/7dadae70-c4c1-4e3d-aff3-9592743ceaa4">

J'ai également enlever un margin-top sur le container qui ne servait à rien