### PR TITLE
fix(RadioCard) remove margin-bottom on heading

### DIFF
--- a/packages/react/src/components/radio-card-group/radio-card-group.test.tsx.snap
+++ b/packages/react/src/components/radio-card-group/radio-card-group.test.tsx.snap
@@ -84,7 +84,6 @@ exports[`Radio Card Matches snapshot (Checked, Desktop) 1`] = `
   background-color: #E0F0F9;
   border: 1px solid #006296;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -256,7 +255,6 @@ exports[`Radio Card Matches snapshot (Default, Desktop) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -427,7 +425,6 @@ exports[`Radio Card Matches snapshot (Default, Mobile) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -598,7 +595,6 @@ exports[`Radio Card Matches snapshot (Disabled, Desktop) 1`] = `
   background-color: #F1F2F2;
   border: 1px solid #B7BBC2;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
   color: #B7BBC2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -770,7 +766,6 @@ exports[`Radio Card Matches snapshot (Label, Desktop) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -943,7 +938,6 @@ exports[`Radio Card Matches snapshot (Label, Mobile) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
-  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;

--- a/packages/react/src/components/radio-card-group/radio-card-group.test.tsx.snap
+++ b/packages/react/src/components/radio-card-group/radio-card-group.test.tsx.snap
@@ -84,6 +84,7 @@ exports[`Radio Card Matches snapshot (Checked, Desktop) 1`] = `
   background-color: #E0F0F9;
   border: 1px solid #006296;
   border-radius: var(--border-radius-2x);
+  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -255,6 +256,7 @@ exports[`Radio Card Matches snapshot (Default, Desktop) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
+  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -425,6 +427,7 @@ exports[`Radio Card Matches snapshot (Default, Mobile) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
+  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -595,6 +598,7 @@ exports[`Radio Card Matches snapshot (Disabled, Desktop) 1`] = `
   background-color: #F1F2F2;
   border: 1px solid #B7BBC2;
   border-radius: var(--border-radius-2x);
+  box-sizing: border-box;
   color: #B7BBC2;
   display: -webkit-box;
   display: -webkit-flex;
@@ -766,6 +770,7 @@ exports[`Radio Card Matches snapshot (Label, Desktop) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
+  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;
@@ -938,6 +943,7 @@ exports[`Radio Card Matches snapshot (Label, Mobile) 1`] = `
   background-color: #FFFFFF;
   border: 1px solid #60666E;
   border-radius: var(--border-radius-2x);
+  box-sizing: border-box;
   color: #1B1C1E;
   display: -webkit-box;
   display: -webkit-flex;

--- a/packages/react/src/components/radio-card-group/radio-card-group.test.tsx.snap
+++ b/packages/react/src/components/radio-card-group/radio-card-group.test.tsx.snap
@@ -68,12 +68,16 @@ exports[`Radio Card Matches snapshot (Checked, Desktop) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-semi-bold);
   line-height: 1.5rem;
-  margin-bottom: var(--spacing-1x);
 }
 
 .c8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
+  margin-top: var(--spacing-1x);
+}
+
+.c8:empty {
+  margin: 0;
 }
 
 .c3 {
@@ -235,12 +239,16 @@ exports[`Radio Card Matches snapshot (Default, Desktop) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-semi-bold);
   line-height: 1.5rem;
-  margin-bottom: var(--spacing-1x);
 }
 
 .c8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
+  margin-top: var(--spacing-1x);
+}
+
+.c8:empty {
+  margin: 0;
 }
 
 .c3 {
@@ -401,12 +409,16 @@ exports[`Radio Card Matches snapshot (Default, Mobile) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-semi-bold);
   line-height: 1.5rem;
-  margin-bottom: var(--spacing-1x);
 }
 
 .c8 {
   font-size: 1rem;
   line-height: 1.25rem;
+  margin-top: var(--spacing-1x);
+}
+
+.c8:empty {
+  margin: 0;
 }
 
 .c3 {
@@ -567,12 +579,16 @@ exports[`Radio Card Matches snapshot (Disabled, Desktop) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-semi-bold);
   line-height: 1.5rem;
-  margin-bottom: var(--spacing-1x);
 }
 
 .c8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
+  margin-top: var(--spacing-1x);
+}
+
+.c8:empty {
+  margin: 0;
 }
 
 .c3 {
@@ -734,12 +750,16 @@ exports[`Radio Card Matches snapshot (Label, Desktop) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-semi-bold);
   line-height: 1.5rem;
-  margin-bottom: var(--spacing-1x);
 }
 
 .c8 {
   font-size: 0.875rem;
   line-height: 1.25rem;
+  margin-top: var(--spacing-1x);
+}
+
+.c8:empty {
+  margin: 0;
 }
 
 .c3 {
@@ -902,12 +922,16 @@ exports[`Radio Card Matches snapshot (Label, Mobile) 1`] = `
   font-size: 1rem;
   font-weight: var(--font-semi-bold);
   line-height: 1.5rem;
-  margin-bottom: var(--spacing-1x);
 }
 
 .c8 {
   font-size: 1rem;
   line-height: 1.25rem;
+  margin-top: var(--spacing-1x);
+}
+
+.c8:empty {
+  margin: 0;
 }
 
 .c3 {

--- a/packages/react/src/components/radio-card-group/styled-components.ts
+++ b/packages/react/src/components/radio-card-group/styled-components.ts
@@ -55,12 +55,16 @@ export const Title = styled.span<CardProps>`
     font-size: 1rem;
     font-weight: var(--font-semi-bold);
     line-height: 1.5rem;
-    margin-bottom: var(--spacing-1x);
 `;
 
 export const Description = styled.span<DescriptionProps>`
     font-size: ${({ $isMobile }) => ($isMobile ? 1 : 0.875)}rem;
     line-height: 1.25rem;
+    margin-top: var(--spacing-1x);
+
+    &:empty {
+        margin: 0;
+    }
 `;
 
 export const Label = styled.label<CardProps>`

--- a/packages/react/src/components/radio-card-group/styled-components.ts
+++ b/packages/react/src/components/radio-card-group/styled-components.ts
@@ -71,6 +71,7 @@ export const Label = styled.label<CardProps>`
     background-color: ${getLabelBackgroundColor};
     border: 1px solid ${getLabelBorderColor};
     border-radius: var(--border-radius-2x);
+    box-sizing: border-box;
     color: ${getContentColor};
     display: flex;
     gap: var(--spacing-2x);

--- a/packages/react/src/components/radio-card-group/styled-components.ts
+++ b/packages/react/src/components/radio-card-group/styled-components.ts
@@ -71,7 +71,6 @@ export const Label = styled.label<CardProps>`
     background-color: ${getLabelBackgroundColor};
     border: 1px solid ${getLabelBorderColor};
     border-radius: var(--border-radius-2x);
-    box-sizing: border-box;
     color: ${getContentColor};
     display: flex;
     gap: var(--spacing-2x);


### PR DESCRIPTION
Il y avait un problème visuel lorsque la card ne contenait qu’un titre sans texte en dessous. Le margin-bottom appliqué au titre augmentait la hauteur de la card, créant un espace visuel sous le titre qui n'était pas esthétique.

Un autre problème concernait la version verticale, où la propriété width: 100%; faisait dépasser les cards de l'espace alloué par le conteneur parent..

Changements effectués :

- Suppression du margin-bottom appliqué au titre pour éviter l'espacement excessif.
- Ajout d’un margin-top sur le contenu sous le titre, pour gérer l’espacement lorsqu’il est présent.
- Utilisation du pseudo-sélecteur :empty sur le contenu sous le titre afin de retirer le margin-top si le contenu est vide.
- Ajout de box-sizing: border-box; pour corriger la gestion de la largeur de la card.

https://equisoft.atlassian.net/browse/DS-1271