### PR TITLE
fix(TextInput, InvalidField): remove a11y attribute error message + aria-invalid is automatic

### DIFF
--- a/packages/react/src/components/combobox/combobox.test.tsx.snap
+++ b/packages/react/src/components/combobox/combobox.test.tsx.snap
@@ -776,11 +776,9 @@ input + .c2 {
     Select an option
   </label>
   <span
-    aria-live="polite"
     class="c4"
     data-testid="invalid-field"
     id="uuid1_invalid"
-    role="alert"
   >
     <svg
       class="c5"

--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -1950,11 +1950,9 @@ label + .c5 {
     date
   </label>
   <span
-    aria-live="polite"
     class="c3"
     data-testid="invalid-field"
     id="uuid1_invalid"
-    role="alert"
   >
     <svg
       class="c4"

--- a/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
+++ b/packages/react/src/components/dropdown-list/dropdown-list.test.tsx.snap
@@ -1147,11 +1147,9 @@ input + .c2 {
     Select an option
   </label>
   <span
-    aria-live="polite"
     class="c4"
     data-testid="invalid-field"
     id="uuid1_invalid"
-    role="alert"
   >
     <svg
       class="c5"

--- a/packages/react/src/components/feedbacks/invalid-field.test.tsx.snap
+++ b/packages/react/src/components/feedbacks/invalid-field.test.tsx.snap
@@ -28,11 +28,9 @@ exports[`Invalid field Matches the snapshot 1`] = `
 }
 
 <span
-  aria-live="polite"
   class="c0"
   data-testid="invalid-field"
   id="test-id_invalid"
-  role="alert"
 >
   <svg
     class="c1"

--- a/packages/react/src/components/feedbacks/invalid-field.tsx
+++ b/packages/react/src/components/feedbacks/invalid-field.tsx
@@ -30,10 +30,8 @@ const InvalidField: VoidFunctionComponent<InvalidFieldProps> = ({ controlId, fee
     return (
         <Field
             data-testid="invalid-field"
-            aria-live="polite"
             id={`${controlId}_invalid`}
             isMobile={isMobile}
-            role="alert"
         >
             {!noIcon && (
                 <StyledIcon name="alertOctagon" size={isMobile ? '24' : '16'} />

--- a/packages/react/src/components/field-container/field-container.test.tsx.snap
+++ b/packages/react/src/components/field-container/field-container.test.tsx.snap
@@ -121,11 +121,9 @@ input + .c1 {
     test label
   </label>
   <span
-    aria-live="polite"
     class="c3"
     data-testid="invalid-field"
     id="test-id_invalid"
-    role="alert"
   >
     <svg
       class="c4"

--- a/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
+++ b/packages/react/src/components/numeric-input/numeric-input.test.tsx.snap
@@ -349,11 +349,9 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
   data-testid="field-container"
 >
   <span
-    aria-live="polite"
     class="c2"
     data-testid="invalid-field"
     id="uuid1_invalid"
-    role="alert"
   >
     <svg
       class="c3"
@@ -374,6 +372,7 @@ exports[`NumericInput matches the snapshot (Invalid) 1`] = `
     </span>
     <input
       aria-describedby="uuid1_invalid"
+      aria-invalid="true"
       class="c7"
       data-testid="numeric-input"
       id="uuid1"

--- a/packages/react/src/components/password-input/password-input.test.tsx.snap
+++ b/packages/react/src/components/password-input/password-input.test.tsx.snap
@@ -811,11 +811,9 @@ exports[`PasswordInput matches the snapshot (Invalid) 1`] = `
   class="c0"
 >
   <span
-    aria-live="polite"
     class="c1"
     data-testid="invalid-field"
     id="uuid1_invalid"
-    role="alert"
   >
     <svg
       class="c2"

--- a/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
+++ b/packages/react/src/components/stepper-input/stepper-input.test.tsx.snap
@@ -597,11 +597,9 @@ input + .c1 {
     test
   </label>
   <span
-    aria-live="polite"
     class="c3"
     data-testid="invalid-field"
     id="uuid1_invalid"
-    role="alert"
   >
     <svg
       class="c4"

--- a/packages/react/src/components/text-input/text-input.tsx
+++ b/packages/react/src/components/text-input/text-input.tsx
@@ -100,7 +100,6 @@ type PartialInputProps = Pick<DetailedHTMLProps<InputHTMLAttributes<HTMLInputEle
 
 export interface TextInputProps extends PartialInputProps {
     ariaDescribedBy?: string;
-    ariaInvalid?: boolean;
     className?: string;
     defaultValue?: string;
     disabled?: boolean;
@@ -138,7 +137,6 @@ export interface TextInputProps extends PartialInputProps {
 
 export const TextInput = forwardRef(({
     ariaDescribedBy,
-    ariaInvalid,
     autoComplete,
     className,
     defaultValue,
@@ -250,7 +248,7 @@ export const TextInput = forwardRef(({
 
                 <StyleInput
                     aria-describedby={processedAriaDescribedBy || undefined}
-                    aria-invalid={ariaInvalid}
+                    aria-invalid={!validity || undefined}
                     autoComplete={autoComplete}
                     data-testid="text-input"
                     isMobile={isMobile}


### PR DESCRIPTION
DS-1257

Les messages d'erreur dans le design system utilisaient des notifications automatiques pour les lecteurs d'écran (`aria-live` et `role="alert"`), mais avec le nouveau pattern de validation des formulaires, ces notifications ne sont plus nécessaires. De plus, l'attribut `aria-invalid` est maintenant ajouté dès que le champ est en erreur.