### PR TITLE
fix(DatePicker): When entering a date without separators, valid date should call onChange

### DIFF
--- a/packages/react/src/components/date-picker/date-picker.tsx
+++ b/packages/react/src/components/date-picker/date-picker.tsx
@@ -502,9 +502,9 @@ export const Datepicker = forwardRef(({
         const numericalFormat = getNumericalDateFormat(dateFormat);
         if (numericalFormat && /^\d+$/.test(value) && value.length === numericalFormat.length) {
             const date = parse(value, numericalFormat, new Date());
-            setSelectedDate(date);
+            handleInputChange(date);
         }
-    }, [dateFormat]);
+    }, [dateFormat, handleInputChange]);
 
     return (
         <>


### PR DESCRIPTION
DS-1205

**Description**

Après avoir _parsé_ la valeur entrée sans séparateurs, c'était seulement le "selectedDate" (la valeur sélectionné lorsqu'on ouvre le calendrier) et le onChange n'était jamais appelé.
Donc, aucune manière pour le parent du DatePicker de connaitre la date finale.