### PR TITLE
fix(Spinner): replace svg

### DIFF
--- a/packages/react/src/components/icon/icon.tsx
+++ b/packages/react/src/components/icon/icon.tsx
@@ -58,7 +58,6 @@ import Equisoft from '../../logos/logo-equisoft-ico.svg';
 import CaretDown from '../../icons/caret-down.svg';
 import CaretRight from '../../icons/caret-right.svg';
 import Unlink from '../../icons/unlink.svg';
-import Enso from '../../icons/enso.svg';
 
 const iconMapping = {
     alertCircle: AlertCircle,
@@ -91,7 +90,6 @@ const iconMapping = {
     externalLink: ExternalLink,
     eye: Eye,
     eyeOff: EyeOff,
-    enso: Enso,
     files: Files,
     helpCircle: HelpCircle,
     history: History,

--- a/packages/react/src/components/icon/icon.tsx
+++ b/packages/react/src/components/icon/icon.tsx
@@ -58,6 +58,7 @@ import Equisoft from '../../logos/logo-equisoft-ico.svg';
 import CaretDown from '../../icons/caret-down.svg';
 import CaretRight from '../../icons/caret-right.svg';
 import Unlink from '../../icons/unlink.svg';
+import Enso from '../../icons/enso.svg';
 
 const iconMapping = {
     alertCircle: AlertCircle,
@@ -90,6 +91,7 @@ const iconMapping = {
     externalLink: ExternalLink,
     eye: Eye,
     eyeOff: EyeOff,
+    enso: Enso,
     files: Files,
     helpCircle: HelpCircle,
     history: History,

--- a/packages/react/src/components/spinner/spinner.test.tsx.snap
+++ b/packages/react/src/components/spinner/spinner.test.tsx.snap
@@ -2,13 +2,9 @@
 
 exports[`Spinner Matches the snapshot 1`] = `
 .c0 {
-  -webkit-animation: roll 1s infinite;
-  animation: roll 1s infinite;
-  -webkit-animation-timing-function: linear;
-  animation-timing-function: linear;
-  fill: #006296;
+  color: #006296;
   height: 80px;
-  width: 83px;
+  width: 80px;
 }
 
 <svg

--- a/packages/react/src/components/spinner/spinner.tsx
+++ b/packages/react/src/components/spinner/spinner.tsx
@@ -2,16 +2,9 @@ import styled from 'styled-components';
 import Enso from '../../icons/enso.svg';
 
 const Spinner = styled(Enso)`
-    animation: roll 1s infinite;
-    animation-timing-function: linear;
-    fill: ${(props) => props.theme.component['spinner-fill-color']};
+    color: ${(props) => props.theme.component['spinner-fill-color']};
     height: 80px;
-    width: 83px;
-
-    @keyframes roll {
-        from { transform: rotate(0deg); }
-        to { transform: rotate(360deg); }
-    }
+    width: 80px;
 `;
 
 export { Spinner };

--- a/packages/react/src/icons/enso.svg
+++ b/packages/react/src/icons/enso.svg
@@ -1,13 +1,11 @@
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
-     viewBox="0 0 496.1 480.1" style="enable-background:new 0 0 496.1 480.1;" xml:space="preserve">
-<path d="M496.1,248.1c-0.6-33.4-7.9-66.8-21.3-97.2c-13.4-30.5-32.7-58.1-56.5-81C394.5,47,366.3,29,335.8,17
-	c-30.5-12-63.3-17.7-95.7-17c-32.4,0.6-64.7,7.7-94.2,20.7c-29.5,12.9-56.3,31.7-78.4,54.8c-22.1,23-39.6,50.4-51.1,79.9
-	C4.9,185-0.6,216.7,0.1,248.1c0.6,31.4,7.5,62.6,20.1,91.1c12.5,28.5,30.7,54.4,53.1,75.8c22.3,21.4,48.7,38.3,77.3,49.4
-	c28.6,11.2,59.2,16.5,89.6,15.8c30.4-0.6,60.5-7.3,88-19.5c27.6-12.1,52.6-29.7,73.2-51.3c20.6-21.6,36.9-47.1,47.6-74.7
-	c6.5-16.7,10.9-34.2,13.3-51.9c0.6,0,1.2,0.1,1.9,0.1c17.7,0,32-14.3,32-32c0-0.9,0-1.8-0.1-2.7L496.1,248.1L496.1,248.1z
-	 M445.2,333c-11.7,26.6-28.7,50.7-49.6,70.6c-20.8,19.9-45.5,35.6-72.1,45.9c-26.6,10.3-55.1,15.2-83.4,14.5
-	c-28.3-0.6-56.3-6.9-81.9-18.2c-25.6-11.3-48.8-27.7-68-47.9C71,377.9,55.9,354.1,46,328.4c-9.9-25.6-14.6-53.1-13.9-80.4
-	c0.7-27.3,6.7-54.2,17.6-78.8c10.9-24.6,26.7-47,46.1-65.4c19.4-18.4,42.3-32.9,66.9-42.4c24.7-9.5,51.1-14,77.3-13.3
-	c26.3,0.7,52.1,6.5,75.8,17c23.7,10.5,45.1,25.8,62.8,44.4c17.7,18.6,31.6,40.6,40.7,64.3c9.1,23.7,13.4,49,12.7,74.2h0.1
-	c-0.1,0.9-0.1,1.8-0.1,2.7c0,16.5,12.5,30.1,28.5,31.8C457.5,299.9,452.3,316.9,445.2,333L445.2,333z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" width="16" height="16">
+    <radialGradient id="a4" cx=".66" fx=".66" cy=".3125" fy=".3125" gradientTransform="scale(1.5)">
+      <stop offset="0" stop-color="currentColor" stop-opacity="0"></stop>
+      <stop offset="0.5" stop-color="currentColor" stop-opacity="0.3"></stop>
+      <stop offset="1" stop-color="currentColor"></stop>
+    </radialGradient>
+  <circle transform-origin="center" fill="none" stroke="url(#a4)" stroke-width="20" stroke-linecap="round" stroke-dasharray="220 220" stroke-dashoffset="0" cx="100" cy="100" r="70">
+    <animateTransform type="rotate" attributeName="transform" calcMode="spline" dur="1s" values="0;360" keyTimes="0;1" keySplines="0 0 1 1" repeatCount="indefinite"></animateTransform>
+  </circle>
+  <circle transform-origin="center" fill="none" opacity=".2" stroke="currentColor" stroke-width="20" stroke-linecap="round" cx="100" cy="100" r="70"></circle>
 </svg>


### PR DESCRIPTION
Remplacer le `svg` pour le nouveau visuel + bouger l'animation dans le `svg` au lieu de le faire dans le CSS.
**Avant:**
<img width="104" alt="Screenshot 2024-09-03 at 1 38 28 PM" src="https://github.com/user-attachments/assets/d420bf04-59fd-45bb-96e9-b7cdebcfa9fd">
**Après:**
<img width="83" alt="Screenshot 2024-09-03 at 1 38 51 PM" src="https://github.com/user-attachments/assets/0f523812-2bb4-468c-b567-abccd6f03fa6">
