### PR TITLE
fix(MoneyInput): update styling and behavior

### DIFF
--- a/packages/react/src/components/money-input/money-input.test.tsx.snap
+++ b/packages/react/src/components/money-input/money-input.test.tsx.snap
@@ -131,7 +131,6 @@ exports[`CurrencyInput Component matches snapshot (en-CA) 1`] = `
         data-testid="text-input"
         id="uuid1"
         inputmode="numeric"
-        placeholder="$"
         type="text"
         value="$100.00"
       />
@@ -271,7 +270,6 @@ exports[`CurrencyInput Component matches snapshot (en-US) 1`] = `
         data-testid="text-input"
         id="uuid1"
         inputmode="numeric"
-        placeholder="$"
         type="text"
         value="$100.00"
       />
@@ -392,7 +390,7 @@ exports[`CurrencyInput Component matches snapshot (fr-CA) 1`] = `
 }
 
 .c0 input {
-  text-align: right;
+  text-align: left;
   width: 132px;
 }
 
@@ -411,7 +409,6 @@ exports[`CurrencyInput Component matches snapshot (fr-CA) 1`] = `
         data-testid="text-input"
         id="uuid1"
         inputmode="numeric"
-        placeholder="$"
         type="text"
         value="100,00 $"
       />

--- a/packages/react/src/components/money-input/money-input.tsx
+++ b/packages/react/src/components/money-input/money-input.tsx
@@ -5,11 +5,11 @@ import { useTranslation } from '../../i18n/use-translation';
 import { formatCurrency } from '../../utils/currency';
 import { TextInput } from '../text-input/text-input';
 
-type Language = 'en' | 'fr';
+type TextAlignment = 'left' | 'right';
 
-const InputWrapper = styled.div<{ language: Language }>`
+const InputWrapper = styled.div<{ $textAlignment: TextAlignment }>`
     input {
-        text-align: ${({ language }) => (language === 'en' ? 'left' : 'right')};
+        text-align: ${({ $textAlignment }) => $textAlignment};
         width: 132px;
     }
 `;
@@ -50,6 +50,8 @@ interface Props {
      */
     precision?: number;
     hint?: string;
+    noMargin?: boolean;
+    textAlignment?: TextAlignment;
 
     onChange?(value: number | null, formattedValue: string): void;
 }
@@ -76,11 +78,12 @@ export const MoneyInput: VoidFunctionComponent<Props> = ({
     locale = 'fr-CA',
     currency = 'CAD',
     hint,
+    noMargin,
+    textAlignment = 'left',
     ...otherProps
 }) => {
     const { t } = useTranslation('money-input');
     const inputElement = useRef<HTMLInputElement>(null);
-    const language: Language = locale.split('-')[0] as Language;
     const [displayValue, setDisplayValue] = useState(safeFormatCurrency(value, precision, locale, currency));
     const [maskedValue, setMaskedValue] = useState(safeFormatCurrency(value, precision, locale, currency));
     const [hasFocus, setHasFocus] = useState<boolean>(false);
@@ -140,7 +143,7 @@ export const MoneyInput: VoidFunctionComponent<Props> = ({
     }, []);
 
     return (
-        <InputWrapper language={language}>
+        <InputWrapper $textAlignment={textAlignment}>
             <TextInput
                 className={className}
                 required={required}
@@ -150,12 +153,12 @@ export const MoneyInput: VoidFunctionComponent<Props> = ({
                 inputMode="numeric"
                 value={displayValue}
                 label={label}
-                placeholder="$"
                 onChange={handleChangeEvent}
                 onBlur={handleBlurEvent}
                 onFocus={handleFocusEvent}
                 validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
                 hint={hint}
+                noMargin={noMargin}
                 {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
             />
         </InputWrapper>


### PR DESCRIPTION
[DS-710](https://equisoft.atlassian.net/browse/DS-710)

## Description
Ici on vient faire quelques ajustements à notre composante `MoneyInput`
- Retrait du placeholder
- Alignement du texte à gauche par défaut
- Ajout d'une propriété permettant de modifier l'alignement du texte
- Exposition de la propriété `noMargin` du `FieldContainer`

Voici un warning soulevé par le DOM Validator:
```
Warning: The inputmode attribute is not supported in all browsers. Please be sure to test, and consider using a polyfill.
[From line 1, column 382; to line 1, column 588](https://validator.w3.org/nu/#l1c588)
...<input aria-describedby="430c793c-a80a-4ee2-1009-c2ec277e3722_hint" data-testid="some-data-testid" i…793c-a80a-4ee2-1009-c2ec277e3722" inputmode="numeric" type="text" class="sc-fecduv biaUDu" value="">...
```

## Tests fonctionnels
- [ ] Valider le bon fonctionnement de la composante et du respect des critères d'acceptations de ces ajustements

[DS-710]: https://equisoft.atlassian.net/browse/DS-710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ