### PR TITLE
feat(MoneyInput,NumericInput,TextInput): expose CSS class to allow styling elements

### DIFF
--- a/packages/react/src/components/money-input/money-input.test.tsx.snap
+++ b/packages/react/src/components/money-input/money-input.test.tsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CurrencyInput Component matches snapshot (en-CA) 1`] = `
-.c1 {
+.c0 {
   margin: 0 0 var(--spacing-3x);
 }
 
-.c1 input,
-.c1 select,
-.c1 textarea {
+.c0 input,
+.c0 select,
+.c0 textarea {
   border-color: #60666E;
 }
 
-.c1 > :nth-child(0) {
+.c0 > :nth-child(0) {
   margin-bottom: var(--spacing-half);
 }
 
@@ -111,46 +111,42 @@ exports[`CurrencyInput Component matches snapshot (en-CA) 1`] = `
   outline-offset: -2px;
 }
 
-.c0 input {
+.c1 .eds-TextInput-control {
   text-align: left;
   width: 132px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
+  data-testid="field-container"
 >
   <div
-    class="c1"
-    data-testid="field-container"
+    class="c2 eds-TextInput-control"
   >
-    <div
-      class="c2"
-    >
-      <input
-        class="c3"
-        data-testid="text-input"
-        id="uuid1"
-        inputmode="numeric"
-        type="text"
-        value="$100.00"
-      />
-    </div>
+    <input
+      class="c3"
+      data-testid="text-input"
+      id="uuid1"
+      inputmode="numeric"
+      type="text"
+      value="$100.00"
+    />
   </div>
 </div>
 `;
 
 exports[`CurrencyInput Component matches snapshot (en-US) 1`] = `
-.c1 {
+.c0 {
   margin: 0 0 var(--spacing-3x);
 }
 
-.c1 input,
-.c1 select,
-.c1 textarea {
+.c0 input,
+.c0 select,
+.c0 textarea {
   border-color: #60666E;
 }
 
-.c1 > :nth-child(0) {
+.c0 > :nth-child(0) {
   margin-bottom: var(--spacing-half);
 }
 
@@ -250,46 +246,42 @@ exports[`CurrencyInput Component matches snapshot (en-US) 1`] = `
   outline-offset: -2px;
 }
 
-.c0 input {
+.c1 .eds-TextInput-control {
   text-align: left;
   width: 132px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
+  data-testid="field-container"
 >
   <div
-    class="c1"
-    data-testid="field-container"
+    class="c2 eds-TextInput-control"
   >
-    <div
-      class="c2"
-    >
-      <input
-        class="c3"
-        data-testid="text-input"
-        id="uuid1"
-        inputmode="numeric"
-        type="text"
-        value="$100.00"
-      />
-    </div>
+    <input
+      class="c3"
+      data-testid="text-input"
+      id="uuid1"
+      inputmode="numeric"
+      type="text"
+      value="$100.00"
+    />
   </div>
 </div>
 `;
 
 exports[`CurrencyInput Component matches snapshot (fr-CA) 1`] = `
-.c1 {
+.c0 {
   margin: 0 0 var(--spacing-3x);
 }
 
-.c1 input,
-.c1 select,
-.c1 textarea {
+.c0 input,
+.c0 select,
+.c0 textarea {
   border-color: #60666E;
 }
 
-.c1 > :nth-child(0) {
+.c0 > :nth-child(0) {
   margin-bottom: var(--spacing-half);
 }
 
@@ -389,30 +381,26 @@ exports[`CurrencyInput Component matches snapshot (fr-CA) 1`] = `
   outline-offset: -2px;
 }
 
-.c0 input {
+.c1 .eds-TextInput-control {
   text-align: left;
   width: 132px;
 }
 
 <div
-  class="c0"
+  class="c0 c1"
+  data-testid="field-container"
 >
   <div
-    class="c1"
-    data-testid="field-container"
+    class="c2 eds-TextInput-control"
   >
-    <div
-      class="c2"
-    >
-      <input
-        class="c3"
-        data-testid="text-input"
-        id="uuid1"
-        inputmode="numeric"
-        type="text"
-        value="100,00 $"
-      />
-    </div>
+    <input
+      class="c3"
+      data-testid="text-input"
+      id="uuid1"
+      inputmode="numeric"
+      type="text"
+      value="100,00 $"
+    />
   </div>
 </div>
 `;

--- a/packages/react/src/components/money-input/money-input.tsx
+++ b/packages/react/src/components/money-input/money-input.tsx
@@ -3,12 +3,12 @@ import styled from 'styled-components';
 import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { useTranslation } from '../../i18n/use-translation';
 import { formatCurrency } from '../../utils/currency';
-import { TextInput } from '../text-input/text-input';
+import { TextInput, textInputClasses } from '../text-input';
 
 type TextAlignment = 'left' | 'right';
 
-const InputWrapper = styled.div<{ $textAlignment: TextAlignment }>`
-    input {
+const StyledTextInput = styled(TextInput)<{ $textAlignment: TextAlignment }>`
+    .${textInputClasses.control} {
         text-align: ${({ $textAlignment }) => $textAlignment};
         width: 132px;
     }
@@ -24,7 +24,7 @@ function safeFormatCurrency(
 }
 
 interface Props {
-    id?: string
+    id?: string;
     className?: string;
     disabled?: boolean;
     required?: boolean;
@@ -145,25 +145,24 @@ export const MoneyInput: VoidFunctionComponent<Props> = ({
     }, []);
 
     return (
-        <InputWrapper $textAlignment={textAlignment}>
-            <TextInput
-                id={providedId}
-                className={className}
-                required={required}
-                disabled={disabled}
-                ref={inputElement}
-                type="text"
-                inputMode="numeric"
-                value={displayValue}
-                label={label}
-                onChange={handleChangeEvent}
-                onBlur={handleBlurEvent}
-                onFocus={handleFocusEvent}
-                validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
-                hint={hint}
-                noMargin={noMargin}
-                {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
-            />
-        </InputWrapper>
+        <StyledTextInput
+            $textAlignment={textAlignment}
+            id={providedId}
+            className={className}
+            required={required}
+            disabled={disabled}
+            ref={inputElement}
+            type="text"
+            inputMode="numeric"
+            value={displayValue}
+            label={label}
+            onChange={handleChangeEvent}
+            onBlur={handleBlurEvent}
+            onFocus={handleFocusEvent}
+            validationErrorMessage={validationErrorMessage || t('validationErrorMessage')}
+            hint={hint}
+            noMargin={noMargin}
+            {...dataAttributes /* eslint-disable-line react/jsx-props-no-spreading */}
+        />
     );
 };

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`NumericInput matches the snapshot (Disabled) 1`] = `
   margin-bottom: var(--spacing-half);
 }
 
-.c4 {
+.c6 {
   background: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
@@ -38,69 +38,80 @@ exports[`NumericInput matches the snapshot (Disabled) 1`] = `
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   min-height: 100%;
-  text-align: left;
 }
 
-.c4::-webkit-input-placeholder {
+.c6::-webkit-input-placeholder {
   color: #60666E;
 }
 
-.c4::-moz-placeholder {
+.c6::-moz-placeholder {
   color: #60666E;
 }
 
-.c4:-ms-input-placeholder {
+.c6:-ms-input-placeholder {
   color: #60666E;
 }
 
-.c4::placeholder {
+.c6::placeholder {
   color: #60666E;
 }
 
-.c4:disabled {
+.c6:disabled {
   background-color: #F1F2F2;
   border-color: #B7BBC2;
   color: #B7BBC2;
 }
 
-.c4:disabled,
-.c4:disabled::-webkit-input-placeholder {
+.c6:disabled,
+.c6:disabled::-webkit-input-placeholder {
   color: #B7BBC2;
 }
 
-.c4:disabled,
-.c4:disabled::-moz-placeholder {
+.c6:disabled,
+.c6:disabled::-moz-placeholder {
   color: #B7BBC2;
 }
 
-.c4:disabled,
-.c4:disabled:-ms-input-placeholder {
+.c6:disabled,
+.c6:disabled:-ms-input-placeholder {
   color: #B7BBC2;
 }
 
-.c4:disabled,
-.c4:disabled::placeholder {
+.c6:disabled,
+.c6:disabled::placeholder {
   color: #B7BBC2;
 }
 
-.c4:focus,
-.c4:disabled {
+.c6:focus,
+.c6:disabled {
   border: 0;
   box-shadow: none;
 }
 
-.c3 {
+.c4 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c4 > svg {
+  height: 16px;
+  width: 16px;
+}
+
+.c5 {
   padding-left: var(--spacing-1x);
 }
 
-.c1 {
+.c2 {
   background: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
@@ -114,34 +125,44 @@ exports[`NumericInput matches the snapshot (Disabled) 1`] = `
   border-color: #B7BBC2;
 }
 
-.c1 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c1:focus-within {
+.c2:focus-within {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
-.c1 .c2 {
+.c2 .c3 {
   color: #B7BBC2;
 }
 
+.c1 .eds-TextInput-control {
+  text-align: left;
+}
+
+.c1 .eds-TextInput-leftAdornment,
+.c1 .eds-TextInput-rightAdornment {
+  color: #1B1C1E;
+}
+
 <div
-  class="c0"
+  class="c0 c1"
+  data-testid="field-container"
 >
   <div
-    class="c1"
+    class="c2 eds-TextInput-control"
   >
     <span
-      class="c2 c3"
+      class="c3 c4 c5 eds-TextInput-leftAdornment"
     >
       %
     </span>
     <input
-      class="c4"
+      class="c6"
       data-testid="numeric-input"
       disabled=""
       id="uuid1"
@@ -154,7 +175,7 @@ exports[`NumericInput matches the snapshot (Disabled) 1`] = `
 `;
 
 exports[`NumericInput matches the snapshot (Invalid) 1`] = `
-.c1 {
+.c2 {
   color: #CD2C23;
   display: -webkit-box;
   display: -webkit-flex;
@@ -169,7 +190,7 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   line-height: 1.25rem;
 }
 
-.c2 {
+.c3 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
@@ -194,7 +215,7 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   margin-bottom: var(--spacing-half);
 }
 
-.c5 {
+.c7 {
   background: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
@@ -217,69 +238,80 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   min-height: 100%;
-  text-align: left;
 }
 
-.c5::-webkit-input-placeholder {
+.c7::-webkit-input-placeholder {
   color: #60666E;
 }
 
-.c5::-moz-placeholder {
+.c7::-moz-placeholder {
   color: #60666E;
 }
 
-.c5:-ms-input-placeholder {
+.c7:-ms-input-placeholder {
   color: #60666E;
 }
 
-.c5::placeholder {
+.c7::placeholder {
   color: #60666E;
 }
 
-.c5:disabled {
+.c7:disabled {
   background-color: #F1F2F2;
   border-color: #B7BBC2;
   color: #B7BBC2;
 }
 
-.c5:disabled,
-.c5:disabled::-webkit-input-placeholder {
+.c7:disabled,
+.c7:disabled::-webkit-input-placeholder {
   color: #B7BBC2;
 }
 
-.c5:disabled,
-.c5:disabled::-moz-placeholder {
+.c7:disabled,
+.c7:disabled::-moz-placeholder {
   color: #B7BBC2;
 }
 
-.c5:disabled,
-.c5:disabled:-ms-input-placeholder {
+.c7:disabled,
+.c7:disabled:-ms-input-placeholder {
   color: #B7BBC2;
 }
 
-.c5:disabled,
-.c5:disabled::placeholder {
+.c7:disabled,
+.c7:disabled::placeholder {
   color: #B7BBC2;
 }
 
-.c5:focus,
-.c5:disabled {
+.c7:focus,
+.c7:disabled {
   border: 0;
   box-shadow: none;
 }
 
-.c4 {
+.c5 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c5 > svg {
+  height: 16px;
+  width: 16px;
+}
+
+.c6 {
   padding-left: var(--spacing-1x);
 }
 
-.c3 {
+.c4 {
   background: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
@@ -292,29 +324,39 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   border-color: #CD2C23;
 }
 
-.c3 {
+.c4 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c3:focus-within {
+.c4:focus-within {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
+.c1 .eds-TextInput-control {
+  text-align: left;
+}
+
+.c1 .eds-TextInput-leftAdornment,
+.c1 .eds-TextInput-rightAdornment {
+  color: #1B1C1E;
+}
+
 <div
-  class="c0"
+  class="c0 c1"
+  data-testid="field-container"
 >
   <span
     aria-live="polite"
-    class="c1"
+    class="c2"
     data-testid="invalid-field"
     id="uuid1_invalid"
     role="alert"
   >
     <svg
-      class="c2"
+      class="c3"
       color="currentColor"
       focusable="false"
       height="16"
@@ -323,15 +365,16 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
     This is an error message
   </span>
   <div
-    class="c3"
+    class="c4 eds-TextInput-control"
   >
     <span
-      class="c4"
+      class="c5 c6 eds-TextInput-leftAdornment"
     >
       %
     </span>
     <input
-      class="c5"
+      aria-describedby="uuid1_invalid"
+      class="c7"
       data-testid="numeric-input"
       id="uuid1"
       inputmode="numeric"
@@ -357,152 +400,6 @@ exports[`NumericInput matches the snapshot (Normal - Adornment at end) 1`] = `
   margin-bottom: var(--spacing-half);
 }
 
-.c2 {
-  background: #FFFFFF;
-  border: 1px solid #60666E;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  color: #1B1C1E;
-  font-family: inherit;
-  font-size: 0.875rem;
-  -webkit-letter-spacing: 0.015rem;
-  -moz-letter-spacing: 0.015rem;
-  -ms-letter-spacing: 0.015rem;
-  letter-spacing: 0.015rem;
-  line-height: 1.5rem;
-  margin: 0;
-  min-height: var(--size-2x);
-  outline: none;
-  padding: 0 var(--spacing-1x);
-  width: 100%;
-  border: 0;
-  -webkit-flex: 1 1 auto;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  min-height: 100%;
-  text-align: left;
-}
-
-.c2::-webkit-input-placeholder {
-  color: #60666E;
-}
-
-.c2::-moz-placeholder {
-  color: #60666E;
-}
-
-.c2:-ms-input-placeholder {
-  color: #60666E;
-}
-
-.c2::placeholder {
-  color: #60666E;
-}
-
-.c2:disabled {
-  background-color: #F1F2F2;
-  border-color: #B7BBC2;
-  color: #B7BBC2;
-}
-
-.c2:disabled,
-.c2:disabled::-webkit-input-placeholder {
-  color: #B7BBC2;
-}
-
-.c2:disabled,
-.c2:disabled::-moz-placeholder {
-  color: #B7BBC2;
-}
-
-.c2:disabled,
-.c2:disabled:-ms-input-placeholder {
-  color: #B7BBC2;
-}
-
-.c2:disabled,
-.c2:disabled::placeholder {
-  color: #B7BBC2;
-}
-
-.c2:focus,
-.c2:disabled {
-  border: 0;
-  box-shadow: none;
-}
-
-.c3 {
-  -webkit-align-self: center;
-  -ms-flex-item-align: center;
-  align-self: center;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  padding-right: var(--spacing-1x);
-}
-
-.c1 {
-  background: #FFFFFF;
-  border: 1px solid #60666E;
-  border-radius: var(--border-radius);
-  box-sizing: border-box;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  height: var(--size-2x);
-}
-
-.c1 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c1:focus-within {
-  box-shadow: 0 0 0 2px #006296;
-  outline: 2px solid #84C6EA;
-  outline-offset: -2px;
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-  >
-    <input
-      class="c2"
-      data-testid="numeric-input"
-      id="uuid1"
-      inputmode="numeric"
-      type="text"
-      value="50"
-    />
-    <span
-      class="c3"
-    >
-      %
-    </span>
-  </div>
-</div>
-`;
-
-exports[`NumericInput matches the snapshot (Normal - Adornment at start) 1`] = `
-.c0 {
-  margin: 0 0 var(--spacing-3x);
-}
-
-.c0 input,
-.c0 select,
-.c0 textarea {
-  border-color: #60666E;
-}
-
-.c0 > :nth-child(0) {
-  margin-bottom: var(--spacing-half);
-}
-
 .c3 {
   background: #FFFFFF;
   border: 1px solid #60666E;
@@ -526,7 +423,6 @@ exports[`NumericInput matches the snapshot (Normal - Adornment at start) 1`] = `
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
   min-height: 100%;
-  text-align: left;
 }
 
 .c3::-webkit-input-placeholder {
@@ -577,18 +473,30 @@ exports[`NumericInput matches the snapshot (Normal - Adornment at start) 1`] = `
   box-shadow: none;
 }
 
-.c2 {
+.c4 {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
+  color: #60666E;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  padding-left: var(--spacing-1x);
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
 }
 
-.c1 {
+.c4 > svg {
+  height: 16px;
+  width: 16px;
+}
+
+.c5 {
+  padding-right: var(--spacing-1x);
+}
+
+.c2 {
   background: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius);
@@ -600,30 +508,207 @@ exports[`NumericInput matches the snapshot (Normal - Adornment at start) 1`] = `
   height: var(--size-2x);
 }
 
-.c1 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c1:focus-within {
+.c2:focus-within {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
+.c1 .eds-TextInput-control {
+  text-align: left;
+}
+
+.c1 .eds-TextInput-leftAdornment,
+.c1 .eds-TextInput-rightAdornment {
+  color: #1B1C1E;
+}
+
 <div
-  class="c0"
+  class="c0 c1"
+  data-testid="field-container"
 >
   <div
-    class="c1"
+    class="c2 eds-TextInput-control"
+  >
+    <input
+      class="c3"
+      data-testid="numeric-input"
+      id="uuid1"
+      inputmode="numeric"
+      type="text"
+      value="50"
+    />
+    <span
+      class="c4 c5 eds-TextInput-rightAdornment"
+    >
+      %
+    </span>
+  </div>
+</div>
+`;
+
+exports[`NumericInput matches the snapshot (Normal - Adornment at start) 1`] = `
+.c0 {
+  margin: 0 0 var(--spacing-3x);
+}
+
+.c0 input,
+.c0 select,
+.c0 textarea {
+  border-color: #60666E;
+}
+
+.c0 > :nth-child(0) {
+  margin-bottom: var(--spacing-half);
+}
+
+.c5 {
+  background: #FFFFFF;
+  border: 1px solid #60666E;
+  border-radius: var(--border-radius);
+  box-sizing: border-box;
+  color: #1B1C1E;
+  font-family: inherit;
+  font-size: 0.875rem;
+  -webkit-letter-spacing: 0.015rem;
+  -moz-letter-spacing: 0.015rem;
+  -ms-letter-spacing: 0.015rem;
+  letter-spacing: 0.015rem;
+  line-height: 1.5rem;
+  margin: 0;
+  min-height: var(--size-2x);
+  outline: none;
+  padding: 0 var(--spacing-1x);
+  width: 100%;
+  border: 0;
+  -webkit-flex: 1 1 auto;
+  -ms-flex: 1 1 auto;
+  flex: 1 1 auto;
+  min-height: 100%;
+}
+
+.c5::-webkit-input-placeholder {
+  color: #60666E;
+}
+
+.c5::-moz-placeholder {
+  color: #60666E;
+}
+
+.c5:-ms-input-placeholder {
+  color: #60666E;
+}
+
+.c5::placeholder {
+  color: #60666E;
+}
+
+.c5:disabled {
+  background-color: #F1F2F2;
+  border-color: #B7BBC2;
+  color: #B7BBC2;
+}
+
+.c5:disabled,
+.c5:disabled::-webkit-input-placeholder {
+  color: #B7BBC2;
+}
+
+.c5:disabled,
+.c5:disabled::-moz-placeholder {
+  color: #B7BBC2;
+}
+
+.c5:disabled,
+.c5:disabled:-ms-input-placeholder {
+  color: #B7BBC2;
+}
+
+.c5:disabled,
+.c5:disabled::placeholder {
+  color: #B7BBC2;
+}
+
+.c5:focus,
+.c5:disabled {
+  border: 0;
+  box-shadow: none;
+}
+
+.c3 {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  color: #60666E;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+}
+
+.c3 > svg {
+  height: 16px;
+  width: 16px;
+}
+
+.c4 {
+  padding-left: var(--spacing-1x);
+}
+
+.c2 {
+  background: #FFFFFF;
+  border: 1px solid #60666E;
+  border-radius: var(--border-radius);
+  box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  height: var(--size-2x);
+}
+
+.c2 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c2:focus-within {
+  box-shadow: 0 0 0 2px #006296;
+  outline: 2px solid #84C6EA;
+  outline-offset: -2px;
+}
+
+.c1 .eds-TextInput-control {
+  text-align: left;
+}
+
+.c1 .eds-TextInput-leftAdornment,
+.c1 .eds-TextInput-rightAdornment {
+  color: #1B1C1E;
+}
+
+<div
+  class="c0 c1"
+  data-testid="field-container"
+>
+  <div
+    class="c2 eds-TextInput-control"
   >
     <span
-      class="c2"
+      class="c3 c4 eds-TextInput-leftAdornment"
     >
       %
     </span>
     <input
-      class="c3"
+      class="c5"
       data-testid="numeric-input"
       id="uuid1"
       inputmode="numeric"

--- a/packages/react/src/components/numeric-input/numeric-input.tsx
+++ b/packages/react/src/components/numeric-input/numeric-input.tsx
@@ -1,74 +1,22 @@
-import {
-    HTMLProps,
-    ReactNode,
-    useMemo,
-    useRef,
-    VoidFunctionComponent,
-} from 'react';
-import styled, { css } from 'styled-components';
-import { useId } from '../../hooks/use-id';
-import { focus } from '../../utils/css-state';
-import { ResolvedTheme } from '../../themes/theme';
-import { DeviceContextProps, useDeviceContext } from '../device-context-provider/device-context-provider';
-import { FieldContainer } from '../field-container/field-container';
-import { inputsStyle } from '../text-input/styles/inputs';
+import { HTMLProps, ReactNode, useRef, VoidFunctionComponent } from 'react';
+import styled from 'styled-components';
+import { TextInput, textInputClasses, TextInputProps } from '../text-input';
 import { TooltipProps } from '../tooltip/tooltip';
 import { useNumericInput, UseNumericInputParams } from './use-numeric-input';
 
-interface StyledInputProps {
-    device: DeviceContextProps;
-    theme: ResolvedTheme;
+interface StyledInputProps extends TextInputProps {
     $textAlign: 'left' | 'right';
 }
 
-const StyledInput = styled.input<StyledInputProps>`
-    ${({ theme, device }) => inputsStyle({ theme, isMobile: device.isMobile, isFocusable: false })};
-
-    border: 0;
-    flex: 1 1 auto;
-    min-height: 100%;
-    text-align: ${({ $textAlign }) => $textAlign};
-
-    &:focus,
-    &:disabled {
-        border: 0;
-        box-shadow: none;
+const StyledTextInput = styled(TextInput)<StyledInputProps>`
+    .${textInputClasses.control} {
+        text-align: ${({ $textAlign }) => $textAlign};
     }
-`;
 
-const Adornment = styled.span<{ $position: 'start' | 'end' }>`
-    align-self: center;
-    display: flex;
-    padding-left: ${({ $position }) => ($position === 'start' ? 'var(--spacing-1x)' : undefined)};
-    padding-right: ${({ $position }) => ($position === 'end' ? 'var(--spacing-1x)' : undefined)};
-`;
-
-interface StyledWrapperProps {
-    $disabled?: boolean;
-    $invalid?: boolean;
-}
-
-const Wrapper = styled.div<StyledWrapperProps>`
-    background: ${({ theme }) => theme.component['numeric-input-background-color']};
-    border: 1px solid ${({ theme }) => theme.component['numeric-input-border-color']};
-    border-radius: var(--border-radius);
-    box-sizing: border-box;
-    display: flex;
-    height: var(--size-2x);
-
-    ${({ theme }) => focus({ theme }, { focusType: 'focus-within' })};
-
-    ${({ $invalid, theme }) => $invalid && css`
-        border-color: ${theme.component['numeric-input-error-border-color']};
-`};
-    ${({ $disabled, theme }) => $disabled && css`
-        background-color: ${theme.component['numeric-input-disabled-background-color']};
-        border-color: ${theme.component['numeric-input-disabled-border-color']};
-
-        ${Adornment} {
-            color: ${theme.component['numeric-input-disabled-adornment-text-color']};
-        }
-    `};
+    .${textInputClasses.leftAdornment},
+    .${textInputClasses.rightAdornment} {
+        color: ${({ theme }) => theme.alias['color-control-value']};
+    }
 `;
 
 type NativeInputProps = Pick<HTMLProps<HTMLInputElement>, 'disabled' | 'onFocus' | 'placeholder'>;
@@ -120,8 +68,6 @@ export const NumericInput: VoidFunctionComponent<NumericInputProps> = ({
     value,
 }) => {
     const inputRef = useRef<HTMLInputElement>(null);
-    const device = useDeviceContext();
-    const fieldId = useId(id);
 
     const numericInput = useNumericInput({
         defaultValue,
@@ -136,45 +82,33 @@ export const NumericInput: VoidFunctionComponent<NumericInputProps> = ({
         value,
     });
 
-    const adornmentContent = useMemo(() => (
-        adornment ? <Adornment $position={adornmentPosition}>{adornment}</Adornment> : null
-    ), [adornment, adornmentPosition]);
-
     return (
-        <FieldContainer
+        <StyledTextInput
+            $textAlign={textAlign}
             className={className}
-            fieldId={fieldId}
+            data-testid="numeric-input"
+            defaultValue={defaultValue?.toString()}
+            disabled={disabled}
             hint={hint}
+            id={id}
+            inputMode="numeric"
+            valid={numericInput.invalid === undefined ? undefined : !numericInput.invalid}
             label={label}
-            tooltip={tooltip}
+            leftAdornment={adornmentPosition === 'start' && adornment}
             noMargin={noMargin}
-            required={required}
-            valid={!numericInput.invalid}
-            noInvalidFieldIcon={!numericInput.validationErrorMessage}
-            validationErrorMessage={numericInput.validationErrorMessage ?? ''}
-        >
-            <Wrapper $disabled={disabled} $invalid={numericInput.invalid}>
-                {(adornment && adornmentPosition === 'start') && adornmentContent}
-                <StyledInput
-                    $textAlign={textAlign}
-                    data-testid="numeric-input"
-                    device={device}
-                    disabled={disabled}
-                    id={fieldId}
-                    inputMode="numeric"
-                    onBlur={numericInput.onBlurHandler}
-                    onChange={numericInput.onChangeHandler}
-                    onFocus={onFocus}
-                    onInvalid={numericInput.onInvalid}
-                    onPaste={numericInput.onPasteHandler}
-                    placeholder={placeholder}
-                    required={required}
-                    ref={inputRef}
-                    type="text"
-                    value={numericInput.value}
-                />
-                {(adornment && adornmentPosition === 'end') && adornmentContent}
-            </Wrapper>
-        </FieldContainer>
+            onBlur={numericInput.onBlurHandler}
+            onChange={numericInput.onChangeHandler}
+            onFocus={onFocus}
+            onInvalid={numericInput.onInvalid}
+            onPaste={numericInput.onPasteHandler}
+            placeholder={placeholder}
+            required={numericInput.required}
+            ref={inputRef}
+            rightAdornment={adornmentPosition === 'end' && adornment}
+            tooltip={tooltip}
+            type="text"
+            value={numericInput.value}
+            validationErrorMessage={numericInput.validationErrorMessage}
+        />
     );
 };

--- a/packages/react/src/components/numeric-input/use-numeric-input.tsx
+++ b/packages/react/src/components/numeric-input/use-numeric-input.tsx
@@ -79,7 +79,8 @@ function getValidationErrorType(value: string, {
     if (value !== '') {
         if (max !== undefined && Number(value) > max) {
             return 'max';
-        } if (min !== undefined && Number(value) < min) {
+        }
+        if (min !== undefined && Number(value) < min) {
             return 'min';
         }
     }

--- a/packages/react/src/components/text-input/index.ts
+++ b/packages/react/src/components/text-input/index.ts
@@ -1,0 +1,2 @@
+export { TextInput, type TextInputProps } from './text-input';
+export { textInputClasses, type TextInputClasses } from './text-input-classes';

--- a/packages/react/src/components/text-input/text-input-classes.ts
+++ b/packages/react/src/components/text-input/text-input-classes.ts
@@ -1,0 +1,20 @@
+import { generateComponentClasses } from '../../utils/generate-component-classes';
+
+const COMPONENT_NAME = 'TextInput';
+
+export interface TextInputClasses {
+    control: string;
+    leftAdornment: string;
+    rightAdornment: string;
+}
+
+export type TextInputClassKeys = keyof TextInputClasses;
+
+export const textInputClasses: TextInputClasses = generateComponentClasses(
+    COMPONENT_NAME,
+    [
+        'control',
+        'leftAdornment',
+        'rightAdornment',
+    ],
+);

--- a/packages/react/src/components/text-input/text-input.test.tsx.snap
+++ b/packages/react/src/components/text-input/text-input.test.tsx.snap
@@ -145,7 +145,7 @@ input + .c1 {
     Telephone
   </label>
   <div
-    class="c3"
+    class="c3 eds-TextInput-control"
   >
     <input
       class="c4"
@@ -304,7 +304,7 @@ input + .c1 {
     Telephone (required)
   </label>
   <div
-    class="c3"
+    class="c3 eds-TextInput-control"
   >
     <input
       class="c4"
@@ -463,7 +463,7 @@ input + .c1 {
     Telephone
   </label>
   <div
-    class="c3"
+    class="c3 eds-TextInput-control"
   >
     <input
       class="c4"
@@ -644,10 +644,10 @@ input + .c1 {
     Telephone
   </label>
   <div
-    class="c3"
+    class="c3 eds-TextInput-control"
   >
     <span
-      class="c4 c5"
+      class="c4 c5 eds-TextInput-leftAdornment"
     >
       <svg
         color="currentColor"
@@ -835,10 +835,10 @@ input + .c1 {
     Telephone
   </label>
   <div
-    class="c3"
+    class="c3 eds-TextInput-control"
   >
     <span
-      class="c4 c5"
+      class="c4 c5 eds-TextInput-leftAdornment"
     >
       #
     </span>
@@ -1025,10 +1025,10 @@ input + .c1 {
     Telephone
   </label>
   <div
-    class="c3"
+    class="c3 eds-TextInput-control"
   >
     <span
-      class="c4 c5"
+      class="c4 c5 eds-TextInput-leftAdornment"
     >
       #
     </span>
@@ -1042,7 +1042,7 @@ input + .c1 {
       value="foo"
     />
     <span
-      class="c4 c7"
+      class="c4 c7 eds-TextInput-rightAdornment"
     >
       end
     </span>

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -33,7 +33,7 @@ export { RadioButton } from './components/radio-button/radio-button';
 export { StepperInput } from './components/stepper-input/stepper-input';
 export { Tab, Tabs } from './components/tabs/tabs';
 export { TextArea } from './components/text-area/text-area';
-export { TextInput } from './components/text-input/text-input';
+export * from './components/text-input';
 export { ToggleSwitch } from './components/toggle-switch/toggle-switch';
 export {
     hasALowerCaseLetter,

--- a/packages/react/src/utils/generate-component-classes.test.ts
+++ b/packages/react/src/utils/generate-component-classes.test.ts
@@ -1,0 +1,31 @@
+import { generateComponentClasses } from './generate-component-classes';
+
+describe('generateComponentClasses', () => {
+    const keys = ['root', 'label', 'icon'];
+
+    it('should generate correct class names for a given component', () => {
+        const componentName = 'Button';
+        const expectedClasses = {
+            root: 'eds-Button-root',
+            label: 'eds-Button-label',
+            icon: 'eds-Button-icon',
+        };
+
+        const result = generateComponentClasses(componentName, keys);
+
+        expect(result).toEqual(expectedClasses);
+    });
+
+    it('should handle empty component name', () => {
+        const componentName = '';
+        const expectedClasses = {
+            root: 'eds-root',
+            label: 'eds-label',
+            icon: 'eds-icon',
+        };
+
+        const result = generateComponentClasses(componentName, keys);
+
+        expect(result).toEqual(expectedClasses);
+    });
+});

--- a/packages/react/src/utils/generate-component-classes.ts
+++ b/packages/react/src/utils/generate-component-classes.ts
@@ -1,0 +1,12 @@
+const DS_CLASS_PREFIX = 'eds-';
+
+export function generateComponentClasses<T extends string>(componentName: string, keys: T[]): Record<T, string> {
+    const classes = {} as Record<T, string>;
+
+    const componentClass = componentName ? `${componentName}-` : '';
+    keys.forEach((key) => {
+        classes[key] = `${DS_CLASS_PREFIX}${componentClass}${key}`;
+    });
+
+    return classes;
+}


### PR DESCRIPTION
Permet de contrôler la largeur de l'input en faisant 
```typescript
import { TextInput, textInputClasses } from '@equisoft/design-elements-react';

const SomeInput = styled(TextInput)`
    .${textInputClasses.control} {
        width: 80px;
    }
`;
```

J'ai aussi ramené le numeric-input pour qu'il utilise le TextInput, et enlever un layer de div dans le MoneyInput.