### PR TITLE
fix(Modal): icon add ariaHidden

### DIFF
--- a/packages/react/src/components/modal/modal-dialog.tsx
+++ b/packages/react/src/components/modal/modal-dialog.tsx
@@ -127,7 +127,7 @@ export const ModalDialog: VoidFunctionComponent<ModalDialogProps> = ({
             <>
                 <HeadingWrapperComponent>
                     {titleIconName && (
-                        <TitleIcon name={titleIconName} size="24" data-testid="title-icon" />
+                        <TitleIcon name={titleIconName} size="24" data-testid="title-icon" aria-hidden="true" />
                     )}
                     <Heading
                         id={titleId}


### PR DESCRIPTION
Quick fix qui ajoute un attribut d'a11y `aria-hidden="true"` sur l'icône qui se trouve devant le heading.