### PR TITLE
feat(table): include returning subrows when on expandable multiple mode

### DIFF
--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -462,8 +462,7 @@ export const Table = <T extends object>({
             const selectedRows = selectedIndexes.map((index: string) => {
                 if (rowSelectionMode === 'multiple') {
                     const [groupIndex, rowIndex] = index.split('.');
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    return (data[parseInt(groupIndex, 10)] as any)
+                    return (data[parseInt(groupIndex, 10)] as T & { subRows?: Array<T> })
                             ?.subRows
                             ?.[parseInt(rowIndex, 10)]
                         || data[parseInt(index, 10)];

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -457,22 +457,10 @@ export const Table = <T extends object>({
 
     useEffect(() => {
         if (rowSelectionMode && onSelectedRowsChange) {
-            const selectedRowIds = currentRowSelection;
-            const selectedIndexes = Object.keys(selectedRowIds).filter((index) => selectedRowIds[index]);
-            const selectedRows = selectedIndexes.map((index: string) => {
-                if (rowSelectionMode === 'multiple') {
-                    const [groupIndex, rowIndex] = index.split('.');
-                    return (data[parseInt(groupIndex, 10)] as T & { subRows?: Array<T> })
-                            ?.subRows
-                            ?.[parseInt(rowIndex, 10)]
-                        || data[parseInt(index, 10)];
-                }
-
-                return data[parseInt(index, 10)];
-            });
+            const selectedRows = Object.keys(currentRowSelection).map((rowId) => table.getRow(rowId).original as T);
             onSelectedRowsChange(selectedRows);
         }
-    }, [rowSelectionMode, currentRowSelection, onSelectedRowsChange, data]);
+    }, [rowSelectionMode, currentRowSelection, onSelectedRowsChange, table]);
 
     return (
         <StyledTable

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -457,7 +457,7 @@ export const Table = <T extends object>({
 
     useEffect(() => {
         if (rowSelectionMode && onSelectedRowsChange) {
-            const selectedRows = Object.keys(currentRowSelection).map((rowId) => table.getRow(rowId).original as T);
+            const selectedRows = Object.keys(currentRowSelection).map((rowId) => table.getRow(rowId).original);
             onSelectedRowsChange(selectedRows);
         }
     }, [rowSelectionMode, currentRowSelection, onSelectedRowsChange, table]);

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -460,14 +460,16 @@ export const Table = <T extends object>({
             const selectedRowIds = currentRowSelection;
             const selectedIndexes = Object.keys(selectedRowIds).filter((index) => selectedRowIds[index]);
             const selectedRows = selectedIndexes.map((index: string) => {
-                if (rowSelectionMode === 'single') {
-                    return data[parseInt(index, 10)]
-                }
-
                 if (rowSelectionMode === 'multiple') {
                     const [groupIndex, rowIndex] = index.split('.');
-                    return (data[parseInt(groupIndex)] as any)?.subRows?.[parseInt(rowIndex)] || data[parseInt(index, 10)];
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    return (data[parseInt(groupIndex, 10)] as any)
+                            ?.subRows
+                            ?.[parseInt(rowIndex, 10)]
+                        || data[parseInt(index, 10)];
                 }
+
+                return data[parseInt(index, 10)];
             });
             onSelectedRowsChange(selectedRows);
         }

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -459,7 +459,16 @@ export const Table = <T extends object>({
         if (rowSelectionMode && onSelectedRowsChange) {
             const selectedRowIds = currentRowSelection;
             const selectedIndexes = Object.keys(selectedRowIds).filter((index) => selectedRowIds[index]);
-            const selectedRows = selectedIndexes.map((index) => data[parseInt(index, 10)]);
+            const selectedRows = selectedIndexes.map((index: string) => {
+                if (rowSelectionMode === 'single') {
+                    return data[parseInt(index, 10)]
+                }
+
+                if (rowSelectionMode === 'multiple') {
+                    const [groupIndex, rowIndex] = index.split('.');
+                    return (data[parseInt(groupIndex)] as any)?.subRows?.[parseInt(rowIndex)] || data[parseInt(index, 10)];
+                }
+            });
             onSelectedRowsChange(selectedRows);
         }
     }, [rowSelectionMode, currentRowSelection, onSelectedRowsChange, data]);

--- a/packages/storybook/stories/data-table.stories.tsx
+++ b/packages/storybook/stories/data-table.stories.tsx
@@ -653,6 +653,55 @@ export const MultipleSelectableRows: Story = {
     },
 };
 
+export const MultipleSelectableExpandableSubRows: Story = {
+    render() {
+        interface ExpandableData {
+            id: string;
+            name: string;
+        }
+
+        const columns: TableColumn<ExpandableData>[] = [
+            {
+                header: 'ID',
+                accessorKey: 'id',
+            },
+            {
+                header: 'Name',
+                accessorKey: 'name',
+            },
+        ];
+
+        const data: TableData<ExpandableData>[] = [
+            {
+                id: '1',
+                name: 'AAA',
+                subRows: [
+                    { id: '1.A', name: 'AAA-1' },
+                    { id: '1.B', name: 'AAA-2' },
+                ],
+            },
+            {
+                id: '2',
+                name: 'BBB',
+                subRows: [
+                    { id: '2.A', name: 'BBB-1' },
+                    { id: '2.B', name: 'BBB-2' },
+                ],
+            },
+        ];
+        return (
+            <Table
+                expandableRows={'multiple'}
+                rowSelectionMode="multiple"
+                columns={columns}
+                data={data}
+                onSelectedRowsChange={console.info}
+                expandChildsOnRowSelection={true}
+            />
+        );
+    },
+};
+
 export const SingleSelectableRows: Story = {
     render() {
         interface SelectableData {

--- a/packages/storybook/stories/data-table.stories.tsx
+++ b/packages/storybook/stories/data-table.stories.tsx
@@ -691,12 +691,12 @@ export const MultipleSelectableExpandableSubRows: Story = {
         ];
         return (
             <Table
-                expandableRows={'multiple'}
+                expandableRows="multiple"
                 rowSelectionMode="multiple"
                 columns={columns}
                 data={data}
                 onSelectedRowsChange={console.info}
-                expandChildsOnRowSelection={true}
+                expandChildsOnRowSelection
             />
         );
     },


### PR DESCRIPTION
https://equisoft.atlassian.net/browse/DS-1279

La fonction `onSelectedRowsChange` retournait pas les subRows lorsque la data-table était configurée en mode multiple + expandable. Ça retournait juste des copies de la row parente du grouping.