### PR TITLE
fix(DropdownMenu, Bento, UserProfile): add zindex

### DIFF
--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {
@@ -924,6 +925,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {
@@ -1656,6 +1658,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -391,6 +391,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {
@@ -1054,6 +1055,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`DropdownMenu Is hidden 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c6 {
@@ -420,6 +421,7 @@ exports[`DropdownMenu Matches the snapshot 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c6 {

--- a/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/react/src/components/dropdown-menu/dropdown-menu.tsx
@@ -13,6 +13,7 @@ const List = styled.div`
     list-style-type: none;
     position: absolute;
     width: 100%;
+    z-index: 700;
 `;
 
 export interface DropdownMenuProps {

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -124,6 +124,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {
@@ -816,6 +817,7 @@ exports[`UserProfile Matches Snapshot (desktop) 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {
@@ -1516,6 +1518,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {
@@ -2197,6 +2200,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
   list-style-type: none;
   position: absolute;
   width: 100%;
+  z-index: 700;
 }
 
 .c0 {


### PR DESCRIPTION
DS-1326

Le dropdown n'avait pas de `z-index` et lorsqu'il était utilisé dans le header d'une app, les éléments de la `main` section passaient par dessus. Ajout d'un `z-index`.
Il va falloir déterminer une logique pour tous les éléments nécessitant un `z-index` pour éviter que l'ordre respecte la priorité des éléments.