### PR TITLE
fix(Checkbox): prevent input compression with long text by adding flex-shrink

### DIFF
--- a/packages/react/src/components/checkbox-group/checkbox-group.test.tsx.snap
+++ b/packages/react/src/components/checkbox-group/checkbox-group.test.tsx.snap
@@ -33,17 +33,17 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c3 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-1x);
   left: 0;
-  margin-right: var(--spacing-1x);
+  margin: var(--spacing-half) var(--spacing-1x);
   position: relative;
   width: var(--size-1x);
 }
@@ -90,10 +90,10 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -159,17 +159,17 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c3 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-1x);
   left: 0;
-  margin-right: var(--spacing-1x);
+  margin: var(--spacing-half) var(--spacing-1x);
   position: relative;
   width: var(--size-1x);
 }
@@ -216,10 +216,10 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -286,17 +286,17 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c3 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   background-color: #F1F2F2;
   border: 1px solid #B7BBC2;
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-1x);
   left: 0;
-  margin-right: var(--spacing-1x);
+  margin: var(--spacing-half) var(--spacing-1x);
   position: relative;
   width: var(--size-1x);
 }
@@ -343,10 +343,10 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -415,17 +415,17 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c3 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-1x);
   left: 0;
-  margin-right: var(--spacing-1x);
+  margin: var(--spacing-half) var(--spacing-1x);
   position: relative;
   width: var(--size-1x);
 }
@@ -472,10 +472,10 @@ exports[`Checkbox Matches the snapshot 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/react/src/components/checkbox/checkbox.test.tsx.snap
+++ b/packages/react/src/components/checkbox/checkbox.test.tsx.snap
@@ -20,17 +20,17 @@ exports[`Checkbox matches snapshot 1`] = `
 }
 
 .c3 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-1x);
   left: 0;
-  margin-right: var(--spacing-1x);
+  margin: var(--spacing-half) var(--spacing-1x);
   position: relative;
   width: var(--size-1x);
 }
@@ -77,10 +77,10 @@ exports[`Checkbox matches snapshot 1`] = `
 }
 
 .c0 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -33,15 +33,15 @@ const IndeterminateIcon = styled(Icon).attrs({ name: 'minus' })`
 `;
 
 const CustomCheckbox = styled.span<{ disabled?: boolean }>`
-    align-self: center;
     background-color: ${({ disabled, theme }) => (disabled ? theme.component['checkbox-disabled-background-color'] : theme.component['checkbox-unchecked-background-color'])};
     border: 1px solid ${({ disabled, theme }) => (disabled ? theme.component['checkbox-disabled-border-color'] : theme.component['checkbox-unchecked-border-color'])};
     border-radius: var(--border-radius);
     box-sizing: border-box;
     display: inline-block;
+    flex-shrink: 0;
     height: var(--size-1x);
     left: 0;
-    margin-right: var(--spacing-1x);
+    margin: var(--spacing-half) var(--spacing-1x);
     position: relative;
     width: ${checkboxWidth};
 
@@ -84,7 +84,7 @@ interface StyledLabelProps {
 }
 
 const StyledLabel = styled.label<StyledLabelProps>`
-    align-items: center;
+    align-items: flex-start;
     display: flex;
     line-height: 1.5rem;
     position: relative;

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -1495,17 +1495,17 @@ exports[`Table has selectable rows styles 1`] = `
 }
 
 .c7 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
   box-sizing: border-box;
   display: inline-block;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-1x);
   left: 0;
-  margin-right: var(--spacing-1x);
+  margin: var(--spacing-half) var(--spacing-1x);
   position: relative;
   width: var(--size-1x);
 }
@@ -1552,10 +1552,10 @@ exports[`Table has selectable rows styles 1`] = `
 }
 
 .c4 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;


### PR DESCRIPTION
https://equisoft.atlassian.net/browse/DS-1261

Lorsque le label du checkbox est trop long et tombait sur 2 lignes, l'input était compressé.