### PR TITLE
feat(DataTable): bind header checkbox to current page

### DIFF
--- a/packages/react/src/components/table/table.test.tsx
+++ b/packages/react/src/components/table/table.test.tsx
@@ -215,9 +215,8 @@ describe('Table', () => {
         expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    test('onSelectedRows callbacks are called when row-checkbox is checked', () => {
+    test('onSelectedRowIds is called when row-checkbox is checked', () => {
         const onSelectedRowIdsChange = jest.fn();
-        const onSelectedRowsChange = jest.fn();
         const wrapper = mountWithTheme(
             <Table<TestData>
                 rowSelectionMode="multiple"
@@ -225,19 +224,16 @@ describe('Table', () => {
                 data={data}
                 rowIdField="id"
                 onSelectedRowIdsChange={onSelectedRowIdsChange}
-                onSelectedRowsChange={onSelectedRowsChange}
             />,
         );
 
         getByTestId(wrapper, 'row-checkbox-0').find('input').simulate('change', { target: { checked: true } });
 
         expect(onSelectedRowIdsChange).toHaveBeenCalledWith([data[0].id]);
-        expect(onSelectedRowsChange).toHaveBeenCalledWith([data[0]]);
     });
 
-    test('onSelectedRows callbacks are called with all rows when row-checkbox-all is checked', () => {
+    test('onSelectedRowIds is called with all rows when row-checkbox-all is checked', () => {
         const onSelectedRowIdsChange = jest.fn();
-        const onSelectedRowsChange = jest.fn();
         const wrapper = mountWithTheme(
             <Table<TestData>
                 rowSelectionMode="multiple"
@@ -245,7 +241,6 @@ describe('Table', () => {
                 data={data}
                 rowIdField="id"
                 onSelectedRowIdsChange={onSelectedRowIdsChange}
-                onSelectedRowsChange={onSelectedRowsChange}
             />,
         );
 
@@ -253,7 +248,6 @@ describe('Table', () => {
             .simulate('change', { target: { checked: true } });
 
         expect(onSelectedRowIdsChange).toHaveBeenCalledWith(data.map((row) => row.id));
-        expect(onSelectedRowsChange).toHaveBeenCalledWith(data);
     });
 
     test('should hide select all checkbox', () => {
@@ -493,58 +487,6 @@ describe('Table', () => {
             .simulate('change', { target: { checked: true } });
 
         expect(onSelectedRowIdsChange).toHaveBeenLastCalledWith(['0', '1', '2']);
-        expect(getByTestId(wrapper, 'row-checkbox-0')
-            .find('input')
-            .prop('checked')).toBe(true);
-        expect(getByTestId(wrapper, 'row-checkbox-1')
-            .find('input')
-            .prop('checked')).toBe(true);
-        expect(getByTestId(wrapper, 'row-checkbox-2')
-            .find('input')
-            .prop('checked')).toBe(true);
-    });
-
-    test('should exclude group row from selectedRows callback', () => {
-        const onSelectedRowIdsChange = jest.fn();
-        const onSelectedRowChange = jest.fn();
-        const dataWithSubRows: TableData<TestData>[] = [
-            {
-                id: '0',
-                column1: 'Hello',
-                column2: 'World',
-                subRows: [
-                    {
-                        id: '1',
-                        column1: 'Hello',
-                        column2: 'Planet',
-                    },
-                    {
-                        id: '2',
-                        column1: 'Hello',
-                        column2: 'Galaxy',
-                    },
-                ],
-            },
-        ];
-        const wrapper = mountWithTheme(
-            <Table<TestData>
-                rowSelectionMode="multiple"
-                columns={columns}
-                data={dataWithSubRows}
-                rowIdField="id"
-                excludeGroupsFromSelection
-                onSelectedRowIdsChange={onSelectedRowIdsChange}
-                onSelectedRowsChange={onSelectedRowChange}
-                expandChildrenOnRowSelection
-            />,
-        );
-
-        getByTestId(wrapper, 'row-checkbox-0')
-            .find('input')
-            .simulate('change', { target: { checked: true } });
-
-        expect(onSelectedRowIdsChange).toHaveBeenLastCalledWith(['1', '2']);
-        expect(onSelectedRowChange).toHaveBeenLastCalledWith(dataWithSubRows[0].subRows);
         expect(getByTestId(wrapper, 'row-checkbox-0')
             .find('input')
             .prop('checked')).toBe(true);

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -199,9 +199,9 @@ function getSelectionColumn<T extends object>(
             column.header = ({ table }) => (
                 <Checkbox
                     data-testid="row-checkbox-all"
-                    checked={table.getIsAllRowsSelected()}
-                    indeterminate={table.getIsSomeRowsSelected()}
-                    onChange={table.getToggleAllRowsSelectedHandler()}
+                    checked={table.getIsAllPageRowsSelected()}
+                    indeterminate={table.getIsSomePageRowsSelected()}
+                    onChange={table.getToggleAllPageRowsSelectedHandler()}
                 />
             );
         }
@@ -348,7 +348,6 @@ export interface TableProps<T extends object> {
     data: T[];
     defaultSort?: ColumnSort;
     columns: TableColumn<T>[];
-    excludeGroupsFromSelection?: boolean;
     expandableRows?: 'single' | 'multiple';
     expandChildrenOnRowSelection?: boolean;
     hideSelectAll?: boolean;
@@ -380,9 +379,7 @@ export interface TableProps<T extends object> {
 
     onRowClick?(row: Row<T>): void;
 
-    onSelectedRowIdsChange?(selectedRows: TableRowId[]): void;
-
-    onSelectedRowsChange?(selectedRows: T[]): void;
+    onSelectedRowIdsChange?(selectedRowIds: TableRowId[]): void;
 
     onSort?(sort: ColumnSort | null): void;
 }
@@ -394,7 +391,6 @@ export const Table = <T extends object>({
     rowIdField,
     defaultSort,
     columns: providedColumns,
-    excludeGroupsFromSelection = false,
     expandableRows,
     expandChildrenOnRowSelection,
     hideSelectAll = false,
@@ -408,7 +404,6 @@ export const Table = <T extends object>({
     manualSort = false,
     onRowClick,
     onSelectedRowIdsChange,
-    onSelectedRowsChange,
     onSort,
 }: TableProps<T>): ReactElement => {
     const { t } = useTranslation('table');
@@ -506,19 +501,7 @@ export const Table = <T extends object>({
             const currentTable = tableInstance.current;
 
             if (currentTable) {
-                const emittedRowIds = newSelectedRowIds.filter(
-                    (rowId) => !excludeGroupsFromSelection || !currentTable.getRow(rowId).subRows.length,
-                );
-
-                onSelectedRowIdsChange?.(emittedRowIds);
-
-                if (onSelectedRowsChange) {
-                    const emittedSelectedRows = emittedRowIds
-                        .map((rowId) => currentTable.getRow(rowId))
-                        .map((row) => row.original);
-
-                    onSelectedRowsChange(emittedSelectedRows);
-                }
+                onSelectedRowIdsChange?.(newSelectedRowIds);
             }
         },
     };

--- a/packages/storybook/stories/data-table.stories.tsx
+++ b/packages/storybook/stories/data-table.stories.tsx
@@ -666,31 +666,47 @@ export const MultipleSelectableRows: Story = {
                 columns={columns}
                 data={data}
                 rowIdField="column1"
-                onSelectedRowsChange={console.info}
+                onSelectedRowIdsChange={console.info}
             />
         );
     },
 };
 
+interface ExpandableData {
+    id: string;
+    name: string;
+}
+
+const expandableDataColumns: TableColumn<ExpandableData>[] = [
+    {
+        header: 'ID',
+        accessorKey: 'id',
+    },
+    {
+        header: 'Name',
+        accessorKey: 'name',
+    },
+];
+
+const ROWS_PER_PAGE = 5;
+
+function generateData(totalRows: number): TableData<ExpandableData>[] {
+    return new Array(totalRows).fill(null).map((_, index) => {
+        const page = Math.floor(index / ROWS_PER_PAGE) + 1;
+        return {
+            id: `${page}-${index}`,
+            name: `Row ${page}-${index}`,
+            subRows: [
+                { id: `${page}-${index}.A`, name: `Row ${page}-${index}.A` },
+                { id: `${page}-${index}.B`, name: `Row ${page}-${index}.B` },
+            ],
+        };
+    });
+}
+
 export const MultipleSelectableExpandableSubRows: Story = {
     render() {
-        interface ExpandableData {
-            id: string;
-            name: string;
-        }
-
         const [selectedRowIds, setSelectedRowIds] = useState<TableRowId[]>([]);
-
-        const columns: TableColumn<ExpandableData>[] = [
-            {
-                header: 'ID',
-                accessorKey: 'id',
-            },
-            {
-                header: 'Name',
-                accessorKey: 'name',
-            },
-        ];
 
         const data: TableData<ExpandableData>[] = [
             {
@@ -715,7 +731,7 @@ export const MultipleSelectableExpandableSubRows: Story = {
             <Table<ExpandableData>
                 expandableRows="multiple"
                 rowSelectionMode="multiple"
-                columns={columns}
+                columns={expandableDataColumns}
                 data={data}
                 rowIdField="id"
                 selectedRowIds={selectedRowIds}
@@ -723,6 +739,46 @@ export const MultipleSelectableExpandableSubRows: Story = {
                 expandChildrenOnRowSelection
                 hideSelectAll
             />
+        );
+    },
+};
+
+export const PaginatedMultipleSelectableExpandableSubRows: Story = {
+    render() {
+        const TOTAL_PAGES = 3;
+        const data = useMemo(() => generateData(ROWS_PER_PAGE * TOTAL_PAGES), []);
+
+        const [selectedRowIds, setSelectedRowIds] = useState<TableRowId[]>([]);
+        const [currentPage, setCurrentPage] = useState(1);
+
+        const currentData = useMemo(
+            () => data.slice((currentPage - 1) * ROWS_PER_PAGE, currentPage * ROWS_PER_PAGE),
+            [data, currentPage],
+        );
+
+        return (
+            <>
+                <Table<ExpandableData>
+                    expandableRows="multiple"
+                    rowSelectionMode="multiple"
+                    columns={expandableDataColumns}
+                    data={currentData}
+                    rowIdField="id"
+                    selectedRowIds={selectedRowIds}
+                    onSelectedRowIdsChange={(ids: TableRowId[]) => {
+                        console.info(ids);
+                        setSelectedRowIds(ids);
+                    }}
+                    expandChildrenOnRowSelection
+                />
+                <Pagination
+                    resultsPerPage={ROWS_PER_PAGE}
+                    numberOfResults={data.length}
+                    activePage={currentPage}
+                    onPageChange={(page) => setCurrentPage(page)}
+                    pagesShown={5}
+                />
+            </>
         );
     },
 };
@@ -768,7 +824,7 @@ export const SingleSelectableRows: Story = {
                 columns={columns}
                 data={data}
                 rowIdField="column1"
-                onSelectedRowsChange={console.info}
+                onSelectedRowIdsChange={console.info}
                 ariaLabelledByColumnId="column2"
             />
         );
@@ -777,22 +833,6 @@ export const SingleSelectableRows: Story = {
 
 export const ExpandableSubrowsMultiple: Story = {
     render() {
-        interface ExpandableData {
-            id: string;
-            name: string;
-        }
-
-        const columns: TableColumn<ExpandableData>[] = [
-            {
-                header: 'ID',
-                accessorKey: 'id',
-            },
-            {
-                header: 'Name',
-                accessorKey: 'name',
-            },
-        ];
-
         const data: TableData<ExpandableData>[] = [
             {
                 id: '1',
@@ -813,7 +853,7 @@ export const ExpandableSubrowsMultiple: Story = {
         ];
         return (
             <Table<ExpandableData>
-                columns={columns}
+                columns={expandableDataColumns}
                 data={data}
                 rowIdField="id"
                 expandableRows="multiple"
@@ -824,22 +864,6 @@ export const ExpandableSubrowsMultiple: Story = {
 
 export const ExpandableSubrowsSingle: Story = {
     render() {
-        interface ExpandableData {
-            id: string;
-            name: string;
-        }
-
-        const columns: TableColumn<ExpandableData>[] = [
-            {
-                header: 'ID',
-                accessorKey: 'id',
-            },
-            {
-                header: 'Name',
-                accessorKey: 'name',
-            },
-        ];
-
         const data: TableData<ExpandableData>[] = [
             {
                 id: '1',
@@ -860,7 +884,7 @@ export const ExpandableSubrowsSingle: Story = {
         ];
         return (
             <Table<ExpandableData>
-                columns={columns}
+                columns={expandableDataColumns}
                 data={data}
                 rowIdField="id"
                 expandableRows="single"
@@ -871,22 +895,6 @@ export const ExpandableSubrowsSingle: Story = {
 
 export const ExpandableSubContent: Story = {
     render() {
-        interface ExpandableData {
-            id: string;
-            name: string;
-        }
-
-        const columns: TableColumn<ExpandableData>[] = [
-            {
-                header: 'ID',
-                accessorKey: 'id',
-            },
-            {
-                header: 'Name',
-                accessorKey: 'name',
-            },
-        ];
-
         const data: TableData<ExpandableData>[] = [
             {
                 id: '1',
@@ -908,7 +916,7 @@ export const ExpandableSubContent: Story = {
 
         return (
             <Table<ExpandableData>
-                columns={columns}
+                columns={expandableDataColumns}
                 data={data}
                 rowIdField="id"
                 expandableRows="single"
@@ -1537,7 +1545,7 @@ export const WithBackgroundColor: Story = {
                     columns={columns}
                     data={data}
                     rowIdField="column1"
-                    onSelectedRowsChange={console.info}
+                    onSelectedRowIdsChange={console.info}
                 />
             </ScrollableWrap>
         );


### PR DESCRIPTION
DS-1286

L'état et les interactions de la case à cocher dans l'en-tête de la table sont liés aux données présentement affichées dans la table (page en cours).

Les props `onSelectedRowsChange` et `excludeGroupsFromSelection` ont être retirées car la table n’a pas accès aux données des pages précédentes.

La sélection de la page 1...
![image](https://github.com/user-attachments/assets/93c93c32-2c88-4f8a-900f-41305e281451)

...est indépendante de la sélection de la page 2.
![image](https://github.com/user-attachments/assets/50a8ee26-ab0e-43f9-a984-6c4a685e6ae9)

Et la sélection est conservée lorsqu'on revient à la page 1.