### PR TITLE
fix(Token): replace visited color

### DIFF
--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
 }
 
 .c18:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c18 {
@@ -220,7 +220,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
 }
 
 .c19:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c22 {
@@ -260,13 +260,13 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
 }
 
 .c21:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c21:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c21[disabled] {
@@ -960,7 +960,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
 }
 
 .c18:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c18 {
@@ -1040,7 +1040,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
 }
 
 .c19:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c22 {
@@ -1080,13 +1080,13 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
 }
 
 .c21:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c21:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c21[disabled] {
@@ -1692,7 +1692,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
 }
 
 .c18:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c18 {
@@ -1772,7 +1772,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
 }
 
 .c19:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c22 {
@@ -1812,13 +1812,13 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
 }
 
 .c21:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c21:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c21[disabled] {

--- a/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
+++ b/packages/react/src/components/breadcrumb/breadcrumb.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
 }
 
 .c2:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c2 {
@@ -55,7 +55,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
 }
 
 .c3:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3[disabled] {
@@ -206,7 +206,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
 }
 
 .c2:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c2 {
@@ -227,7 +227,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (Three or more entries) 1`] = `
 }
 
 .c3:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3[disabled] {
@@ -437,7 +437,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
 }
 
 .c2:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c2 {
@@ -458,7 +458,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
 }
 
 .c3:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3[disabled] {
@@ -591,7 +591,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
 }
 
 .c2:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c2 {
@@ -612,7 +612,7 @@ exports[`Breadcrumb Snapshots Matches snapshot (double entries) 1`] = `
 }
 
 .c3:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3[disabled] {

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c13:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c13 {
@@ -191,7 +191,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c14:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c16 {
@@ -231,13 +231,13 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c15:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c15:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c15[disabled] {
@@ -774,7 +774,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c13:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c13 {
@@ -854,7 +854,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c14:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c16 {
@@ -894,13 +894,13 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
 }
 
 .c15:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c15:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c15[disabled] {

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`DropdownMenu Is hidden 1`] = `
 }
 
 .c6:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c6 {
@@ -86,7 +86,7 @@ exports[`DropdownMenu Is hidden 1`] = `
 }
 
 .c7:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c9 {
@@ -126,13 +126,13 @@ exports[`DropdownMenu Is hidden 1`] = `
 }
 
 .c8:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c8:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c8[disabled] {
@@ -445,7 +445,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 }
 
 .c6:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c6 {
@@ -496,7 +496,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 }
 
 .c7:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c9 {
@@ -536,13 +536,13 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
 }
 
 .c8:visited {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c8:visited svg {
-  color: #602FA0;
-  fill: #602FA0;
+  color: #006296;
+  fill: #006296;
 }
 
 .c8[disabled] {

--- a/packages/react/src/components/error-summary/error-summary.test.tsx.snap
+++ b/packages/react/src/components/error-summary/error-summary.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ErrorSummary matches the snapshot 1`] = `
 }
 
 .c9:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c9 {

--- a/packages/react/src/components/external-link/external-link.test.tsx.snap
+++ b/packages/react/src/components/external-link/external-link.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`External Link matches snapshot (disabled) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c2 {
@@ -129,7 +129,7 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -187,7 +187,7 @@ exports[`External Link matches snapshot (label and icon) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3 {
@@ -257,7 +257,7 @@ exports[`External Link matches snapshot (only icon) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -315,7 +315,7 @@ exports[`External Link matches snapshot (only icon) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3 {
@@ -383,7 +383,7 @@ exports[`External Link matches snapshot (without href) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -441,7 +441,7 @@ exports[`External Link matches snapshot (without href) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c3 {
@@ -511,7 +511,7 @@ exports[`External Link matches snapshot 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -562,7 +562,7 @@ exports[`External Link matches snapshot 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c2 {

--- a/packages/react/src/components/link/link.test.tsx.snap
+++ b/packages/react/src/components/link/link.test.tsx.snap
@@ -38,12 +38,12 @@ exports[`Link Component Styling matches NavLink snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],
@@ -175,12 +175,12 @@ exports[`Link Component Styling matches RouteLink snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],
@@ -408,12 +408,12 @@ exports[`Link Component Styling matches default snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],
@@ -508,12 +508,12 @@ exports[`Link Component Styling matches disabled snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],
@@ -613,12 +613,12 @@ exports[`Link Component Styling matches external link snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],
@@ -716,12 +716,12 @@ exports[`Link Component Styling matches icon and label snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],
@@ -837,12 +837,12 @@ exports[`Link Component Styling matches icon only snapshot 1`] = `
 
 .c1[visited],
 .c1:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[visited] svg,
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[hover],
@@ -1101,12 +1101,12 @@ exports[`Link Component Styling matches with children snapshot 1`] = `
 
 .c0[visited],
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[visited] svg,
 .c0:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0[hover],

--- a/packages/react/src/components/route-link/route-link.test.tsx.snap
+++ b/packages/react/src/components/route-link/route-link.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -96,7 +96,7 @@ exports[`Route Link matches snapshot (Link | label and icon) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[disabled] {
@@ -143,7 +143,7 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -164,7 +164,7 @@ exports[`Route Link matches snapshot (Link | only icon) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[disabled] {
@@ -210,7 +210,7 @@ exports[`Route Link matches snapshot (Link) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -231,7 +231,7 @@ exports[`Route Link matches snapshot (Link) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[disabled] {
@@ -322,7 +322,7 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -343,7 +343,7 @@ exports[`Route Link matches snapshot (NavLink | label and icon) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[disabled] {
@@ -390,7 +390,7 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -411,7 +411,7 @@ exports[`Route Link matches snapshot (NavLink | only icon) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[disabled] {
@@ -457,7 +457,7 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
 }
 
 .c0:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c0 {
@@ -478,7 +478,7 @@ exports[`Route Link matches snapshot (NavLink) 1`] = `
 }
 
 .c1:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c1[disabled] {

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c19:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c19 {
@@ -221,7 +221,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
 }
 
 .c20:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c22 {
@@ -862,7 +862,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
 }
 
 .c19:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c19 {
@@ -913,7 +913,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
 }
 
 .c20:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c22 {
@@ -1552,7 +1552,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 }
 
 .c18:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c18 {
@@ -1603,7 +1603,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
 }
 
 .c19:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c21 {
@@ -2243,7 +2243,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
 }
 
 .c19:visited {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c19 {
@@ -2294,7 +2294,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
 }
 
 .c20:visited svg {
-  color: #602FA0;
+  color: #006296;
 }
 
 .c22 {

--- a/packages/react/src/themes/tokens/alias-tokens.ts
+++ b/packages/react/src/themes/tokens/alias-tokens.ts
@@ -429,7 +429,7 @@ export const defaultAliasTokens: AliasTokenMap = {
     'color-link-content': 'color-informative-50',
     'color-link-content-disabled': 'color-informative-20',
     'color-link-content-hover': 'color-informative-70',
-    'color-link-content-visited': 'color-discovery-50',
+    'color-link-content-visited': 'color-informative-50',
 
     /**
      * BOX-SHADOW


### PR DESCRIPTION
Actuellement, l'état visited des Link conserve une couleur différente de l'état par défaut. Cela cause des problèmes visuels car l'application ne vide pas l'historique de navigation, et les liens déjà visités restent dans cet état même lorsque l'utilisateur revient à une nouvelle session. Nous avons décidé de garder le même style pour l'état visited que celui par défaut.
https://equisoft.atlassian.net/browse/DS-1240