### PR TITLE
DS-1299 feat(Webapp): add meta viewport

### DIFF
--- a/packages/webapp/src/browser/index.html
+++ b/packages/webapp/src/browser/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title><%= PROJECT_DISPLAY_NAME %></title>
         <link rel="shortcut icon" href="./favicon.ico">
     </head>


### PR DESCRIPTION
## Contexte 
Ajoute le meta viewport pour prévenir un render `zoom-out` en mobile.

### Exemple avec et sans
<img width="300" alt="Screenshot 2025-02-03 at 8 53 27 PM" src="https://github.com/user-attachments/assets/926cf74a-a2ee-4721-856b-6f18deb6cf8b" /> <img width="400" alt="Screenshot 2025-02-03 at 8 53 44 PM" src="https://github.com/user-attachments/assets/ceef26b3-f6ea-4b6e-be8b-7b2035cabd79" />

## Test 

- [ ]  Conforme avec la règle d'accessibilité [Meta viewport allows for zoom](https://www.w3.org/WAI/standards-guidelines/act/rules/b4f0c3/#implementations)

## Note
Réplique les changements fait ici: https://github.com/kronostechnologies/webapp-boilerplate/pull/878