### PR TITLE
ci: remove commitlint config override

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,7 +1,0 @@
-export default {
-    extends: ['@commitlint/config-conventional'],
-    ignores: [(message) => /^chore\([a-z-]+\): bump [^ ]+( from [^ ]+ to [^ ]+)?$/m.test(message)],
-    rules: {
-        'scope-case': [2, 'always', ['lower-case', 'pascal-case', 'camel-case']],
-    },
-};


### PR DESCRIPTION
La config de l'action inclut déjà tout ça, plus des scopes supplémentaires, comme `deps`