### PR TITLE
fix(Tabs)!: update visuel global vs section

### DIFF
--- a/packages/react/src/components/buttons/abstract/types.ts
+++ b/packages/react/src/components/buttons/abstract/types.ts
@@ -6,4 +6,5 @@ export interface AbstractButtonProps extends ButtonHTMLAttributes<HTMLButtonElem
     focusable?: boolean;
     isMobile: boolean;
     size?: Size;
+    tabIndex?: number;
 }

--- a/packages/react/src/components/buttons/types.ts
+++ b/packages/react/src/components/buttons/types.ts
@@ -38,6 +38,7 @@ export interface ButtonProps {
      * @default medium
      */
     size?: Size;
+    tabIndex?: number;
     title?: string;
     type?: Type;
 

--- a/packages/react/src/components/tabs/tab-button.test.tsx
+++ b/packages/react/src/components/tabs/tab-button.test.tsx
@@ -4,7 +4,12 @@ import { mountWithProviders } from '../../test-utils/renderer';
 import { TabButton } from './tab-button';
 
 describe('TabButton', () => {
+    const defaultProps = {
+        size: 'default' as const,
+    };
+
     const focusedAndSelected = {
+        ...defaultProps,
         id: 'aId',
         panelId: 'aPanelId',
         isSelected: true,
@@ -15,7 +20,7 @@ describe('TabButton', () => {
 
     test('should display button text', () => {
         const expectedButtonText = 'some text';
-        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected}>{expectedButtonText}</TabButton>);
+        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>);
 
         const tabPanel = getByTestId(wrapper, 'tab-text');
 
@@ -23,7 +28,7 @@ describe('TabButton', () => {
     });
 
     test('should not have a left icon in button when tab doesn\'t have a left icon name', () => {
-        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected}>some text</TabButton>);
+        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="default">some text</TabButton>);
 
         const tabButtonLeftIcon = findByTestId(wrapper, 'tab-left-icon');
 
@@ -33,7 +38,7 @@ describe('TabButton', () => {
     test('should have a left icon in button when tab has a left icon name', () => {
         const expectedLeftIcon = 'chevronUp';
         const wrapper = mountWithProviders(
-            <TabButton {...focusedAndSelected} leftIcon={expectedLeftIcon}>some text</TabButton>,
+            <TabButton {...focusedAndSelected} size="default" leftIcon={expectedLeftIcon}>some text</TabButton>,
         );
 
         const tabButtonLeftIcon = getByTestId(wrapper, 'tab-left-icon');
@@ -42,7 +47,7 @@ describe('TabButton', () => {
     });
 
     test('should not have a right icon in button when tab doesn\'t have a right icon name', () => {
-        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected}>some text</TabButton>);
+        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="default">some text</TabButton>);
 
         const tabButtonRightIcon = findByTestId(wrapper, 'tab-right-icon');
 
@@ -52,7 +57,7 @@ describe('TabButton', () => {
     test('should have a right icon in button when tab has a right icon name', () => {
         const expectedRightIcon = 'chevronDown';
         const wrapper = mountWithProviders(
-            <TabButton {...focusedAndSelected} rightIcon={expectedRightIcon}>some text</TabButton>,
+            <TabButton {...focusedAndSelected} size="default" rightIcon={expectedRightIcon}>some text</TabButton>,
         );
 
         const tabButtonRightIcon = getByTestId(wrapper, 'tab-right-icon');
@@ -68,6 +73,7 @@ describe('TabButton', () => {
                 panelId="aPanelId"
                 isSelected
                 onClick={expectedOnClickCall}
+                size="default"
             >
                 some text
             </TabButton>,

--- a/packages/react/src/components/tabs/tab-button.test.tsx
+++ b/packages/react/src/components/tabs/tab-button.test.tsx
@@ -5,7 +5,7 @@ import { TabButton } from './tab-button';
 
 describe('TabButton', () => {
     const defaultProps = {
-        size: 'default' as const,
+
     };
 
     const focusedAndSelected = {
@@ -21,7 +21,7 @@ describe('TabButton', () => {
     test('should display button text', () => {
         const expectedButtonText = 'some text';
         const wrapper = mountWithProviders(
-            <TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>,
+            <TabButton {...focusedAndSelected} size="medium">{expectedButtonText}</TabButton>,
         );
 
         const tabPanel = getByTestId(wrapper, 'tab-text');
@@ -30,7 +30,7 @@ describe('TabButton', () => {
     });
 
     test('should not have a left icon in button when tab doesn\'t have a left icon name', () => {
-        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="default">some text</TabButton>);
+        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="medium">some text</TabButton>);
 
         const tabButtonLeftIcon = findByTestId(wrapper, 'tab-left-icon');
 
@@ -40,7 +40,7 @@ describe('TabButton', () => {
     test('should have a left icon in button when tab has a left icon name', () => {
         const expectedLeftIcon = 'chevronUp';
         const wrapper = mountWithProviders(
-            <TabButton {...focusedAndSelected} size="default" leftIcon={expectedLeftIcon}>some text</TabButton>,
+            <TabButton {...focusedAndSelected} size="medium" leftIcon={expectedLeftIcon}>some text</TabButton>,
         );
 
         const tabButtonLeftIcon = getByTestId(wrapper, 'tab-left-icon');
@@ -49,7 +49,7 @@ describe('TabButton', () => {
     });
 
     test('should not have a right icon in button when tab doesn\'t have a right icon name', () => {
-        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="default">some text</TabButton>);
+        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="medium">some text</TabButton>);
 
         const tabButtonRightIcon = findByTestId(wrapper, 'tab-right-icon');
 
@@ -59,7 +59,7 @@ describe('TabButton', () => {
     test('should have a right icon in button when tab has a right icon name', () => {
         const expectedRightIcon = 'chevronDown';
         const wrapper = mountWithProviders(
-            <TabButton {...focusedAndSelected} size="default" rightIcon={expectedRightIcon}>some text</TabButton>,
+            <TabButton {...focusedAndSelected} size="medium" rightIcon={expectedRightIcon}>some text</TabButton>,
         );
 
         const tabButtonRightIcon = getByTestId(wrapper, 'tab-right-icon');
@@ -75,7 +75,7 @@ describe('TabButton', () => {
                 panelId="aPanelId"
                 isSelected
                 onClick={expectedOnClickCall}
-                size="default"
+                size="medium"
             >
                 some text
             </TabButton>,

--- a/packages/react/src/components/tabs/tab-button.test.tsx
+++ b/packages/react/src/components/tabs/tab-button.test.tsx
@@ -20,7 +20,8 @@ describe('TabButton', () => {
 
     test('should display button text', () => {
         const expectedButtonText = 'some text';
-        const wrapper = mountWithProviders(<TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>);
+        const wrapper = mountWithProviders(
+        <TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>);
 
         const tabPanel = getByTestId(wrapper, 'tab-text');
 

--- a/packages/react/src/components/tabs/tab-button.test.tsx
+++ b/packages/react/src/components/tabs/tab-button.test.tsx
@@ -4,12 +4,7 @@ import { mountWithProviders } from '../../test-utils/renderer';
 import { TabButton } from './tab-button';
 
 describe('TabButton', () => {
-    const defaultProps = {
-
-    };
-
     const focusedAndSelected = {
-        ...defaultProps,
         id: 'aId',
         panelId: 'aPanelId',
         isSelected: true,

--- a/packages/react/src/components/tabs/tab-button.test.tsx
+++ b/packages/react/src/components/tabs/tab-button.test.tsx
@@ -21,7 +21,7 @@ describe('TabButton', () => {
     test('should display button text', () => {
         const expectedButtonText = 'some text';
         const wrapper = mountWithProviders(
-            <TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>
+            <TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>,
         );
 
         const tabPanel = getByTestId(wrapper, 'tab-text');

--- a/packages/react/src/components/tabs/tab-button.test.tsx
+++ b/packages/react/src/components/tabs/tab-button.test.tsx
@@ -21,7 +21,8 @@ describe('TabButton', () => {
     test('should display button text', () => {
         const expectedButtonText = 'some text';
         const wrapper = mountWithProviders(
-        <TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>);
+            <TabButton {...focusedAndSelected} size="default">{expectedButtonText}</TabButton>
+        );
 
         const tabPanel = getByTestId(wrapper, 'tab-text');
 

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -5,15 +5,16 @@ import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { useTranslation } from '../../i18n/use-translation';
 import { focus } from '../../utils/css-state';
 import { Icon, IconName } from '../icon/icon';
+import { TabSize } from './tabs';
 
-const StyledButton = styled.button<{ $global?: boolean; $selected?: boolean; $removable?: boolean; }>`
+const StyledButton = styled.button<{ $size?: TabSize; $selected?: boolean; $removable?: boolean; }>`
     align-items: center;
     color: ${({ $selected, theme }) => ($selected ? theme.component['tab-button-selected-text-color'] : theme.component['tab-button-text-color'])};
     display: flex;
     font-family: var(--font-family);
-    font-size: ${({ $global }) => ($global ? '0.875rem' : '0.75rem')};
+    font-size: ${({ $size }) => ($size === 'default' ? '0.875rem' : '0.75rem')};
     gap: var(--spacing-half);
-    padding: ${({ $global }) => ($global ? '0 var(--spacing-2x)' : '0 var(--spacing-1x)')};
+    padding: ${({ $size }) => ($size === 'default' ? '0 var(--spacing-2x)' : '0 var(--spacing-1x)')};
     padding-right: ${({ $removable }) => ($removable && 'var(--spacing-4x)')};
     position: relative;
     user-select: none;
@@ -26,7 +27,7 @@ const StyledButton = styled.button<{ $global?: boolean; $selected?: boolean; $re
         bottom: 0;
         content: '';
         display: block;
-        height: ${({ $global }) => ($global ? '0.25rem' : '0.125rem')};
+        height: ${({ $size }) => ($size === 'default' ? '0.25rem' : '0.125rem')};
         left: 0;
         position: absolute;
         width: 100%;
@@ -94,7 +95,7 @@ const ButtonLabel = styled.span`
 `;
 
 interface TabButtonProps {
-    global?: boolean;
+    size?: TabSize;
     id: string;
     children: string;
     panelId: string;
@@ -107,7 +108,7 @@ interface TabButtonProps {
 }
 
 export const TabButton = forwardRef(({
-    global,
+    size = 'default',
     id,
     panelId,
     children,
@@ -142,7 +143,7 @@ export const TabButton = forwardRef(({
                 onClick={onClick}
                 $removable={hasRemove}
                 $selected={isSelected}
-                $global={global}
+                $size={size}
             >
                 {leftIcon && (
                     <StyledButtonIcon

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -1,11 +1,11 @@
-import { forwardRef, KeyboardEvent, ReactElement, Ref } from 'react';
+import { forwardRef, ReactElement, Ref } from 'react';
 import styled, { css } from 'styled-components';
 import { IconButton } from '../buttons/icon-button';
 import { useDataAttributes } from '../../hooks/use-data-attributes';
 import { useTranslation } from '../../i18n/use-translation';
 import { focus } from '../../utils/css-state';
-import { Icon, IconName } from '../icon/icon';
-import { TabSize } from './tabs';
+import { Icon } from '../icon/icon';
+import { TabButtonProps, TabSize } from './types';
 
 const StyledButton = styled.button<{ $size?: TabSize; $selected?: boolean; $removable?: boolean; }>`
     align-items: center;
@@ -93,19 +93,6 @@ const ButtonLabel = styled.span`
         visibility: hidden;
     }
 `;
-
-interface TabButtonProps {
-    size?: TabSize;
-    id: string;
-    children: string;
-    panelId: string;
-    leftIcon?: IconName
-    rightIcon?: IconName;
-    isSelected: boolean;
-    onClick(): void;
-    onRemove?(): void;
-    onKeyDown?(event: KeyboardEvent<HTMLDivElement>): void;
-}
 
 export const TabButton = forwardRef(({
     size = 'default',

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -6,16 +6,14 @@ import { useTranslation } from '../../i18n/use-translation';
 import { focus } from '../../utils/css-state';
 import { Icon, IconName } from '../icon/icon';
 
-const selectedIndicatorPosition = (global: boolean | undefined): string => (global ? 'bottom: 0' : 'top: 0');
-
 const StyledButton = styled.button<{ $global?: boolean; $selected?: boolean; $removable?: boolean; }>`
     align-items: center;
     color: ${({ $selected, theme }) => ($selected ? theme.component['tab-button-selected-text-color'] : theme.component['tab-button-text-color'])};
     display: flex;
     font-family: var(--font-family);
-    font-size: 0.875rem;
+    font-size: ${({ $global }) => ($global ? '0.875rem' : '0.75rem')};
     gap: var(--spacing-half);
-    padding: 0 var(--spacing-2x);
+    padding: ${({ $global }) => ($global ? '0 var(--spacing-2x)' : '0 var(--spacing-1x)')};
     padding-right: ${({ $removable }) => ($removable && 'var(--spacing-4x)')};
     position: relative;
     user-select: none;
@@ -25,13 +23,13 @@ const StyledButton = styled.button<{ $global?: boolean; $selected?: boolean; $re
     }
 
     &::after {
+        bottom: 0;
         content: '';
         display: block;
-        height: 4px;
+        height: ${({ $global }) => ($global ? '0.25rem' : '0.125rem')};
         left: 0;
         position: absolute;
         width: 100%;
-        ${({ $global }) => selectedIndicatorPosition($global)};
     }
 
     ${({ theme }) => focus({ theme }, { focusType: 'focus-visible', insideOnly: true })};
@@ -47,8 +45,7 @@ const StyledButton = styled.button<{ $global?: boolean; $selected?: boolean; $re
         }
     `}
 
-    ${({ $global, $selected, theme }) => $selected && css`
-        background: ${$global ? theme.component['tab-global-button-selected-background-color'] : theme.component['tab-section-button-selected-background-color']};
+    ${({ $selected, theme }) => $selected && css`
         font-weight: var(--font-semi-bold);
 
         &::after {

--- a/packages/react/src/components/tabs/tab-button.tsx
+++ b/packages/react/src/components/tabs/tab-button.tsx
@@ -12,9 +12,9 @@ const StyledButton = styled.button<{ $size?: TabSize; $selected?: boolean; $remo
     color: ${({ $selected, theme }) => ($selected ? theme.component['tab-button-selected-text-color'] : theme.component['tab-button-text-color'])};
     display: flex;
     font-family: var(--font-family);
-    font-size: ${({ $size }) => ($size === 'default' ? '0.875rem' : '0.75rem')};
+    font-size: ${({ $size }) => ($size === 'medium' ? '0.875rem' : '0.75rem')};
     gap: var(--spacing-half);
-    padding: ${({ $size }) => ($size === 'default' ? '0 var(--spacing-2x)' : '0 var(--spacing-1x)')};
+    padding: ${({ $size }) => ($size === 'medium' ? '0 var(--spacing-2x)' : '0 var(--spacing-1x)')};
     padding-right: ${({ $removable }) => ($removable && 'var(--spacing-4x)')};
     position: relative;
     user-select: none;
@@ -27,7 +27,7 @@ const StyledButton = styled.button<{ $size?: TabSize; $selected?: boolean; $remo
         bottom: 0;
         content: '';
         display: block;
-        height: ${({ $size }) => ($size === 'default' ? '0.25rem' : '0.125rem')};
+        height: ${({ $size }) => ($size === 'medium' ? '0.25rem' : '0.125rem')};
         left: 0;
         position: absolute;
         width: 100%;
@@ -95,7 +95,7 @@ const ButtonLabel = styled.span`
 `;
 
 export const TabButton = forwardRef(({
-    size = 'default',
+    size,
     id,
     panelId,
     children,

--- a/packages/react/src/components/tabs/tab-panel.tsx
+++ b/packages/react/src/components/tabs/tab-panel.tsx
@@ -12,7 +12,7 @@ const StyledDiv = styled.div<{ $size?: TabSize }>`
 export const TabPanel: FunctionComponent<PropsWithChildren<TabPanelProps>> = ({
     buttonId,
     children,
-    size = 'default',
+    size,
     hidden,
     id,
 }) => (

--- a/packages/react/src/components/tabs/tab-panel.tsx
+++ b/packages/react/src/components/tabs/tab-panel.tsx
@@ -1,16 +1,17 @@
 import { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
 import styled from 'styled-components';
 import { focus } from '../../utils/css-state';
+import { TabSize } from './tabs';
 
 interface TabPanelProps {
     buttonId: string,
     children: ReactNode;
     hidden: boolean,
     id: string,
-    global?: boolean;
+    size?: TabSize;
 }
 
-const StyledDiv = styled.div<{ $isGlobal?: boolean; }>`
+const StyledDiv = styled.div<{ $size?: TabSize }>`
     border-top: none;
 
     ${({ theme }) => focus({ theme }, { focusType: 'focus-visible' })}
@@ -19,12 +20,12 @@ const StyledDiv = styled.div<{ $isGlobal?: boolean; }>`
 export const TabPanel: FunctionComponent<PropsWithChildren<TabPanelProps>> = ({
     buttonId,
     children,
-    global = false,
+    size = 'default',
     hidden,
     id,
 }) => (
     <StyledDiv
-        $isGlobal={global}
+        $size={size}
         aria-hidden={hidden}
         aria-labelledby={buttonId}
         hidden={hidden}

--- a/packages/react/src/components/tabs/tab-panel.tsx
+++ b/packages/react/src/components/tabs/tab-panel.tsx
@@ -1,15 +1,7 @@
-import { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
+import { FunctionComponent, PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import { focus } from '../../utils/css-state';
-import { TabSize } from './tabs';
-
-interface TabPanelProps {
-    buttonId: string,
-    children: ReactNode;
-    hidden: boolean,
-    id: string,
-    size?: TabSize;
-}
+import { TabSize, TabPanelProps } from './types';
 
 const StyledDiv = styled.div<{ $size?: TabSize }>`
     border-top: none;
@@ -32,7 +24,6 @@ export const TabPanel: FunctionComponent<PropsWithChildren<TabPanelProps>> = ({
         id={id}
         role="tabpanel"
         tabIndex={0}
-
     >
         {children}
     </StyledDiv>

--- a/packages/react/src/components/tabs/tabs-classes.ts
+++ b/packages/react/src/components/tabs/tabs-classes.ts
@@ -1,0 +1,16 @@
+import { generateComponentClasses } from '../../utils/generate-component-classes';
+
+const COMPONENT_NAME = 'Tabs';
+
+export interface TabsClasses {
+    tablistContainer: string;
+}
+
+export type TabsClassKeys = keyof TabsClasses;
+
+export const tabsClasses: TabsClasses = generateComponentClasses(
+    COMPONENT_NAME,
+    [
+        'tablistContainer',
+    ],
+);

--- a/packages/react/src/components/tabs/tabs.test.tsx
+++ b/packages/react/src/components/tabs/tabs.test.tsx
@@ -173,7 +173,7 @@ describe('Tabs', () => {
     test('has small styles', () => {
         const tabs: Tab[] = givenTabs(2);
 
-        const wrapper = renderWithProviders(
+        const { container } = renderWithProviders(
             <Tabs
                 tabs={tabs}
                 forceRenderTabPanels
@@ -181,7 +181,7 @@ describe('Tabs', () => {
             />,
         );
 
-        expect(wrapper).toMatchSnapshot();
+        expect(container.firstChild).toMatchSnapshot();
     });
 
     test('matches snapshot (mobile)', () => {

--- a/packages/react/src/components/tabs/tabs.test.tsx
+++ b/packages/react/src/components/tabs/tabs.test.tsx
@@ -170,12 +170,18 @@ describe('Tabs', () => {
         expect(container.firstChild).toMatchSnapshot();
     });
 
-    test('matches snapshot (global)', () => {
+    test('has small styles', () => {
         const tabs: Tab[] = givenTabs(2);
-
-        const { container } = renderWithProviders(<Tabs tabs={tabs} global forceRenderTabPanels />);
-
-        expect(container.firstChild).toMatchSnapshot();
+    
+        const wrapper = renderWithProviders(
+            <Tabs 
+                tabs={tabs} 
+                forceRenderTabPanels 
+                size="small"
+            />
+        );
+    
+        expect(wrapper).toMatchSnapshot();
     });
 
     test('matches snapshot (mobile)', () => {

--- a/packages/react/src/components/tabs/tabs.test.tsx
+++ b/packages/react/src/components/tabs/tabs.test.tsx
@@ -178,7 +178,7 @@ describe('Tabs', () => {
                 tabs={tabs}
                 forceRenderTabPanels
                 size="small"
-            />,
+            />
         );
 
         expect(wrapper).toMatchSnapshot();

--- a/packages/react/src/components/tabs/tabs.test.tsx
+++ b/packages/react/src/components/tabs/tabs.test.tsx
@@ -178,7 +178,7 @@ describe('Tabs', () => {
                 tabs={tabs}
                 forceRenderTabPanels
                 size="small"
-            />
+            />,
         );
 
         expect(wrapper).toMatchSnapshot();

--- a/packages/react/src/components/tabs/tabs.test.tsx
+++ b/packages/react/src/components/tabs/tabs.test.tsx
@@ -172,15 +172,15 @@ describe('Tabs', () => {
 
     test('has small styles', () => {
         const tabs: Tab[] = givenTabs(2);
-    
+
         const wrapper = renderWithProviders(
-            <Tabs 
-                tabs={tabs} 
-                forceRenderTabPanels 
+            <Tabs
+                tabs={tabs}
+                forceRenderTabPanels
                 size="small"
             />
         );
-    
+
         expect(wrapper).toMatchSnapshot();
     });
 

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Tabs has small styles 1`] = `
   outline-offset: -2px;
 }
 
-.c1:focus-visible {
+.c2:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
@@ -68,7 +68,7 @@ exports[`Tabs has small styles 1`] = `
   outline-offset: -2px;
 }
 
-.c2:focus-visible {
+.c3:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
@@ -327,7 +327,7 @@ exports[`Tabs has small styles 1`] = `
   outline-offset: -2px;
 }
 
-.c4:focus {
+.c4:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
@@ -372,7 +372,7 @@ exports[`Tabs has small styles 1`] = `
   outline-offset: -2px;
 }
 
-.c13:focus {
+.c13:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
@@ -552,7 +552,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   outline-offset: -2px;
 }
 
-.c2:focus {
+.c2:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
@@ -833,7 +833,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   outline-offset: -2px;
 }
 
-.c4:focus {
+.c4:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
@@ -878,7 +878,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   outline-offset: -2px;
 }
 
-.c13:focus {
+.c13:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
@@ -1339,7 +1339,7 @@ exports[`Tabs matches snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c4:focus {
+.c4:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
@@ -1384,7 +1384,7 @@ exports[`Tabs matches snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c13:focus {
+.c13:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tabs matches snapshot (global) 1`] = `
+exports[`Tabs has small styles 1`] = `
 .c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
@@ -89,7 +89,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   pointer-events: none;
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -100,9 +100,9 @@ exports[`Tabs matches snapshot (global) 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-1x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -111,36 +111,36 @@ exports[`Tabs matches snapshot (global) 1`] = `
   font-weight: var(--font-semi-bold);
 }
 
-.c7:hover {
+.c8:hover {
   color: #000000;
 }
 
-.c7::after {
+.c8::after {
   bottom: 0;
   content: '';
   display: block;
-  height: 0.25rem;
+  height: 0.125rem;
   left: 0;
   position: absolute;
   width: 100%;
 }
 
-.c7 {
+.c8 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c7:focus-visible {
+.c8:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c7::after {
+.c8::after {
   background-color: #006296;
 }
 
-.c10 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -151,9 +151,9 @@ exports[`Tabs matches snapshot (global) 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-1x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -161,41 +161,41 @@ exports[`Tabs matches snapshot (global) 1`] = `
   user-select: none;
 }
 
-.c10:hover {
+.c11:hover {
   color: #000000;
 }
 
-.c10::after {
+.c11::after {
   bottom: 0;
   content: '';
   display: block;
-  height: 0.25rem;
+  height: 0.125rem;
   left: 0;
   position: absolute;
   width: 100%;
 }
 
-.c10 {
+.c11 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c10:focus-visible {
+.c11:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c10:active {
+.c11:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c10:active::after {
+.c11:active::after {
   background-color: #012639 !important;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -203,7 +203,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   position: relative;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -211,12 +211,12 @@ exports[`Tabs matches snapshot (global) 1`] = `
   position: relative;
 }
 
-.c9:hover .c6::after {
+.c10:hover .c7::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c8::after {
+.c9::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -224,16 +224,16 @@ exports[`Tabs matches snapshot (global) 1`] = `
   visibility: hidden;
 }
 
-.c12 {
+.c13 {
   border-top: none;
 }
 
-.c12 {
+.c13 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c12:focus-visible {
+.c13:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
@@ -255,7 +255,11 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c4 {
-  background-color: #FFFFFF;
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -264,7 +268,6 @@ exports[`Tabs matches snapshot (global) 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 var(--spacing-2halfx);
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -277,7 +280,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: inherit;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -292,6 +295,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   min-height: auto;
   padding: 0 var(--spacing-1x);
   position: absolute;
+  width: var(--size-2x);
   z-index: 1;
   box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
   left: 0;
@@ -305,12 +309,12 @@ exports[`Tabs matches snapshot (global) 1`] = `
   display: none;
 }
 
-.c11 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: inherit;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -325,22 +329,23 @@ exports[`Tabs matches snapshot (global) 1`] = `
   min-height: auto;
   padding: 0 var(--spacing-1x);
   position: absolute;
+  width: var(--size-2x);
   z-index: 1;
   box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
   right: 0;
 }
 
-.c11:hover {
+.c12:hover {
   background: #DBDEE1;
 }
 
-.c11.hidden {
+.c12.hidden {
   display: none;
 }
 
 <div>
   <div
-    class="c0"
+    class="c0 eds-Tabs-tablistContainer"
   >
     <button
       aria-hidden="true"
@@ -356,59 +361,63 @@ exports[`Tabs matches snapshot (global) 1`] = `
       />
     </button>
     <div
-      aria-label="tabs label"
       class="c4"
-      role="tablist"
     >
       <div
+        aria-label="tabs label"
         class="c5"
-        data-testid="tab-1"
+        role="tablist"
       >
-        <button
-          aria-controls="tab-1-panel"
-          aria-selected="true"
-          class="c6 c7"
-          data-testid="tab-1-button"
-          id="tab-1"
-          role="tab"
-          type="button"
+        <div
+          class="c6"
+          data-testid="tab-1"
         >
-          <span
-            class="c8"
-            data-content="button 1"
-            data-testid="tab-1-text"
+          <button
+            aria-controls="uuid1"
+            aria-selected="true"
+            class="c7 c8"
+            data-testid="tab-1-button"
+            id="tab-1"
+            role="tab"
+            type="button"
           >
-            button 1
-          </span>
-        </button>
-      </div>
-      <div
-        class="c9"
-        data-testid="tab-2"
-      >
-        <button
-          aria-controls="tab-2-panel"
-          aria-selected="false"
-          class="c6 c10"
-          data-testid="tab-2-button"
-          id="tab-2"
-          role="tab"
-          tabindex="-1"
-          type="button"
+            <span
+              class="c9"
+              data-content="button 1"
+              data-testid="tab-1-text"
+            >
+              button 1
+            </span>
+          </button>
+        </div>
+        <div
+          class="c10"
+          data-testid="tab-2"
         >
-          <span
-            class="c8"
-            data-content="button 2"
-            data-testid="tab-2-text"
+          <button
+            aria-controls="uuid2"
+            aria-selected="false"
+            class="c7 c11"
+            data-testid="tab-2-button"
+            id="tab-2"
+            role="tab"
+            tabindex="-1"
+            type="button"
           >
-            button 2
-          </span>
-        </button>
+            <span
+              class="c9"
+              data-content="button 2"
+              data-testid="tab-2-text"
+            >
+              button 2
+            </span>
+          </button>
+        </div>
       </div>
     </div>
     <button
       aria-hidden="true"
-      class="c1 c2 c11 hidden"
+      class="c1 c2 c12 hidden"
       type="button"
     >
       <svg
@@ -423,8 +432,8 @@ exports[`Tabs matches snapshot (global) 1`] = `
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c12"
-    id="tab-1-panel"
+    class="c13"
+    id="uuid1"
     role="tabpanel"
     tabindex="0"
   >
@@ -437,7 +446,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c12"
+    class="c13"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"
@@ -541,7 +550,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   pointer-events: none;
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -552,9 +561,9 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-1x);
+  padding: 0 var(--spacing-2x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -563,36 +572,36 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   font-weight: var(--font-semi-bold);
 }
 
-.c7:hover {
+.c8:hover {
   color: #000000;
 }
 
-.c7::after {
+.c8::after {
   bottom: 0;
   content: '';
   display: block;
-  height: 0.125rem;
+  height: 0.25rem;
   left: 0;
   position: absolute;
   width: 100%;
 }
 
-.c7 {
+.c8 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c7:focus-visible {
+.c8:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c7::after {
+.c8::after {
   background-color: #006296;
 }
 
-.c10 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -603,9 +612,9 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-1x);
+  padding: 0 var(--spacing-2x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -613,41 +622,41 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   user-select: none;
 }
 
-.c10:hover {
+.c11:hover {
   color: #000000;
 }
 
-.c10::after {
+.c11::after {
   bottom: 0;
   content: '';
   display: block;
-  height: 0.125rem;
+  height: 0.25rem;
   left: 0;
   position: absolute;
   width: 100%;
 }
 
-.c10 {
+.c11 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c10:focus-visible {
+.c11:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c10:active {
+.c11:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c10:active::after {
+.c11:active::after {
   background-color: #012639 !important;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -655,7 +664,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   position: relative;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -663,12 +672,12 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   position: relative;
 }
 
-.c9:hover .c6::after {
+.c10:hover .c7::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c8::after {
+.c9::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -676,16 +685,16 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   visibility: hidden;
 }
 
-.c12 {
+.c13 {
   border-top: none;
 }
 
-.c12 {
+.c13 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c12:focus-visible {
+.c13:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
@@ -707,7 +716,11 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 }
 
 .c4 {
-  background-color: #FFFFFF;
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -716,7 +729,6 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 var(--spacing-2halfx);
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -729,7 +741,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: inherit;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -744,6 +756,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   min-height: auto;
   padding: 0 var(--spacing-1x);
   position: absolute;
+  width: var(--size-2x);
   z-index: 1;
   box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
   left: 0;
@@ -757,12 +770,12 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: none;
 }
 
-.c11 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: inherit;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -777,22 +790,23 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   min-height: auto;
   padding: 0 var(--spacing-1x);
   position: absolute;
+  width: var(--size-2x);
   z-index: 1;
   box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
   right: 0;
 }
 
-.c11:hover {
+.c12:hover {
   background: #DBDEE1;
 }
 
-.c11.hidden {
+.c12.hidden {
   display: none;
 }
 
 <div>
   <div
-    class="c0"
+    class="c0 eds-Tabs-tablistContainer"
   >
     <button
       aria-hidden="true"
@@ -808,59 +822,63 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
       />
     </button>
     <div
-      aria-label="tabs label"
       class="c4"
-      role="tablist"
     >
       <div
+        aria-label="tabs label"
         class="c5"
-        data-testid="tab-1"
+        role="tablist"
       >
-        <button
-          aria-controls="tab-1-panel"
-          aria-selected="true"
-          class="c6 c7"
-          data-testid="tab-1-button"
-          id="tab-1"
-          role="tab"
-          type="button"
+        <div
+          class="c6"
+          data-testid="tab-1"
         >
-          <span
-            class="c8"
-            data-content="button 1"
-            data-testid="tab-1-text"
+          <button
+            aria-controls="uuid1"
+            aria-selected="true"
+            class="c7 c8"
+            data-testid="tab-1-button"
+            id="tab-1"
+            role="tab"
+            type="button"
           >
-            button 1
-          </span>
-        </button>
-      </div>
-      <div
-        class="c9"
-        data-testid="tab-2"
-      >
-        <button
-          aria-controls="tab-2-panel"
-          aria-selected="false"
-          class="c6 c10"
-          data-testid="tab-2-button"
-          id="tab-2"
-          role="tab"
-          tabindex="-1"
-          type="button"
+            <span
+              class="c9"
+              data-content="button 1"
+              data-testid="tab-1-text"
+            >
+              button 1
+            </span>
+          </button>
+        </div>
+        <div
+          class="c10"
+          data-testid="tab-2"
         >
-          <span
-            class="c8"
-            data-content="button 2"
-            data-testid="tab-2-text"
+          <button
+            aria-controls="uuid2"
+            aria-selected="false"
+            class="c7 c11"
+            data-testid="tab-2-button"
+            id="tab-2"
+            role="tab"
+            tabindex="-1"
+            type="button"
           >
-            button 2
-          </span>
-        </button>
+            <span
+              class="c9"
+              data-content="button 2"
+              data-testid="tab-2-text"
+            >
+              button 2
+            </span>
+          </button>
+        </div>
       </div>
     </div>
     <button
       aria-hidden="true"
-      class="c1 c2 c11 hidden"
+      class="c1 c2 c12 hidden"
       type="button"
     >
       <svg
@@ -875,7 +893,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c12"
+    class="c13"
     id="uuid1"
     role="tabpanel"
     tabindex="0"
@@ -889,7 +907,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c12"
+    class="c13"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"
@@ -993,7 +1011,7 @@ exports[`Tabs matches snapshot 1`] = `
   pointer-events: none;
 }
 
-.c7 {
+.c8 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1004,9 +1022,9 @@ exports[`Tabs matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-1x);
+  padding: 0 var(--spacing-2x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1015,36 +1033,36 @@ exports[`Tabs matches snapshot 1`] = `
   font-weight: var(--font-semi-bold);
 }
 
-.c7:hover {
+.c8:hover {
   color: #000000;
 }
 
-.c7::after {
+.c8::after {
   bottom: 0;
   content: '';
   display: block;
-  height: 0.125rem;
+  height: 0.25rem;
   left: 0;
   position: absolute;
   width: 100%;
 }
 
-.c7 {
+.c8 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c7:focus-visible {
+.c8:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c7::after {
+.c8::after {
   background-color: #006296;
 }
 
-.c10 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1055,9 +1073,9 @@ exports[`Tabs matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-1x);
+  padding: 0 var(--spacing-2x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1065,41 +1083,41 @@ exports[`Tabs matches snapshot 1`] = `
   user-select: none;
 }
 
-.c10:hover {
+.c11:hover {
   color: #000000;
 }
 
-.c10::after {
+.c11::after {
   bottom: 0;
   content: '';
   display: block;
-  height: 0.125rem;
+  height: 0.25rem;
   left: 0;
   position: absolute;
   width: 100%;
 }
 
-.c10 {
+.c11 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c10:focus-visible {
+.c11:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c10:active {
+.c11:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c10:active::after {
+.c11:active::after {
   background-color: #012639 !important;
 }
 
-.c5 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1107,7 +1125,7 @@ exports[`Tabs matches snapshot 1`] = `
   position: relative;
 }
 
-.c9 {
+.c10 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1115,12 +1133,12 @@ exports[`Tabs matches snapshot 1`] = `
   position: relative;
 }
 
-.c9:hover .c6::after {
+.c10:hover .c7::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c8::after {
+.c9::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -1128,16 +1146,16 @@ exports[`Tabs matches snapshot 1`] = `
   visibility: hidden;
 }
 
-.c12 {
+.c13 {
   border-top: none;
 }
 
-.c12 {
+.c13 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c12:focus-visible {
+.c13:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
@@ -1159,7 +1177,11 @@ exports[`Tabs matches snapshot 1`] = `
 }
 
 .c4 {
-  background-color: #FFFFFF;
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+}
+
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1168,7 +1190,6 @@ exports[`Tabs matches snapshot 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 var(--spacing-2halfx);
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -1181,7 +1202,7 @@ exports[`Tabs matches snapshot 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: inherit;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -1196,6 +1217,7 @@ exports[`Tabs matches snapshot 1`] = `
   min-height: auto;
   padding: 0 var(--spacing-1x);
   position: absolute;
+  width: var(--size-2x);
   z-index: 1;
   box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
   left: 0;
@@ -1209,12 +1231,12 @@ exports[`Tabs matches snapshot 1`] = `
   display: none;
 }
 
-.c11 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: #FFFFFF;
+  background-color: inherit;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -1229,22 +1251,23 @@ exports[`Tabs matches snapshot 1`] = `
   min-height: auto;
   padding: 0 var(--spacing-1x);
   position: absolute;
+  width: var(--size-2x);
   z-index: 1;
   box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
   right: 0;
 }
 
-.c11:hover {
+.c12:hover {
   background: #DBDEE1;
 }
 
-.c11.hidden {
+.c12.hidden {
   display: none;
 }
 
 <div>
   <div
-    class="c0"
+    class="c0 eds-Tabs-tablistContainer"
   >
     <button
       aria-hidden="true"
@@ -1260,59 +1283,63 @@ exports[`Tabs matches snapshot 1`] = `
       />
     </button>
     <div
-      aria-label="tabs label"
       class="c4"
-      role="tablist"
     >
       <div
+        aria-label="tabs label"
         class="c5"
-        data-testid="tab-1"
+        role="tablist"
       >
-        <button
-          aria-controls="tab-1-panel"
-          aria-selected="true"
-          class="c6 c7"
-          data-testid="tab-1-button"
-          id="tab-1"
-          role="tab"
-          type="button"
+        <div
+          class="c6"
+          data-testid="tab-1"
         >
-          <span
-            class="c8"
-            data-content="button 1"
-            data-testid="tab-1-text"
+          <button
+            aria-controls="uuid1"
+            aria-selected="true"
+            class="c7 c8"
+            data-testid="tab-1-button"
+            id="tab-1"
+            role="tab"
+            type="button"
           >
-            button 1
-          </span>
-        </button>
-      </div>
-      <div
-        class="c9"
-        data-testid="tab-2"
-      >
-        <button
-          aria-controls="tab-2-panel"
-          aria-selected="false"
-          class="c6 c10"
-          data-testid="tab-2-button"
-          id="tab-2"
-          role="tab"
-          tabindex="-1"
-          type="button"
+            <span
+              class="c9"
+              data-content="button 1"
+              data-testid="tab-1-text"
+            >
+              button 1
+            </span>
+          </button>
+        </div>
+        <div
+          class="c10"
+          data-testid="tab-2"
         >
-          <span
-            class="c8"
-            data-content="button 2"
-            data-testid="tab-2-text"
+          <button
+            aria-controls="uuid2"
+            aria-selected="false"
+            class="c7 c11"
+            data-testid="tab-2-button"
+            id="tab-2"
+            role="tab"
+            tabindex="-1"
+            type="button"
           >
-            button 2
-          </span>
-        </button>
+            <span
+              class="c9"
+              data-content="button 2"
+              data-testid="tab-2-text"
+            >
+              button 2
+            </span>
+          </button>
+        </div>
       </div>
     </div>
     <button
       aria-hidden="true"
-      class="c1 c2 c11 hidden"
+      class="c1 c2 c12 hidden"
       type="button"
     >
       <svg
@@ -1327,7 +1354,7 @@ exports[`Tabs matches snapshot 1`] = `
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c12"
+    class="c13"
     id="uuid1"
     role="tabpanel"
     tabindex="0"
@@ -1341,7 +1368,7 @@ exports[`Tabs matches snapshot 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c12"
+    class="c13"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -241,7 +241,7 @@ exports[`Tabs has small styles 1`] = `
 
 .c0 {
   display: grid;
-  grid-template-areas: "tabs addButton";
+  grid-template-areas: 'tabs addButton';
   grid-template-columns: auto 1fr;
   position: relative;
   width: 100%;
@@ -264,8 +264,8 @@ exports[`Tabs has small styles 1`] = `
   display: flex;
   grid-area: tabs;
   height: var(--size-2halfx);
-  position: relative;
   overflow: hidden;
+  position: relative;
 }
 
 .c5 {
@@ -746,7 +746,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 
 .c0 {
   display: grid;
-  grid-template-areas: "tabs addButton";
+  grid-template-areas: 'tabs addButton';
   grid-template-columns: auto 1fr;
   position: relative;
   width: 100%;
@@ -769,8 +769,8 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: flex;
   grid-area: tabs;
   height: var(--size-2halfx);
-  position: relative;
   overflow: hidden;
+  position: relative;
 }
 
 .c5 {
@@ -1251,7 +1251,7 @@ exports[`Tabs matches snapshot 1`] = `
 
 .c0 {
   display: grid;
-  grid-template-areas: "tabs addButton";
+  grid-template-areas: 'tabs addButton';
   grid-template-columns: auto 1fr;
   position: relative;
   width: 100%;
@@ -1274,8 +1274,8 @@ exports[`Tabs matches snapshot 1`] = `
   display: flex;
   grid-area: tabs;
   height: var(--size-2halfx);
-  position: relative;
   overflow: hidden;
+  position: relative;
 }
 
 .c5 {

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -240,9 +240,10 @@ exports[`Tabs has small styles 1`] = `
 }
 
 .c0 {
-  display: grid;
-  grid-template-areas: 'tabs addButton';
-  grid-template-columns: auto 1fr;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   width: 100%;
 }
@@ -745,9 +746,10 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 }
 
 .c0 {
-  display: grid;
-  grid-template-areas: 'tabs addButton';
-  grid-template-columns: auto 1fr;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   width: 100%;
 }
@@ -1250,9 +1252,10 @@ exports[`Tabs matches snapshot 1`] = `
 }
 
 .c0 {
-  display: grid;
-  grid-template-areas: 'tabs addButton';
-  grid-template-columns: auto 1fr;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   position: relative;
   width: 100%;
 }

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -108,7 +108,6 @@ exports[`Tabs matches snapshot (global) 1`] = `
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  background: transparent;
   font-weight: var(--font-semi-bold);
 }
 
@@ -117,13 +116,13 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c7::after {
+  bottom: 0;
   content: '';
   display: block;
-  height: 4px;
+  height: 0.25rem;
   left: 0;
   position: absolute;
   width: 100%;
-  bottom: 0;
 }
 
 .c7 {
@@ -167,13 +166,13 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c10::after {
+  bottom: 0;
   content: '';
   display: block;
-  height: 4px;
+  height: 0.25rem;
   left: 0;
   position: absolute;
   width: 100%;
-  bottom: 0;
 }
 
 .c10 {
@@ -241,10 +240,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c0 {
-  background: #FFFFFF;
-  box-sizing: content-box;
   height: var(--size-2halfx);
-  padding-top: var(--spacing-2x);
   position: relative;
 }
 
@@ -259,6 +255,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
 }
 
 .c4 {
+  background-color: #FFFFFF;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -267,6 +264,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
+  padding: 0 var(--spacing-2halfx);
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -279,7 +277,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -287,13 +285,16 @@ exports[`Tabs matches snapshot (global) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-2halfx);
   min-height: auto;
+  padding: 0 var(--spacing-1x);
   position: absolute;
   z-index: 1;
   box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
   left: 0;
-  padding: 0 var(--spacing-1x) 0 var(--spacing-2x);
 }
 
 .c3:hover {
@@ -309,7 +310,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #FFFFFF;
+  background-color: #FFFFFF;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -317,12 +318,15 @@ exports[`Tabs matches snapshot (global) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-2halfx);
   min-height: auto;
+  padding: 0 var(--spacing-1x);
   position: absolute;
   z-index: 1;
   box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
-  padding: 0 var(--spacing-2x) 0 var(--spacing-1x);
   right: 0;
 }
 
@@ -334,9 +338,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
   display: none;
 }
 
-<div
-  class=""
->
+<div>
   <div
     class="c0"
   >
@@ -451,7 +453,7 @@ exports[`Tabs matches snapshot (global) 1`] = `
 `;
 
 exports[`Tabs matches snapshot (mobile) 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -491,29 +493,29 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   user-select: none;
 }
 
-.c2 {
+.c1 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c2:focus-visible {
+.c1:focus {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
-.c2 > svg {
+.c1 > svg {
   height: var(--size-1halfx);
   width: var(--size-1halfx);
 }
 
-.c3 {
+.c2 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
 }
 
-.c3 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -524,14 +526,14 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   outline-offset: -2px;
 }
 
-.c3:hover,
-.c3[aria-expanded='true'] {
+.c2:hover,
+.c2[aria-expanded='true'] {
   background-color: rgb(0 0 0 / 0.15);
   border-color: transparent;
   color: #000000;
 }
 
-.c3[aria-disabled='true'] {
+.c2[aria-disabled='true'] {
   background-color: transparent;
   border-color: transparent;
   color: #B7BBC2;
@@ -539,7 +541,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   pointer-events: none;
 }
 
-.c8 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -550,48 +552,47 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-1x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  background: #FFFFFF;
   font-weight: var(--font-semi-bold);
 }
 
-.c8:hover {
+.c7:hover {
   color: #000000;
 }
 
-.c8::after {
+.c7::after {
+  bottom: 0;
   content: '';
   display: block;
-  height: 4px;
+  height: 0.125rem;
   left: 0;
   position: absolute;
   width: 100%;
-  top: 0;
 }
 
-.c8 {
+.c7 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c8:focus-visible {
+.c7:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c8::after {
+.c7::after {
   background-color: #006296;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -602,9 +603,9 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-1x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -612,41 +613,41 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   user-select: none;
 }
 
-.c11:hover {
+.c10:hover {
   color: #000000;
 }
 
-.c11::after {
+.c10::after {
+  bottom: 0;
   content: '';
   display: block;
-  height: 4px;
+  height: 0.125rem;
   left: 0;
   position: absolute;
   width: 100%;
-  top: 0;
 }
 
-.c11 {
+.c10 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c11:focus-visible {
+.c10:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c11:active {
+.c10:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c11:active::after {
+.c10:active::after {
   background-color: #012639 !important;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -654,7 +655,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   position: relative;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -662,12 +663,12 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   position: relative;
 }
 
-.c10:hover .c7::after {
+.c9:hover .c6::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c9::after {
+.c8::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -675,37 +676,27 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   visibility: hidden;
 }
 
-.c13 {
+.c12 {
   border-top: none;
 }
 
-.c13 {
+.c12 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c13:focus-visible {
+.c12:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
 .c0 {
-  background: #FFFFFF;
-  border: 1px solid #DBDEE1;
-  border-radius: var(--border-radius-2x);
-  box-shadow: 0 1px 4px 0 rgb(0 0 0 / 0.2);
-}
-
-.c1 {
-  background: #F1F2F2;
-  border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
-  box-sizing: content-box;
   height: var(--size-2halfx);
   position: relative;
 }
 
-.c1::before {
+.c0::before {
   border-bottom: 1px solid #DBDEE1;
   bottom: 0;
   content: '';
@@ -715,8 +706,8 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   width: 100%;
 }
 
-.c5 {
-  border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+.c4 {
+  background-color: #FFFFFF;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -725,7 +716,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-2halfx);
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -733,12 +724,12 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   white-space: nowrap;
 }
 
-.c4 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #F1F2F2;
+  background-color: #FFFFFF;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -746,30 +737,32 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-2halfx);
   min-height: auto;
+  padding: 0 var(--spacing-1x);
   position: absolute;
   z-index: 1;
   box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
   left: 0;
-  padding: 0 var(--spacing-1x) 0 var(--spacing-2x);
-  border-radius: var(--border-radius-2x) 0 0 0;
 }
 
-.c4:hover {
+.c3:hover {
   background: #DBDEE1;
 }
 
-.c4.hidden {
+.c3.hidden {
   display: none;
 }
 
-.c12 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #F1F2F2;
+  background-color: #FFFFFF;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -777,33 +770,33 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-2halfx);
   min-height: auto;
+  padding: 0 var(--spacing-1x);
   position: absolute;
   z-index: 1;
   box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
-  padding: 0 var(--spacing-2x) 0 var(--spacing-1x);
   right: 0;
-  border-radius: 0 var(--border-radius-2x) 0 0;
 }
 
-.c12:hover {
+.c11:hover {
   background: #DBDEE1;
 }
 
-.c12.hidden {
+.c11.hidden {
   display: none;
 }
 
-<div
-  class="c0"
->
+<div>
   <div
-    class="c1"
+    class="c0"
   >
     <button
       aria-hidden="true"
-      class="c2 c3 c4 hidden"
+      class="c1 c2 c3 hidden"
       type="button"
     >
       <svg
@@ -816,24 +809,24 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
     </button>
     <div
       aria-label="tabs label"
-      class="c5"
+      class="c4"
       role="tablist"
     >
       <div
-        class="c6"
+        class="c5"
         data-testid="tab-1"
       >
         <button
           aria-controls="tab-1-panel"
           aria-selected="true"
-          class="c7 c8"
+          class="c6 c7"
           data-testid="tab-1-button"
           id="tab-1"
           role="tab"
           type="button"
         >
           <span
-            class="c9"
+            class="c8"
             data-content="button 1"
             data-testid="tab-1-text"
           >
@@ -842,13 +835,13 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
         </button>
       </div>
       <div
-        class="c10"
+        class="c9"
         data-testid="tab-2"
       >
         <button
           aria-controls="tab-2-panel"
           aria-selected="false"
-          class="c7 c11"
+          class="c6 c10"
           data-testid="tab-2-button"
           id="tab-2"
           role="tab"
@@ -856,7 +849,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
           type="button"
         >
           <span
-            class="c9"
+            class="c8"
             data-content="button 2"
             data-testid="tab-2-text"
           >
@@ -867,7 +860,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
     </div>
     <button
       aria-hidden="true"
-      class="c2 c3 c12 hidden"
+      class="c1 c2 c11 hidden"
       type="button"
     >
       <svg
@@ -882,8 +875,8 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c13"
-    id="tab-1-panel"
+    class="c12"
+    id="uuid1"
     role="tabpanel"
     tabindex="0"
   >
@@ -896,7 +889,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c13"
+    class="c12"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"
@@ -912,7 +905,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 `;
 
 exports[`Tabs matches snapshot 1`] = `
-.c2 {
+.c1 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -952,7 +945,7 @@ exports[`Tabs matches snapshot 1`] = `
   user-select: none;
 }
 
-.c2 {
+.c1 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -963,18 +956,18 @@ exports[`Tabs matches snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c2 > svg {
+.c1 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
 
-.c3 {
+.c2 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
 }
 
-.c3 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -985,14 +978,14 @@ exports[`Tabs matches snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c3:hover,
-.c3[aria-expanded='true'] {
+.c2:hover,
+.c2[aria-expanded='true'] {
   background-color: rgb(0 0 0 / 0.15);
   border-color: transparent;
   color: #000000;
 }
 
-.c3[aria-disabled='true'] {
+.c2[aria-disabled='true'] {
   background-color: transparent;
   border-color: transparent;
   color: #B7BBC2;
@@ -1000,7 +993,7 @@ exports[`Tabs matches snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 {
+.c7 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1011,48 +1004,47 @@ exports[`Tabs matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-1x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
-  background: #FFFFFF;
   font-weight: var(--font-semi-bold);
 }
 
-.c8:hover {
+.c7:hover {
   color: #000000;
 }
 
-.c8::after {
+.c7::after {
+  bottom: 0;
   content: '';
   display: block;
-  height: 4px;
+  height: 0.125rem;
   left: 0;
   position: absolute;
   width: 100%;
-  top: 0;
 }
 
-.c8 {
+.c7 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c8:focus-visible {
+.c7:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c8::after {
+.c7::after {
   background-color: #006296;
 }
 
-.c11 {
+.c10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1063,9 +1055,9 @@ exports[`Tabs matches snapshot 1`] = `
   display: -ms-flexbox;
   display: flex;
   font-family: var(--font-family);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
   gap: var(--spacing-half);
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-1x);
   position: relative;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -1073,41 +1065,41 @@ exports[`Tabs matches snapshot 1`] = `
   user-select: none;
 }
 
-.c11:hover {
+.c10:hover {
   color: #000000;
 }
 
-.c11::after {
+.c10::after {
+  bottom: 0;
   content: '';
   display: block;
-  height: 4px;
+  height: 0.125rem;
   left: 0;
   position: absolute;
   width: 100%;
-  top: 0;
 }
 
-.c11 {
+.c10 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c11:focus-visible {
+.c10:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c11:active {
+.c10:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c11:active::after {
+.c10:active::after {
   background-color: #012639 !important;
 }
 
-.c6 {
+.c5 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1115,7 +1107,7 @@ exports[`Tabs matches snapshot 1`] = `
   position: relative;
 }
 
-.c10 {
+.c9 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1123,12 +1115,12 @@ exports[`Tabs matches snapshot 1`] = `
   position: relative;
 }
 
-.c10:hover .c7::after {
+.c9:hover .c6::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c9::after {
+.c8::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -1136,37 +1128,27 @@ exports[`Tabs matches snapshot 1`] = `
   visibility: hidden;
 }
 
-.c13 {
+.c12 {
   border-top: none;
 }
 
-.c13 {
+.c12 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c13:focus-visible {
+.c12:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
 .c0 {
-  background: #FFFFFF;
-  border: 1px solid #DBDEE1;
-  border-radius: var(--border-radius-2x);
-  box-shadow: 0 1px 4px 0 rgb(0 0 0 / 0.2);
-}
-
-.c1 {
-  background: #F1F2F2;
-  border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
-  box-sizing: content-box;
   height: var(--size-2halfx);
   position: relative;
 }
 
-.c1::before {
+.c0::before {
   border-bottom: 1px solid #DBDEE1;
   bottom: 0;
   content: '';
@@ -1176,8 +1158,8 @@ exports[`Tabs matches snapshot 1`] = `
   width: 100%;
 }
 
-.c5 {
-  border-radius: var(--border-radius-2x) var(--border-radius-2x) 0 0;
+.c4 {
+  background-color: #FFFFFF;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1186,7 +1168,7 @@ exports[`Tabs matches snapshot 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
-  padding: 0 var(--spacing-2x);
+  padding: 0 var(--spacing-2halfx);
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -1194,12 +1176,12 @@ exports[`Tabs matches snapshot 1`] = `
   white-space: nowrap;
 }
 
-.c4 {
+.c3 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #F1F2F2;
+  background-color: #FFFFFF;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -1207,30 +1189,32 @@ exports[`Tabs matches snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-2halfx);
   min-height: auto;
+  padding: 0 var(--spacing-1x);
   position: absolute;
   z-index: 1;
   box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
   left: 0;
-  padding: 0 var(--spacing-1x) 0 var(--spacing-2x);
-  border-radius: var(--border-radius-2x) 0 0 0;
 }
 
-.c4:hover {
+.c3:hover {
   background: #DBDEE1;
 }
 
-.c4.hidden {
+.c3.hidden {
   display: none;
 }
 
-.c12 {
+.c11 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background: #F1F2F2;
+  background-color: #FFFFFF;
   border-bottom: 1px solid #DBDEE1;
   border-radius: 0;
   bottom: 0;
@@ -1238,33 +1222,33 @@ exports[`Tabs matches snapshot 1`] = `
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
   display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
   height: var(--size-2halfx);
   min-height: auto;
+  padding: 0 var(--spacing-1x);
   position: absolute;
   z-index: 1;
   box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
-  padding: 0 var(--spacing-2x) 0 var(--spacing-1x);
   right: 0;
-  border-radius: 0 var(--border-radius-2x) 0 0;
 }
 
-.c12:hover {
+.c11:hover {
   background: #DBDEE1;
 }
 
-.c12.hidden {
+.c11.hidden {
   display: none;
 }
 
-<div
-  class="c0"
->
+<div>
   <div
-    class="c1"
+    class="c0"
   >
     <button
       aria-hidden="true"
-      class="c2 c3 c4 hidden"
+      class="c1 c2 c3 hidden"
       type="button"
     >
       <svg
@@ -1277,24 +1261,24 @@ exports[`Tabs matches snapshot 1`] = `
     </button>
     <div
       aria-label="tabs label"
-      class="c5"
+      class="c4"
       role="tablist"
     >
       <div
-        class="c6"
+        class="c5"
         data-testid="tab-1"
       >
         <button
           aria-controls="tab-1-panel"
           aria-selected="true"
-          class="c7 c8"
+          class="c6 c7"
           data-testid="tab-1-button"
           id="tab-1"
           role="tab"
           type="button"
         >
           <span
-            class="c9"
+            class="c8"
             data-content="button 1"
             data-testid="tab-1-text"
           >
@@ -1303,13 +1287,13 @@ exports[`Tabs matches snapshot 1`] = `
         </button>
       </div>
       <div
-        class="c10"
+        class="c9"
         data-testid="tab-2"
       >
         <button
           aria-controls="tab-2-panel"
           aria-selected="false"
-          class="c7 c11"
+          class="c6 c10"
           data-testid="tab-2-button"
           id="tab-2"
           role="tab"
@@ -1317,7 +1301,7 @@ exports[`Tabs matches snapshot 1`] = `
           type="button"
         >
           <span
-            class="c9"
+            class="c8"
             data-content="button 2"
             data-testid="tab-2-text"
           >
@@ -1328,7 +1312,7 @@ exports[`Tabs matches snapshot 1`] = `
     </div>
     <button
       aria-hidden="true"
-      class="c2 c3 c12 hidden"
+      class="c1 c2 c11 hidden"
       type="button"
     >
       <svg
@@ -1343,8 +1327,8 @@ exports[`Tabs matches snapshot 1`] = `
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c13"
-    id="tab-1-panel"
+    class="c12"
+    id="uuid1"
     role="tabpanel"
     tabindex="0"
   >
@@ -1357,7 +1341,7 @@ exports[`Tabs matches snapshot 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c13"
+    class="c12"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs has small styles 1`] = `
-.c1 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -41,7 +41,7 @@ exports[`Tabs has small styles 1`] = `
   user-select: none;
 }
 
-.c1 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -52,18 +52,18 @@ exports[`Tabs has small styles 1`] = `
   outline-offset: -2px;
 }
 
-.c1 > svg {
+.c2 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
 }
 
-.c2 {
+.c3 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -74,14 +74,14 @@ exports[`Tabs has small styles 1`] = `
   outline-offset: -2px;
 }
 
-.c2:hover,
-.c2[aria-expanded='true'] {
+.c3:hover,
+.c3[aria-expanded='true'] {
   background-color: rgb(0 0 0 / 0.15);
   border-color: transparent;
   color: #000000;
 }
 
-.c2[aria-disabled='true'] {
+.c3[aria-disabled='true'] {
   background-color: transparent;
   border-color: transparent;
   color: #B7BBC2;
@@ -89,7 +89,7 @@ exports[`Tabs has small styles 1`] = `
   pointer-events: none;
 }
 
-.c8 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -111,11 +111,11 @@ exports[`Tabs has small styles 1`] = `
   font-weight: var(--font-semi-bold);
 }
 
-.c8:hover {
+.c9:hover {
   color: #000000;
 }
 
-.c8::after {
+.c9::after {
   bottom: 0;
   content: '';
   display: block;
@@ -125,22 +125,22 @@ exports[`Tabs has small styles 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c9 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c8:focus-visible {
+.c9:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c8::after {
+.c9::after {
   background-color: #006296;
 }
 
-.c11 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -161,11 +161,11 @@ exports[`Tabs has small styles 1`] = `
   user-select: none;
 }
 
-.c11:hover {
+.c12:hover {
   color: #000000;
 }
 
-.c11::after {
+.c12::after {
   bottom: 0;
   content: '';
   display: block;
@@ -175,27 +175,27 @@ exports[`Tabs has small styles 1`] = `
   width: 100%;
 }
 
-.c11 {
+.c12 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c11:focus-visible {
+.c12:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c11:active {
+.c12:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c11:active::after {
+.c12:active::after {
   background-color: #012639 !important;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -203,7 +203,7 @@ exports[`Tabs has small styles 1`] = `
   position: relative;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -211,12 +211,12 @@ exports[`Tabs has small styles 1`] = `
   position: relative;
 }
 
-.c10:hover .c7::after {
+.c11:hover .c8::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c9::after {
+.c10::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -224,24 +224,27 @@ exports[`Tabs has small styles 1`] = `
   visibility: hidden;
 }
 
-.c13 {
+.c14 {
   border-top: none;
 }
 
-.c13 {
+.c14 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c13:focus-visible {
+.c14:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
 .c0 {
-  height: var(--size-2halfx);
+  display: grid;
+  grid-template-areas: "tabs addButton";
+  grid-template-columns: auto 1fr;
   position: relative;
+  width: 100%;
 }
 
 .c0::before {
@@ -254,12 +257,24 @@ exports[`Tabs has small styles 1`] = `
   width: 100%;
 }
 
-.c4 {
-  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
-  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: tabs;
+  height: var(--size-2halfx);
+  position: relative;
+  overflow: hidden;
 }
 
 .c5 {
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  overflow: hidden;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -268,6 +283,7 @@ exports[`Tabs has small styles 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
+  position: relative;
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -275,7 +291,7 @@ exports[`Tabs has small styles 1`] = `
   white-space: nowrap;
 }
 
-.c3 {
+.c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -301,15 +317,26 @@ exports[`Tabs has small styles 1`] = `
   left: 0;
 }
 
-.c3:hover {
+.c4:hover {
   background: #DBDEE1;
 }
 
-.c3.hidden {
+.c4 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c4.hidden {
   display: none;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -335,104 +362,121 @@ exports[`Tabs has small styles 1`] = `
   right: 0;
 }
 
-.c12:hover {
+.c13:hover {
   background: #DBDEE1;
 }
 
-.c12.hidden {
+.c13 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c13:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c13.hidden {
   display: none;
 }
 
 <div>
   <div
-    class="c0 eds-Tabs-tablistContainer"
+    class="c0"
   >
-    <button
-      aria-hidden="true"
-      class="c1 c2 c3 hidden"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
     <div
-      class="c4"
+      class="c1 eds-Tabs-tablistContainer"
     >
+      <button
+        aria-hidden="true"
+        class="c2 c3 c4 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
       <div
-        aria-label="tabs label"
         class="c5"
-        role="tablist"
       >
         <div
+          aria-label="tabs label"
           class="c6"
-          data-testid="tab-1"
+          role="tablist"
         >
-          <button
-            aria-controls="uuid1"
-            aria-selected="true"
-            class="c7 c8"
-            data-testid="tab-1-button"
-            id="tab-1"
-            role="tab"
-            type="button"
+          <div
+            class="c7"
+            data-testid="tab-1"
           >
-            <span
-              class="c9"
-              data-content="button 1"
-              data-testid="tab-1-text"
+            <button
+              aria-controls="uuid1"
+              aria-selected="true"
+              class="c8 c9"
+              data-testid="tab-1-button"
+              id="tab-1"
+              role="tab"
+              type="button"
             >
-              button 1
-            </span>
-          </button>
-        </div>
-        <div
-          class="c10"
-          data-testid="tab-2"
-        >
-          <button
-            aria-controls="uuid2"
-            aria-selected="false"
-            class="c7 c11"
-            data-testid="tab-2-button"
-            id="tab-2"
-            role="tab"
-            tabindex="-1"
-            type="button"
+              <span
+                class="c10"
+                data-content="button 1"
+                data-testid="tab-1-text"
+              >
+                button 1
+              </span>
+            </button>
+          </div>
+          <div
+            class="c11"
+            data-testid="tab-2"
           >
-            <span
-              class="c9"
-              data-content="button 2"
-              data-testid="tab-2-text"
+            <button
+              aria-controls="uuid2"
+              aria-selected="false"
+              class="c8 c12"
+              data-testid="tab-2-button"
+              id="tab-2"
+              role="tab"
+              tabindex="-1"
+              type="button"
             >
-              button 2
-            </span>
-          </button>
+              <span
+                class="c10"
+                data-content="button 2"
+                data-testid="tab-2-text"
+              >
+                button 2
+              </span>
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-    <button
-      aria-hidden="true"
-      class="c1 c2 c12 hidden"
-      type="button"
-    >
-      <svg
+      <button
         aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
+        class="c2 c3 c13 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
+    </div>
   </div>
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c13"
+    class="c14"
     id="uuid1"
     role="tabpanel"
     tabindex="0"
@@ -446,7 +490,7 @@ exports[`Tabs has small styles 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c13"
+    class="c14"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"
@@ -462,7 +506,7 @@ exports[`Tabs has small styles 1`] = `
 `;
 
 exports[`Tabs matches snapshot (mobile) 1`] = `
-.c1 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -502,29 +546,29 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   user-select: none;
 }
 
-.c1 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c1:focus {
+.c2:focus {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
-.c1 > svg {
+.c2 > svg {
   height: var(--size-1halfx);
   width: var(--size-1halfx);
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
 }
 
-.c2 {
+.c3 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -535,14 +579,14 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   outline-offset: -2px;
 }
 
-.c2:hover,
-.c2[aria-expanded='true'] {
+.c3:hover,
+.c3[aria-expanded='true'] {
   background-color: rgb(0 0 0 / 0.15);
   border-color: transparent;
   color: #000000;
 }
 
-.c2[aria-disabled='true'] {
+.c3[aria-disabled='true'] {
   background-color: transparent;
   border-color: transparent;
   color: #B7BBC2;
@@ -550,7 +594,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   pointer-events: none;
 }
 
-.c8 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -572,11 +616,11 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   font-weight: var(--font-semi-bold);
 }
 
-.c8:hover {
+.c9:hover {
   color: #000000;
 }
 
-.c8::after {
+.c9::after {
   bottom: 0;
   content: '';
   display: block;
@@ -586,22 +630,22 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c9 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c8:focus-visible {
+.c9:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c8::after {
+.c9::after {
   background-color: #006296;
 }
 
-.c11 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -622,11 +666,11 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   user-select: none;
 }
 
-.c11:hover {
+.c12:hover {
   color: #000000;
 }
 
-.c11::after {
+.c12::after {
   bottom: 0;
   content: '';
   display: block;
@@ -636,27 +680,27 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   width: 100%;
 }
 
-.c11 {
+.c12 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c11:focus-visible {
+.c12:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c11:active {
+.c12:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c11:active::after {
+.c12:active::after {
   background-color: #012639 !important;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -664,7 +708,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   position: relative;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -672,12 +716,12 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   position: relative;
 }
 
-.c10:hover .c7::after {
+.c11:hover .c8::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c9::after {
+.c10::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -685,24 +729,27 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   visibility: hidden;
 }
 
-.c13 {
+.c14 {
   border-top: none;
 }
 
-.c13 {
+.c14 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c13:focus-visible {
+.c14:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
 .c0 {
-  height: var(--size-2halfx);
+  display: grid;
+  grid-template-areas: "tabs addButton";
+  grid-template-columns: auto 1fr;
   position: relative;
+  width: 100%;
 }
 
 .c0::before {
@@ -715,12 +762,24 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   width: 100%;
 }
 
-.c4 {
-  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
-  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: tabs;
+  height: var(--size-2halfx);
+  position: relative;
+  overflow: hidden;
 }
 
 .c5 {
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  overflow: hidden;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -729,6 +788,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
+  position: relative;
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -736,7 +796,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   white-space: nowrap;
 }
 
-.c3 {
+.c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -762,15 +822,26 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   left: 0;
 }
 
-.c3:hover {
+.c4:hover {
   background: #DBDEE1;
 }
 
-.c3.hidden {
+.c4 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c4.hidden {
   display: none;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -796,104 +867,121 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   right: 0;
 }
 
-.c12:hover {
+.c13:hover {
   background: #DBDEE1;
 }
 
-.c12.hidden {
+.c13 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c13:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c13.hidden {
   display: none;
 }
 
 <div>
   <div
-    class="c0 eds-Tabs-tablistContainer"
+    class="c0"
   >
-    <button
-      aria-hidden="true"
-      class="c1 c2 c3 hidden"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
     <div
-      class="c4"
+      class="c1 eds-Tabs-tablistContainer"
     >
+      <button
+        aria-hidden="true"
+        class="c2 c3 c4 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
       <div
-        aria-label="tabs label"
         class="c5"
-        role="tablist"
       >
         <div
+          aria-label="tabs label"
           class="c6"
-          data-testid="tab-1"
+          role="tablist"
         >
-          <button
-            aria-controls="uuid1"
-            aria-selected="true"
-            class="c7 c8"
-            data-testid="tab-1-button"
-            id="tab-1"
-            role="tab"
-            type="button"
+          <div
+            class="c7"
+            data-testid="tab-1"
           >
-            <span
-              class="c9"
-              data-content="button 1"
-              data-testid="tab-1-text"
+            <button
+              aria-controls="uuid1"
+              aria-selected="true"
+              class="c8 c9"
+              data-testid="tab-1-button"
+              id="tab-1"
+              role="tab"
+              type="button"
             >
-              button 1
-            </span>
-          </button>
-        </div>
-        <div
-          class="c10"
-          data-testid="tab-2"
-        >
-          <button
-            aria-controls="uuid2"
-            aria-selected="false"
-            class="c7 c11"
-            data-testid="tab-2-button"
-            id="tab-2"
-            role="tab"
-            tabindex="-1"
-            type="button"
+              <span
+                class="c10"
+                data-content="button 1"
+                data-testid="tab-1-text"
+              >
+                button 1
+              </span>
+            </button>
+          </div>
+          <div
+            class="c11"
+            data-testid="tab-2"
           >
-            <span
-              class="c9"
-              data-content="button 2"
-              data-testid="tab-2-text"
+            <button
+              aria-controls="uuid2"
+              aria-selected="false"
+              class="c8 c12"
+              data-testid="tab-2-button"
+              id="tab-2"
+              role="tab"
+              tabindex="-1"
+              type="button"
             >
-              button 2
-            </span>
-          </button>
+              <span
+                class="c10"
+                data-content="button 2"
+                data-testid="tab-2-text"
+              >
+                button 2
+              </span>
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-    <button
-      aria-hidden="true"
-      class="c1 c2 c12 hidden"
-      type="button"
-    >
-      <svg
+      <button
         aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
+        class="c2 c3 c13 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
+    </div>
   </div>
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c13"
+    class="c14"
     id="uuid1"
     role="tabpanel"
     tabindex="0"
@@ -907,7 +995,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c13"
+    class="c14"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"
@@ -923,7 +1011,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
 `;
 
 exports[`Tabs matches snapshot 1`] = `
-.c1 {
+.c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -963,7 +1051,7 @@ exports[`Tabs matches snapshot 1`] = `
   user-select: none;
 }
 
-.c1 {
+.c2 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -974,18 +1062,18 @@ exports[`Tabs matches snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c1 > svg {
+.c2 > svg {
   height: var(--size-1x);
   width: var(--size-1x);
 }
 
-.c2 {
+.c3 {
   background-color: transparent;
   border-color: transparent;
   color: #60666E;
 }
 
-.c2 {
+.c3 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
@@ -996,14 +1084,14 @@ exports[`Tabs matches snapshot 1`] = `
   outline-offset: -2px;
 }
 
-.c2:hover,
-.c2[aria-expanded='true'] {
+.c3:hover,
+.c3[aria-expanded='true'] {
   background-color: rgb(0 0 0 / 0.15);
   border-color: transparent;
   color: #000000;
 }
 
-.c2[aria-disabled='true'] {
+.c3[aria-disabled='true'] {
   background-color: transparent;
   border-color: transparent;
   color: #B7BBC2;
@@ -1011,7 +1099,7 @@ exports[`Tabs matches snapshot 1`] = `
   pointer-events: none;
 }
 
-.c8 {
+.c9 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1033,11 +1121,11 @@ exports[`Tabs matches snapshot 1`] = `
   font-weight: var(--font-semi-bold);
 }
 
-.c8:hover {
+.c9:hover {
   color: #000000;
 }
 
-.c8::after {
+.c9::after {
   bottom: 0;
   content: '';
   display: block;
@@ -1047,22 +1135,22 @@ exports[`Tabs matches snapshot 1`] = `
   width: 100%;
 }
 
-.c8 {
+.c9 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c8:focus-visible {
+.c9:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c8::after {
+.c9::after {
   background-color: #006296;
 }
 
-.c11 {
+.c12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1083,11 +1171,11 @@ exports[`Tabs matches snapshot 1`] = `
   user-select: none;
 }
 
-.c11:hover {
+.c12:hover {
   color: #000000;
 }
 
-.c11::after {
+.c12::after {
   bottom: 0;
   content: '';
   display: block;
@@ -1097,27 +1185,27 @@ exports[`Tabs matches snapshot 1`] = `
   width: 100%;
 }
 
-.c11 {
+.c12 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c11:focus-visible {
+.c12:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
   outline-offset: -2px;
 }
 
-.c11:active {
+.c12:active {
   color: #1B1C1E;
   font-weight: var(--font-semi-bold);
 }
 
-.c11:active::after {
+.c12:active::after {
   background-color: #012639 !important;
 }
 
-.c6 {
+.c7 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1125,7 +1213,7 @@ exports[`Tabs matches snapshot 1`] = `
   position: relative;
 }
 
-.c10 {
+.c11 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1133,12 +1221,12 @@ exports[`Tabs matches snapshot 1`] = `
   position: relative;
 }
 
-.c10:hover .c7::after {
+.c11:hover .c8::after {
   background-color: #DBDEE1;
   color: #000000;
 }
 
-.c9::after {
+.c10::after {
   content: attr(data-content);
   display: block;
   font-weight: var(--font-semi-bold);
@@ -1146,24 +1234,27 @@ exports[`Tabs matches snapshot 1`] = `
   visibility: hidden;
 }
 
-.c13 {
+.c14 {
   border-top: none;
 }
 
-.c13 {
+.c14 {
   outline: 2px solid transparent;
   outline-offset: -2px;
 }
 
-.c13:focus-visible {
+.c14:focus-visible {
   box-shadow: 0 0 0 2px #006296;
   outline: 2px solid #84C6EA;
   outline-offset: -2px;
 }
 
 .c0 {
-  height: var(--size-2halfx);
+  display: grid;
+  grid-template-areas: "tabs addButton";
+  grid-template-columns: auto 1fr;
   position: relative;
+  width: 100%;
 }
 
 .c0::before {
@@ -1176,12 +1267,24 @@ exports[`Tabs matches snapshot 1`] = `
   width: 100%;
 }
 
-.c4 {
-  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
-  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: tabs;
+  height: var(--size-2halfx);
+  position: relative;
+  overflow: hidden;
 }
 
 .c5 {
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  overflow: hidden;
+}
+
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1190,6 +1293,7 @@ exports[`Tabs matches snapshot 1`] = `
   height: var(--size-2halfx);
   overflow-x: auto;
   overflow-y: hidden;
+  position: relative;
   -webkit-scrollbar-width: none;
   -moz-scrollbar-width: none;
   -ms-scrollbar-width: none;
@@ -1197,7 +1301,7 @@ exports[`Tabs matches snapshot 1`] = `
   white-space: nowrap;
 }
 
-.c3 {
+.c4 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1223,15 +1327,26 @@ exports[`Tabs matches snapshot 1`] = `
   left: 0;
 }
 
-.c3:hover {
+.c4:hover {
   background: #DBDEE1;
 }
 
-.c3.hidden {
+.c4 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c4.hidden {
   display: none;
 }
 
-.c12 {
+.c13 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -1257,104 +1372,121 @@ exports[`Tabs matches snapshot 1`] = `
   right: 0;
 }
 
-.c12:hover {
+.c13:hover {
   background: #DBDEE1;
 }
 
-.c12.hidden {
+.c13 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c13:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c13.hidden {
   display: none;
 }
 
 <div>
   <div
-    class="c0 eds-Tabs-tablistContainer"
+    class="c0"
   >
-    <button
-      aria-hidden="true"
-      class="c1 c2 c3 hidden"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
     <div
-      class="c4"
+      class="c1 eds-Tabs-tablistContainer"
     >
+      <button
+        aria-hidden="true"
+        class="c2 c3 c4 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
       <div
-        aria-label="tabs label"
         class="c5"
-        role="tablist"
       >
         <div
+          aria-label="tabs label"
           class="c6"
-          data-testid="tab-1"
+          role="tablist"
         >
-          <button
-            aria-controls="uuid1"
-            aria-selected="true"
-            class="c7 c8"
-            data-testid="tab-1-button"
-            id="tab-1"
-            role="tab"
-            type="button"
+          <div
+            class="c7"
+            data-testid="tab-1"
           >
-            <span
-              class="c9"
-              data-content="button 1"
-              data-testid="tab-1-text"
+            <button
+              aria-controls="uuid1"
+              aria-selected="true"
+              class="c8 c9"
+              data-testid="tab-1-button"
+              id="tab-1"
+              role="tab"
+              type="button"
             >
-              button 1
-            </span>
-          </button>
-        </div>
-        <div
-          class="c10"
-          data-testid="tab-2"
-        >
-          <button
-            aria-controls="uuid2"
-            aria-selected="false"
-            class="c7 c11"
-            data-testid="tab-2-button"
-            id="tab-2"
-            role="tab"
-            tabindex="-1"
-            type="button"
+              <span
+                class="c10"
+                data-content="button 1"
+                data-testid="tab-1-text"
+              >
+                button 1
+              </span>
+            </button>
+          </div>
+          <div
+            class="c11"
+            data-testid="tab-2"
           >
-            <span
-              class="c9"
-              data-content="button 2"
-              data-testid="tab-2-text"
+            <button
+              aria-controls="uuid2"
+              aria-selected="false"
+              class="c8 c12"
+              data-testid="tab-2-button"
+              id="tab-2"
+              role="tab"
+              tabindex="-1"
+              type="button"
             >
-              button 2
-            </span>
-          </button>
+              <span
+                class="c10"
+                data-content="button 2"
+                data-testid="tab-2-text"
+              >
+                button 2
+              </span>
+            </button>
+          </div>
         </div>
       </div>
-    </div>
-    <button
-      aria-hidden="true"
-      class="c1 c2 c12 hidden"
-      type="button"
-    >
-      <svg
+      <button
         aria-hidden="true"
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
+        class="c2 c3 c13 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
+    </div>
   </div>
   <div
     aria-hidden="false"
     aria-labelledby="tab-1"
-    class="c13"
+    class="c14"
     id="uuid1"
     role="tabpanel"
     tabindex="0"
@@ -1368,7 +1500,7 @@ exports[`Tabs matches snapshot 1`] = `
   <div
     aria-hidden="true"
     aria-labelledby="tab-2"
-    class="c13"
+    class="c14"
     hidden=""
     id="tab-2-panel"
     role="tabpanel"

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -1,7 +1,568 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs has small styles 1`] = `
+{
+  "asFragment": [Function],
+  "baseElement": .c3 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: inherit;
+  border: 1px solid;
+  border-radius: 1.5rem;
+  box-sizing: border-box;
+  color: inherit;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: var(--font-bold);
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-letter-spacing: 0.025rem;
+  -moz-letter-spacing: 0.025rem;
+  -ms-letter-spacing: 0.025rem;
+  letter-spacing: 0.025rem;
+  line-height: 1rem;
+  min-height: var(--size-2x);
+  min-width: 2rem;
+  outline: none;
+  padding: 0 var(--spacing-2x);
+  text-transform: uppercase;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c3 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c3:focus {
+  box-shadow: 0 0 0 2px #006296;
+  outline: 2px solid #84C6EA;
+  outline-offset: -2px;
+}
+
+.c3 > svg {
+  height: var(--size-1x);
+  width: var(--size-1x);
+}
+
+.c4 {
+  background-color: transparent;
+  border-color: transparent;
+  color: #60666E;
+}
+
+.c4 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c4:focus {
+  box-shadow: 0 0 0 2px #006296;
+  outline: 2px solid #84C6EA;
+  outline-offset: -2px;
+}
+
+.c4:hover,
+.c4[aria-expanded='true'] {
+  background-color: rgb(0 0 0 / 0.15);
+  border-color: transparent;
+  color: #000000;
+}
+
+.c4[aria-disabled='true'] {
+  background-color: transparent;
+  border-color: transparent;
+  color: #B7BBC2;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.c0 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+.c10 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #1B1C1E;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: var(--font-family);
+  font-size: 0.75rem;
+  gap: var(--spacing-half);
+  padding: 0 var(--spacing-1x);
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-weight: var(--font-semi-bold);
+}
+
+.c10:hover {
+  color: #000000;
+}
+
+.c10::after {
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 0.125rem;
+  left: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.c10 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c10:focus-visible {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c10::after {
+  background-color: #006296;
+}
+
+.c13 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  color: #60666E;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-family: var(--font-family);
+  font-size: 0.75rem;
+  gap: var(--spacing-half);
+  padding: 0 var(--spacing-1x);
+  position: relative;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.c13:hover {
+  color: #000000;
+}
+
+.c13::after {
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 0.125rem;
+  left: 0;
+  position: absolute;
+  width: 100%;
+}
+
+.c13 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c13:focus-visible {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c13:active {
+  color: #1B1C1E;
+  font-weight: var(--font-semi-bold);
+}
+
+.c13:active::after {
+  background-color: #012639 !important;
+}
+
+.c8 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+}
+
+.c12 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+}
+
+.c12:hover .c9::after {
+  background-color: #DBDEE1;
+  color: #000000;
+}
+
+.c11::after {
+  content: attr(data-content);
+  display: block;
+  font-weight: var(--font-semi-bold);
+  height: 0;
+  visibility: hidden;
+}
+
+.c15 {
+  border-top: none;
+}
+
+.c15 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c15:focus-visible {
+  box-shadow: 0 0 0 2px #006296;
+  outline: 2px solid #84C6EA;
+  outline-offset: -2px;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  position: relative;
+  width: 100%;
+}
+
+.c1::before {
+  border-bottom: 1px solid #DBDEE1;
+  bottom: 0;
+  content: '';
+  display: block;
+  height: 1px;
+  position: absolute;
+  width: 100%;
+}
+
 .c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  grid-area: tabs;
+  height: var(--size-2halfx);
+  overflow: hidden;
+  position: relative;
+}
+
+.c6 {
+  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
+  overflow: hidden;
+}
+
+.c7 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  gap: var(--spacing-half);
+  height: var(--size-2halfx);
+  overflow-x: auto;
+  overflow-y: hidden;
+  position: relative;
+  -webkit-scrollbar-width: none;
+  -moz-scrollbar-width: none;
+  -ms-scrollbar-width: none;
+  scrollbar-width: none;
+  white-space: nowrap;
+}
+
+.c5 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: inherit;
+  border-bottom: 1px solid #DBDEE1;
+  border-radius: 0;
+  bottom: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: var(--size-2halfx);
+  min-height: auto;
+  padding: 0 var(--spacing-1x);
+  position: absolute;
+  width: var(--size-2x);
+  z-index: 1;
+  box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
+  left: 0;
+}
+
+.c5:hover {
+  background: #DBDEE1;
+}
+
+.c5 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c5:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c5.hidden {
+  display: none;
+}
+
+.c14 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: inherit;
+  border-bottom: 1px solid #DBDEE1;
+  border-radius: 0;
+  bottom: 0;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex-shrink: 0;
+  -ms-flex-negative: 0;
+  flex-shrink: 0;
+  height: var(--size-2halfx);
+  min-height: auto;
+  padding: 0 var(--spacing-1x);
+  position: absolute;
+  width: var(--size-2x);
+  z-index: 1;
+  box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
+  right: 0;
+}
+
+.c14:hover {
+  background: #DBDEE1;
+}
+
+.c14 {
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+}
+
+.c14:focus {
+  box-shadow: 0 0 0 0 transparent;
+  outline: 2px solid #006296;
+  outline-offset: -2px;
+}
+
+.c14.hidden {
+  display: none;
+}
+
+<body>
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+    <div>
+      <div>
+        <div
+          class="c1"
+        >
+          <div
+            class="c2 eds-Tabs-tablistContainer"
+          >
+            <button
+              aria-hidden="true"
+              class="c3 c4 c5 hidden"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                color="currentColor"
+                focusable="false"
+                height="16"
+                width="16"
+              />
+            </button>
+            <div
+              class="c6"
+            >
+              <div
+                aria-label="tabs label"
+                class="c7"
+                role="tablist"
+              >
+                <div
+                  class="c8"
+                  data-testid="tab-1"
+                >
+                  <button
+                    aria-controls="tab-1-panel"
+                    aria-selected="true"
+                    class="c9 c10"
+                    data-testid="tab-1-button"
+                    id="tab-1"
+                    role="tab"
+                    type="button"
+                  >
+                    <span
+                      class="c11"
+                      data-content="button 1"
+                      data-testid="tab-1-text"
+                    >
+                      button 1
+                    </span>
+                  </button>
+                </div>
+                <div
+                  class="c12"
+                  data-testid="tab-2"
+                >
+                  <button
+                    aria-controls="tab-2-panel"
+                    aria-selected="false"
+                    class="c9 c13"
+                    data-testid="tab-2-button"
+                    id="tab-2"
+                    role="tab"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <span
+                      class="c11"
+                      data-content="button 2"
+                      data-testid="tab-2-text"
+                    >
+                      button 2
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <button
+              aria-hidden="true"
+              class="c3 c4 c14 hidden"
+              tabindex="-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                color="currentColor"
+                focusable="false"
+                height="16"
+                width="16"
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          aria-hidden="false"
+          aria-labelledby="tab-1"
+          class="c15"
+          id="tab-1-panel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          <div
+            data-testid="tab-panel-1"
+          >
+            content
+          </div>
+        </div>
+        <div
+          aria-hidden="true"
+          aria-labelledby="tab-2"
+          class="c15"
+          hidden=""
+          id="tab-2-panel"
+          role="tabpanel"
+          tabindex="0"
+        >
+          <div
+            data-testid="tab-panel-2"
+          >
+            content
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="c0"
+      data-testid="toasts"
+    />
+  </body>,
+  "container": .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -383,127 +944,181 @@ exports[`Tabs has small styles 1`] = `
 }
 
 <div>
-  <div
-    class="c0"
-  >
-    <div
-      class="c1 eds-Tabs-tablistContainer"
-    >
-      <button
-        aria-hidden="true"
-        class="c2 c3 c4 hidden"
-        tabindex="-1"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          color="currentColor"
-          focusable="false"
-          height="16"
-          width="16"
-        />
-      </button>
+    <div>
       <div
-        class="c5"
+        class="c0"
       >
         <div
-          aria-label="tabs label"
-          class="c6"
-          role="tablist"
+          class="c1 eds-Tabs-tablistContainer"
         >
-          <div
-            class="c7"
-            data-testid="tab-1"
+          <button
+            aria-hidden="true"
+            class="c2 c3 c4 hidden"
+            tabindex="-1"
+            type="button"
           >
-            <button
-              aria-controls="uuid1"
-              aria-selected="true"
-              class="c8 c9"
-              data-testid="tab-1-button"
-              id="tab-1"
-              role="tab"
-              type="button"
-            >
-              <span
-                class="c10"
-                data-content="button 1"
-                data-testid="tab-1-text"
-              >
-                button 1
-              </span>
-            </button>
-          </div>
+            <svg
+              aria-hidden="true"
+              color="currentColor"
+              focusable="false"
+              height="16"
+              width="16"
+            />
+          </button>
           <div
-            class="c11"
-            data-testid="tab-2"
+            class="c5"
           >
-            <button
-              aria-controls="uuid2"
-              aria-selected="false"
-              class="c8 c12"
-              data-testid="tab-2-button"
-              id="tab-2"
-              role="tab"
-              tabindex="-1"
-              type="button"
+            <div
+              aria-label="tabs label"
+              class="c6"
+              role="tablist"
             >
-              <span
-                class="c10"
-                data-content="button 2"
-                data-testid="tab-2-text"
+              <div
+                class="c7"
+                data-testid="tab-1"
               >
-                button 2
-              </span>
-            </button>
+                <button
+                  aria-controls="tab-1-panel"
+                  aria-selected="true"
+                  class="c8 c9"
+                  data-testid="tab-1-button"
+                  id="tab-1"
+                  role="tab"
+                  type="button"
+                >
+                  <span
+                    class="c10"
+                    data-content="button 1"
+                    data-testid="tab-1-text"
+                  >
+                    button 1
+                  </span>
+                </button>
+              </div>
+              <div
+                class="c11"
+                data-testid="tab-2"
+              >
+                <button
+                  aria-controls="tab-2-panel"
+                  aria-selected="false"
+                  class="c8 c12"
+                  data-testid="tab-2-button"
+                  id="tab-2"
+                  role="tab"
+                  tabindex="-1"
+                  type="button"
+                >
+                  <span
+                    class="c10"
+                    data-content="button 2"
+                    data-testid="tab-2-text"
+                  >
+                    button 2
+                  </span>
+                </button>
+              </div>
+            </div>
           </div>
+          <button
+            aria-hidden="true"
+            class="c2 c3 c13 hidden"
+            tabindex="-1"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              color="currentColor"
+              focusable="false"
+              height="16"
+              width="16"
+            />
+          </button>
         </div>
       </div>
-      <button
-        aria-hidden="true"
-        class="c2 c3 c13 hidden"
-        tabindex="-1"
-        type="button"
+      <div
+        aria-hidden="false"
+        aria-labelledby="tab-1"
+        class="c14"
+        id="tab-1-panel"
+        role="tabpanel"
+        tabindex="0"
       >
-        <svg
-          aria-hidden="true"
-          color="currentColor"
-          focusable="false"
-          height="16"
-          width="16"
-        />
-      </button>
+        <div
+          data-testid="tab-panel-1"
+        >
+          content
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        aria-labelledby="tab-2"
+        class="c14"
+        hidden=""
+        id="tab-2-panel"
+        role="tabpanel"
+        tabindex="0"
+      >
+        <div
+          data-testid="tab-panel-2"
+        >
+          content
+        </div>
+      </div>
     </div>
-  </div>
-  <div
-    aria-hidden="false"
-    aria-labelledby="tab-1"
-    class="c14"
-    id="uuid1"
-    role="tabpanel"
-    tabindex="0"
-  >
-    <div
-      data-testid="tab-panel-1"
-    >
-      content
-    </div>
-  </div>
-  <div
-    aria-hidden="true"
-    aria-labelledby="tab-2"
-    class="c14"
-    hidden=""
-    id="tab-2-panel"
-    role="tabpanel"
-    tabindex="0"
-  >
-    <div
-      data-testid="tab-panel-2"
-    >
-      content
-    </div>
-  </div>
-</div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;
 
 exports[`Tabs matches snapshot (mobile) 1`] = `
@@ -922,7 +1537,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
             data-testid="tab-1"
           >
             <button
-              aria-controls="uuid1"
+              aria-controls="tab-1-panel"
               aria-selected="true"
               class="c8 c9"
               data-testid="tab-1-button"
@@ -944,7 +1559,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
             data-testid="tab-2"
           >
             <button
-              aria-controls="uuid2"
+              aria-controls="tab-2-panel"
               aria-selected="false"
               class="c8 c12"
               data-testid="tab-2-button"
@@ -984,7 +1599,7 @@ exports[`Tabs matches snapshot (mobile) 1`] = `
     aria-hidden="false"
     aria-labelledby="tab-1"
     class="c14"
-    id="uuid1"
+    id="tab-1-panel"
     role="tabpanel"
     tabindex="0"
   >
@@ -1428,7 +2043,7 @@ exports[`Tabs matches snapshot 1`] = `
             data-testid="tab-1"
           >
             <button
-              aria-controls="uuid1"
+              aria-controls="tab-1-panel"
               aria-selected="true"
               class="c8 c9"
               data-testid="tab-1-button"
@@ -1450,7 +2065,7 @@ exports[`Tabs matches snapshot 1`] = `
             data-testid="tab-2"
           >
             <button
-              aria-controls="uuid2"
+              aria-controls="tab-2-panel"
               aria-selected="false"
               class="c8 c12"
               data-testid="tab-2-button"
@@ -1490,7 +2105,7 @@ exports[`Tabs matches snapshot 1`] = `
     aria-hidden="false"
     aria-labelledby="tab-1"
     class="c14"
-    id="uuid1"
+    id="tab-1-panel"
     role="tabpanel"
     tabindex="0"
   >

--- a/packages/react/src/components/tabs/tabs.test.tsx.snap
+++ b/packages/react/src/components/tabs/tabs.test.tsx.snap
@@ -1,568 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs has small styles 1`] = `
-{
-  "asFragment": [Function],
-  "baseElement": .c3 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background: inherit;
-  border: 1px solid;
-  border-radius: 1.5rem;
-  box-sizing: border-box;
-  color: inherit;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  font-family: inherit;
-  font-size: 0.75rem;
-  font-weight: var(--font-bold);
-  -webkit-box-pack: center;
-  -webkit-justify-content: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  -webkit-letter-spacing: 0.025rem;
-  -moz-letter-spacing: 0.025rem;
-  -ms-letter-spacing: 0.025rem;
-  letter-spacing: 0.025rem;
-  line-height: 1rem;
-  min-height: var(--size-2x);
-  min-width: 2rem;
-  outline: none;
-  padding: 0 var(--spacing-2x);
-  text-transform: uppercase;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c3 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c3:focus {
-  box-shadow: 0 0 0 2px #006296;
-  outline: 2px solid #84C6EA;
-  outline-offset: -2px;
-}
-
-.c3 > svg {
-  height: var(--size-1x);
-  width: var(--size-1x);
-}
-
-.c4 {
-  background-color: transparent;
-  border-color: transparent;
-  color: #60666E;
-}
-
-.c4 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c4:focus {
-  box-shadow: 0 0 0 2px #006296;
-  outline: 2px solid #84C6EA;
-  outline-offset: -2px;
-}
-
-.c4:hover,
-.c4[aria-expanded='true'] {
-  background-color: rgb(0 0 0 / 0.15);
-  border-color: transparent;
-  color: #000000;
-}
-
-.c4[aria-disabled='true'] {
-  background-color: transparent;
-  border-color: transparent;
-  color: #B7BBC2;
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.c0 {
-  box-sizing: border-box;
-  position: fixed;
-  z-index: 100000;
-  bottom: var(--spacing-2x);
-  right: var(--spacing-2x);
-}
-
-.c10 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #1B1C1E;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-family: var(--font-family);
-  font-size: 0.75rem;
-  gap: var(--spacing-half);
-  padding: 0 var(--spacing-1x);
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  font-weight: var(--font-semi-bold);
-}
-
-.c10:hover {
-  color: #000000;
-}
-
-.c10::after {
-  bottom: 0;
-  content: '';
-  display: block;
-  height: 0.125rem;
-  left: 0;
-  position: absolute;
-  width: 100%;
-}
-
-.c10 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c10:focus-visible {
-  box-shadow: 0 0 0 0 transparent;
-  outline: 2px solid #006296;
-  outline-offset: -2px;
-}
-
-.c10::after {
-  background-color: #006296;
-}
-
-.c13 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  color: #60666E;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  font-family: var(--font-family);
-  font-size: 0.75rem;
-  gap: var(--spacing-half);
-  padding: 0 var(--spacing-1x);
-  position: relative;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-}
-
-.c13:hover {
-  color: #000000;
-}
-
-.c13::after {
-  bottom: 0;
-  content: '';
-  display: block;
-  height: 0.125rem;
-  left: 0;
-  position: absolute;
-  width: 100%;
-}
-
-.c13 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c13:focus-visible {
-  box-shadow: 0 0 0 0 transparent;
-  outline: 2px solid #006296;
-  outline-offset: -2px;
-}
-
-.c13:active {
-  color: #1B1C1E;
-  font-weight: var(--font-semi-bold);
-}
-
-.c13:active::after {
-  background-color: #012639 !important;
-}
-
-.c8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-}
-
-.c12 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-}
-
-.c12:hover .c9::after {
-  background-color: #DBDEE1;
-  color: #000000;
-}
-
-.c11::after {
-  content: attr(data-content);
-  display: block;
-  font-weight: var(--font-semi-bold);
-  height: 0;
-  visibility: hidden;
-}
-
-.c15 {
-  border-top: none;
-}
-
-.c15 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c15:focus-visible {
-  box-shadow: 0 0 0 2px #006296;
-  outline: 2px solid #84C6EA;
-  outline-offset: -2px;
-}
-
-.c1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  position: relative;
-  width: 100%;
-}
-
-.c1::before {
-  border-bottom: 1px solid #DBDEE1;
-  bottom: 0;
-  content: '';
-  display: block;
-  height: 1px;
-  position: absolute;
-  width: 100%;
-}
-
 .c2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  grid-area: tabs;
-  height: var(--size-2halfx);
-  overflow: hidden;
-  position: relative;
-}
-
-.c6 {
-  -webkit-mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
-  mask-image: linear-gradient( 90deg, #000 0px, #000 calc(100% - var(--size-2x)), #000 100% );
-  overflow: hidden;
-}
-
-.c7 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  gap: var(--spacing-half);
-  height: var(--size-2halfx);
-  overflow-x: auto;
-  overflow-y: hidden;
-  position: relative;
-  -webkit-scrollbar-width: none;
-  -moz-scrollbar-width: none;
-  -ms-scrollbar-width: none;
-  scrollbar-width: none;
-  white-space: nowrap;
-}
-
-.c5 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: inherit;
-  border-bottom: 1px solid #DBDEE1;
-  border-radius: 0;
-  bottom: 0;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  height: var(--size-2halfx);
-  min-height: auto;
-  padding: 0 var(--spacing-1x);
-  position: absolute;
-  width: var(--size-2x);
-  z-index: 1;
-  box-shadow: 3px 0px 3px -2px rgba(0,0,0,0.1);
-  left: 0;
-}
-
-.c5:hover {
-  background: #DBDEE1;
-}
-
-.c5 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c5:focus {
-  box-shadow: 0 0 0 0 transparent;
-  outline: 2px solid #006296;
-  outline-offset: -2px;
-}
-
-.c5.hidden {
-  display: none;
-}
-
-.c14 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  background-color: inherit;
-  border-bottom: 1px solid #DBDEE1;
-  border-radius: 0;
-  bottom: 0;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -webkit-flex-shrink: 0;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  height: var(--size-2halfx);
-  min-height: auto;
-  padding: 0 var(--spacing-1x);
-  position: absolute;
-  width: var(--size-2x);
-  z-index: 1;
-  box-shadow: -3px 0px 3px -2px rgba(0,0,0,0.1);
-  right: 0;
-}
-
-.c14:hover {
-  background: #DBDEE1;
-}
-
-.c14 {
-  outline: 2px solid transparent;
-  outline-offset: -2px;
-}
-
-.c14:focus {
-  box-shadow: 0 0 0 0 transparent;
-  outline: 2px solid #006296;
-  outline-offset: -2px;
-}
-
-.c14.hidden {
-  display: none;
-}
-
-<body>
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-    <div>
-      <div>
-        <div
-          class="c1"
-        >
-          <div
-            class="c2 eds-Tabs-tablistContainer"
-          >
-            <button
-              aria-hidden="true"
-              class="c3 c4 c5 hidden"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                color="currentColor"
-                focusable="false"
-                height="16"
-                width="16"
-              />
-            </button>
-            <div
-              class="c6"
-            >
-              <div
-                aria-label="tabs label"
-                class="c7"
-                role="tablist"
-              >
-                <div
-                  class="c8"
-                  data-testid="tab-1"
-                >
-                  <button
-                    aria-controls="tab-1-panel"
-                    aria-selected="true"
-                    class="c9 c10"
-                    data-testid="tab-1-button"
-                    id="tab-1"
-                    role="tab"
-                    type="button"
-                  >
-                    <span
-                      class="c11"
-                      data-content="button 1"
-                      data-testid="tab-1-text"
-                    >
-                      button 1
-                    </span>
-                  </button>
-                </div>
-                <div
-                  class="c12"
-                  data-testid="tab-2"
-                >
-                  <button
-                    aria-controls="tab-2-panel"
-                    aria-selected="false"
-                    class="c9 c13"
-                    data-testid="tab-2-button"
-                    id="tab-2"
-                    role="tab"
-                    tabindex="-1"
-                    type="button"
-                  >
-                    <span
-                      class="c11"
-                      data-content="button 2"
-                      data-testid="tab-2-text"
-                    >
-                      button 2
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-            <button
-              aria-hidden="true"
-              class="c3 c4 c14 hidden"
-              tabindex="-1"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                color="currentColor"
-                focusable="false"
-                height="16"
-                width="16"
-              />
-            </button>
-          </div>
-        </div>
-        <div
-          aria-hidden="false"
-          aria-labelledby="tab-1"
-          class="c15"
-          id="tab-1-panel"
-          role="tabpanel"
-          tabindex="0"
-        >
-          <div
-            data-testid="tab-panel-1"
-          >
-            content
-          </div>
-        </div>
-        <div
-          aria-hidden="true"
-          aria-labelledby="tab-2"
-          class="c15"
-          hidden=""
-          id="tab-2-panel"
-          role="tabpanel"
-          tabindex="0"
-        >
-          <div
-            data-testid="tab-panel-2"
-          >
-            content
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      class="c0"
-      data-testid="toasts"
-    />
-  </body>,
-  "container": .c2 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -944,181 +383,127 @@ exports[`Tabs has small styles 1`] = `
 }
 
 <div>
-    <div>
-      <div
-        class="c0"
-      >
-        <div
-          class="c1 eds-Tabs-tablistContainer"
-        >
-          <button
-            aria-hidden="true"
-            class="c2 c3 c4 hidden"
-            tabindex="-1"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              color="currentColor"
-              focusable="false"
-              height="16"
-              width="16"
-            />
-          </button>
-          <div
-            class="c5"
-          >
-            <div
-              aria-label="tabs label"
-              class="c6"
-              role="tablist"
-            >
-              <div
-                class="c7"
-                data-testid="tab-1"
-              >
-                <button
-                  aria-controls="tab-1-panel"
-                  aria-selected="true"
-                  class="c8 c9"
-                  data-testid="tab-1-button"
-                  id="tab-1"
-                  role="tab"
-                  type="button"
-                >
-                  <span
-                    class="c10"
-                    data-content="button 1"
-                    data-testid="tab-1-text"
-                  >
-                    button 1
-                  </span>
-                </button>
-              </div>
-              <div
-                class="c11"
-                data-testid="tab-2"
-              >
-                <button
-                  aria-controls="tab-2-panel"
-                  aria-selected="false"
-                  class="c8 c12"
-                  data-testid="tab-2-button"
-                  id="tab-2"
-                  role="tab"
-                  tabindex="-1"
-                  type="button"
-                >
-                  <span
-                    class="c10"
-                    data-content="button 2"
-                    data-testid="tab-2-text"
-                  >
-                    button 2
-                  </span>
-                </button>
-              </div>
-            </div>
-          </div>
-          <button
-            aria-hidden="true"
-            class="c2 c3 c13 hidden"
-            tabindex="-1"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              color="currentColor"
-              focusable="false"
-              height="16"
-              width="16"
-            />
-          </button>
-        </div>
-      </div>
-      <div
-        aria-hidden="false"
-        aria-labelledby="tab-1"
-        class="c14"
-        id="tab-1-panel"
-        role="tabpanel"
-        tabindex="0"
-      >
-        <div
-          data-testid="tab-panel-1"
-        >
-          content
-        </div>
-      </div>
-      <div
+  <div
+    class="c0"
+  >
+    <div
+      class="c1 eds-Tabs-tablistContainer"
+    >
+      <button
         aria-hidden="true"
-        aria-labelledby="tab-2"
-        class="c14"
-        hidden=""
-        id="tab-2-panel"
-        role="tabpanel"
-        tabindex="0"
+        class="c2 c3 c4 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
+      <div
+        class="c5"
       >
         <div
-          data-testid="tab-panel-2"
+          aria-label="tabs label"
+          class="c6"
+          role="tablist"
         >
-          content
+          <div
+            class="c7"
+            data-testid="tab-1"
+          >
+            <button
+              aria-controls="tab-1-panel"
+              aria-selected="true"
+              class="c8 c9"
+              data-testid="tab-1-button"
+              id="tab-1"
+              role="tab"
+              type="button"
+            >
+              <span
+                class="c10"
+                data-content="button 1"
+                data-testid="tab-1-text"
+              >
+                button 1
+              </span>
+            </button>
+          </div>
+          <div
+            class="c11"
+            data-testid="tab-2"
+          >
+            <button
+              aria-controls="tab-2-panel"
+              aria-selected="false"
+              class="c8 c12"
+              data-testid="tab-2-button"
+              id="tab-2"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              <span
+                class="c10"
+                data-content="button 2"
+                data-testid="tab-2-text"
+              >
+                button 2
+              </span>
+            </button>
+          </div>
         </div>
       </div>
+      <button
+        aria-hidden="true"
+        class="c2 c3 c13 hidden"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
+        />
+      </button>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+  </div>
+  <div
+    aria-hidden="false"
+    aria-labelledby="tab-1"
+    class="c14"
+    id="tab-1-panel"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-1"
+    >
+      content
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    aria-labelledby="tab-2"
+    class="c14"
+    hidden=""
+    id="tab-2-panel"
+    role="tabpanel"
+    tabindex="0"
+  >
+    <div
+      data-testid="tab-panel-2"
+    >
+      content
+    </div>
+  </div>
+</div>
 `;
 
 exports[`Tabs matches snapshot (mobile) 1`] = `

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -46,18 +46,20 @@ const TabButtonsContainer = styled.div`
 const TabsWrapper = styled.div<TabsWrapperProps>`
     mask-image: linear-gradient(
         90deg,
-        ${(props) =>
+        ${(props) => (
             props.$hasLeftScroll
                 ? `transparent 0px,
                    transparent ${getButtonSize()},
                    #000 ${getButtonSize()},`
-                : '#000 0px,'}
+                : '#000 0px,'
+        )}
         #000 calc(100% - ${getButtonSize()}),
-        ${(props) =>
+        ${(props) => (
             props.$hasRightScroll
                 ? `transparent calc(100% - ${getButtonSize()}),
                    transparent 100%`
-                : '#000 100%'}
+                : '#000 100%'
+        )}
     );
 `;
 

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -44,24 +44,27 @@ const TabButtonsContainer = styled.div`
 `;
 
 const TabsWrapper = styled.div<TabsWrapperProps>`
-    mask-image: 
+    mask-image:
         linear-gradient(
-        90deg,
-        ${(props) => (
-            props.$hasLeftScroll
-                ? `transparent 0px,
-                   transparent ${getButtonSize()},
-                   #000 ${getButtonSize()},`
-                : '#000 0px,'
-        )}
-        #000 calc(100% - ${getButtonSize()}),
-        ${(props) => (
-            props.$hasRightScroll
-                ? `transparent calc(100% - ${getButtonSize()}),
-                   transparent 100%`
-                : '#000 100%'
-        )}
-    );
+            90deg,
+            ${(props) => (
+                props.$hasLeftScroll
+                    ? `transparent 0px,
+                       transparent ${getButtonSize()},
+                       #000 ${getButtonSize()},`
+                    : 
+                    '#000 0px,'
+            )}
+            #000 calc(100% - ${getButtonSize()}),
+            ${(props) => (
+                props.$hasRightScroll
+                    ? `transparent calc(100% - ${getButtonSize()}),
+                       transparent 100%`
+                    : 
+                    '#000 100%'
+            )}
+        )
+    ;
 `;
 
 const TabList = styled.div`

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -29,9 +29,7 @@ interface TabsWrapperProps {
 }
 
 const TabTopSection = styled.div`
-    display: grid;
-    grid-template-areas: 'tabs addButton';
-    grid-template-columns: auto 1fr;
+    display: flex;
     position: relative;
     width: 100%;
 
@@ -124,10 +122,8 @@ const ScrollButton = styled(Button) <{ $position: 'left' | 'right'; }>`
 `;
 
 const AddButton = styled(Button)`
-    align-self: center;
-    grid-area: addButton;
-    min-width: auto;
-    white-space: nowrap;
+    align-self: center;  
+    flex-shrink: 0;  
 `;
 
 export interface Tab {
@@ -361,7 +357,7 @@ export const Tabs: VoidFunctionComponent<Props> = ({
                     </ScrollButton>
                 </TabButtonsContainer>
                 {addButtonComponent && (
-                    addButtonProps.tooltipContent ? (
+                    addButtonProps.tooltipContent && addButtonProps.disabled ? (
                         <Tooltip label={addButtonProps.tooltipContent} desktopPlacement="top">
                             {addButtonComponent}
                         </Tooltip>

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -45,10 +45,19 @@ const TabButtonsContainer = styled.div`
 
 const TabsWrapper = styled.div<TabsWrapperProps>`
     mask-image: linear-gradient(
-        90deg, 
-        ${(props) => (props.$hasLeftScroll ? `transparent 0px, transparent ${getButtonSize()}, #000 ${getButtonSize()},` : '#000 0px,')}
-        #000 calc(100% - ${getButtonSize()}), 
-        ${(props) => (props.$hasRightScroll ? `transparent calc(100% - ${getButtonSize()}), transparent 100%` : '#000 100%')}
+        90deg,
+        ${(props) =>
+            props.$hasLeftScroll
+                ? `transparent 0px,
+                   transparent ${getButtonSize()},
+                   #000 ${getButtonSize()},`
+                : '#000 0px,'}
+        #000 calc(100% - ${getButtonSize()}),
+        ${(props) =>
+            props.$hasRightScroll
+                ? `transparent calc(100% - ${getButtonSize()}),
+                   transparent 100%`
+                : '#000 100%'}
     );
 `;
 

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -51,17 +51,13 @@ const TabsWrapper = styled.div<TabsWrapperProps>`
                 props.$hasLeftScroll
                     ? `transparent 0px,
                        transparent ${getButtonSize()},
-                       #000 ${getButtonSize()},`
-                    : 
-                    '#000 0px,'
+                       #000 ${getButtonSize()},` : '#000 0px,'
             )}
             #000 calc(100% - ${getButtonSize()}),
             ${(props) => (
                 props.$hasRightScroll
                     ? `transparent calc(100% - ${getButtonSize()}),
-                       transparent 100%`
-                    : 
-                    '#000 100%'
+                       transparent 100%` : '#000 100%'
             )}
         )
     ;

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -122,8 +122,8 @@ const ScrollButton = styled(Button) <{ $position: 'left' | 'right'; }>`
 `;
 
 const AddButton = styled(Button)`
-    align-self: center;  
-    flex-shrink: 0;  
+    align-self: center;
+    flex-shrink: 0;
 `;
 
 export interface Tab {

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -56,20 +56,12 @@ const TabsWrapper = styled.div<TabsWrapperProps>`
     mask-image:
         linear-gradient(
             90deg,
-            ${(props) => (
-        props.$hasLeftScroll
-            ? `transparent 0px,
-                       transparent ${buttonSize},
-                       #000 ${buttonSize},` : '#000 0px,'
-    )}
+            ${(props) => ( props.$hasLeftScroll
+            ? `transparent 0px, transparent ${buttonSize}, #000 ${buttonSize},` : '#000 0px,')}
             #000 calc(100% - ${buttonSize}),
-            ${(props) => (
-        props.$hasRightScroll
-            ? `transparent calc(100% - ${buttonSize}),
-                       transparent 100%` : '#000 100%'
-    )}
-        )
-    ;
+            ${(props) => ( props.$hasRightScroll
+            ? `transparent calc(100% - ${buttonSize}), transparent 100%` : '#000 100%')}
+        );
     overflow: hidden;
 `;
 

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -44,7 +44,8 @@ const TabButtonsContainer = styled.div`
 `;
 
 const TabsWrapper = styled.div<TabsWrapperProps>`
-    mask-image: linear-gradient(
+    mask-image: 
+        linear-gradient(
         90deg,
         ${(props) => (
             props.$hasLeftScroll

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -30,7 +30,7 @@ interface TabsWrapperProps {
 
 const TabTopSection = styled.div`
     display: grid;
-    grid-template-areas: "tabs addButton";
+    grid-template-areas: 'tabs addButton';
     grid-template-columns: auto 1fr;
     position: relative;
     width: 100%;
@@ -44,15 +44,15 @@ const TabTopSection = styled.div`
         position: absolute;
         width: 100%;
     }
-`
+`;
 
 const TabButtonsContainer = styled.div`
     /* stylelint-disable-next-line @stylistic/declaration-bang-space-before */
     display: flex;
     grid-area: tabs;
     height: var(--size-2halfx);
-    position: relative;
     overflow: hidden;
+    position: relative;
 `;
 
 const TabsWrapper = styled.div<TabsWrapperProps>`

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -56,10 +56,10 @@ const TabsWrapper = styled.div<TabsWrapperProps>`
     mask-image:
         linear-gradient(
             90deg,
-            ${(props) => ( props.$hasLeftScroll
+            ${(props) => (props.$hasLeftScroll
             ? `transparent 0px, transparent ${buttonSize}, #000 ${buttonSize},` : '#000 0px,')}
             #000 calc(100% - ${buttonSize}),
-            ${(props) => ( props.$hasRightScroll
+            ${(props) => (props.$hasRightScroll
             ? `transparent calc(100% - ${buttonSize}), transparent 100%` : '#000 100%')}
         );
     overflow: hidden;

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -21,7 +21,7 @@ import { TabSize } from './types';
 import { tabsClasses } from './tabs-classes';
 import { focus } from '../../utils/css-state';
 
-const getButtonSize = (): string => 'var(--size-2x)';
+const buttonSize = 'var(--size-2x)';
 
 interface TabsWrapperProps {
     $hasLeftScroll: boolean;
@@ -45,7 +45,6 @@ const TabTopSection = styled.div`
 `;
 
 const TabButtonsContainer = styled.div`
-    /* stylelint-disable-next-line @stylistic/declaration-bang-space-before */
     display: flex;
     grid-area: tabs;
     height: var(--size-2halfx);
@@ -60,13 +59,13 @@ const TabsWrapper = styled.div<TabsWrapperProps>`
             ${(props) => (
         props.$hasLeftScroll
             ? `transparent 0px,
-                       transparent ${getButtonSize()},
-                       #000 ${getButtonSize()},` : '#000 0px,'
+                       transparent ${buttonSize},
+                       #000 ${buttonSize},` : '#000 0px,'
     )}
-            #000 calc(100% - ${getButtonSize()}),
+            #000 calc(100% - ${buttonSize}),
             ${(props) => (
         props.$hasRightScroll
-            ? `transparent calc(100% - ${getButtonSize()}),
+            ? `transparent calc(100% - ${buttonSize}),
                        transparent 100%` : '#000 100%'
     )}
         )
@@ -97,7 +96,7 @@ const ScrollButton = styled(Button) <{ $position: 'left' | 'right'; }>`
     min-height: auto;
     padding: 0 var(--spacing-1x);
     position: absolute;
-    width: ${getButtonSize};
+    width: ${buttonSize};
     z-index: 1;
 
     &:hover {
@@ -162,7 +161,7 @@ interface Props {
 
 export const Tabs: VoidFunctionComponent<Props> = ({
     className,
-    size = 'default',
+    size = 'medium',
     forceRenderTabPanels,
     tabs,
     defaultSelectedId,

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -17,9 +17,8 @@ import { Tooltip } from '../tooltip/tooltip';
 import { Button } from '../buttons/button';
 import { TabButton } from './tab-button';
 import { TabPanel } from './tab-panel';
+import { TabSize } from './types';
 import { tabsClasses } from './tabs-classes';
-
-export type TabSize = 'default' | 'small';
 
 const getButtonSize = (): string => 'var(--size-2x)';
 
@@ -45,7 +44,6 @@ const TabButtonsContainer = styled.div`
 `;
 
 const TabsWrapper = styled.div<TabsWrapperProps>`
-    // Prevent show Tabs behind buttons when scrolling
     mask-image: linear-gradient(
         90deg, 
         ${(props) => (props.$hasLeftScroll ? `transparent 0px, transparent ${getButtonSize()}, #000 ${getButtonSize()},` : '#000 0px,')}
@@ -114,10 +112,8 @@ export interface Tab {
 }
 
 interface TabItem extends Tab {
-    id: string;
     panelId: string;
     buttonRef: RefObject<HTMLButtonElement>;
-    onBeforeUnload?(): Promise<boolean>;
 }
 
 interface AddButtonProps {
@@ -162,6 +158,7 @@ export const Tabs: VoidFunctionComponent<Props> = ({
         tooltipContent: null,
         ...providedAddButtonProps,
     };
+
     const addButtonComponent = providedAddButtonProps && (
         <AddButton
             type="button"

--- a/packages/react/src/components/tabs/tabs.tsx
+++ b/packages/react/src/components/tabs/tabs.tsx
@@ -14,16 +14,14 @@ import { useTranslation } from '../../i18n/use-translation';
 import { getNextElement, getPreviousElement } from '../../utils/array';
 import { Icon, IconName } from '../icon/icon';
 import { Tooltip } from '../tooltip/tooltip';
+import { Button } from '../buttons/button';
 import { TabButton } from './tab-button';
 import { TabPanel } from './tab-panel';
-import { Button } from '../buttons/button';
 import { tabsClasses } from './tabs-classes';
 
 export type TabSize = 'default' | 'small';
 
-const getButtonSize = () => {
-    return 'var(--size-2x)';
-};
+const getButtonSize = (): string => 'var(--size-2x)';
 
 interface TabsWrapperProps {
     $hasLeftScroll: boolean;
@@ -47,14 +45,14 @@ const TabButtonsContainer = styled.div`
 `;
 
 const TabsWrapper = styled.div<TabsWrapperProps>`
-    // Hides Tabs behind buttons when scrolling
+    // Prevent show Tabs behind buttons when scrolling
     mask-image: linear-gradient(
         90deg, 
-        ${props => props.$hasLeftScroll ? `transparent 0px, transparent ${getButtonSize()}, #000 ${getButtonSize()},` : '#000 0px,'}
+        ${(props) => (props.$hasLeftScroll ? `transparent 0px, transparent ${getButtonSize()}, #000 ${getButtonSize()},` : '#000 0px,')}
         #000 calc(100% - ${getButtonSize()}), 
-        ${props => props.$hasRightScroll ? `transparent calc(100% - ${getButtonSize()}), transparent 100%` : '#000 100%'}
+        ${(props) => (props.$hasRightScroll ? `transparent calc(100% - ${getButtonSize()}), transparent 100%` : '#000 100%')}
     );
-`
+`;
 
 const TabList = styled.div`
     display: flex;
@@ -133,10 +131,10 @@ interface AddButtonProps {
 interface Props {
     className?: string;
     forceRenderTabPanels?: boolean;
-    size?: TabSize;  
+    size?: TabSize;
     tabs: Tab[];
     defaultSelectedId?: string;
-    onAddTab?(): void;
+    addButton?: AddButtonProps;
     onRemove?(tabId: string): void;
 }
 
@@ -182,7 +180,7 @@ export const Tabs: VoidFunctionComponent<Props> = ({
         onScroll: ({ atStartX, atEndX }) => {
             scrollLeftButtonRef.current?.classList.toggle('hidden', atStartX);
             scrollRightButtonRef.current?.classList.toggle('hidden', atEndX);
-            
+
             // Mettre à jour les états
             setIsLeftScrollVisible(!atStartX);
             setIsRightScrollVisible(!atEndX);

--- a/packages/react/src/components/tabs/types.ts
+++ b/packages/react/src/components/tabs/types.ts
@@ -1,7 +1,7 @@
 import { ReactNode, KeyboardEvent } from 'react';
 import { IconName } from '../icon/icon';
 
-export type TabSize = 'default' | 'small';
+export type TabSize = 'medium' | 'small';
 
 export interface Tab {
     id: string;

--- a/packages/react/src/components/tabs/types.ts
+++ b/packages/react/src/components/tabs/types.ts
@@ -1,0 +1,34 @@
+import { ReactNode, KeyboardEvent } from 'react';
+import { IconName } from '../icon/icon';
+
+export type TabSize = 'default' | 'small';
+
+export interface Tab {
+    id: string;
+    title: string;
+    leftIcon?: IconName;
+    rightIcon?: IconName;
+    panelContent: ReactNode;
+    onBeforeUnload?(): Promise<boolean>;
+}
+
+export interface TabButtonProps {
+    size: TabSize;
+    id: string;
+    panelId: string;
+    leftIcon?: IconName;
+    rightIcon?: IconName;
+    isSelected: boolean;
+    onClick(): void;
+    onRemove?(): void;
+    onKeyDown?(event: KeyboardEvent<HTMLDivElement>): void;
+    children: ReactNode;
+}
+
+export interface TabPanelProps {
+    buttonId: string,
+    children: ReactNode;
+    hidden: boolean,
+    id: string,
+    size?: TabSize;
+}

--- a/packages/react/src/themes/tokens/component/tab-tokens.ts
+++ b/packages/react/src/themes/tokens/component/tab-tokens.ts
@@ -1,12 +1,8 @@
 import type { ComponentTokenMap } from '../tokens';
 
 export type TabToken =
-    | 'tab-section-border-color'
-    | 'tab-section-box-shadow-color'
-    | 'tab-global-list-background-color'
-    | 'tab-section-list-background-color'
-    | 'tab-section-button-background-color'
-    | 'tab-global-button-background-color'
+    | 'tab-list-default-background-color'
+    | 'tab-list-dimmed-background-color'
     | 'tab-button-icon-color'
     | 'tab-button-text-color'
     | 'tab-button-indicator-hover-background-color'
@@ -14,23 +10,13 @@ export type TabToken =
     | 'tab-button-indicator-active-background-color'
     | 'tab-button-active-text-color'
     | 'tab-button-indicator-selected-background-color'
-    | 'tab-global-button-selected-background-color'
-    | 'tab-section-button-selected-background-color'
     | 'tab-button-selected-text-color'
-    | 'tab-section-background-color'
     | 'tab-scroll-button-hover-background-color'
     | 'tab-border-bottom-color';
 
 export const defaultTabTokens: ComponentTokenMap<TabToken> = {
-    'tab-global-button-background-color': 'transparent-100',
-    'tab-global-list-background-color': 'color-background',
-    'tab-global-button-selected-background-color': 'transparent-100',
-    'tab-section-background-color': 'color-background',
-    'tab-section-border-color': 'color-border',
-    'tab-section-box-shadow-color': 'color-box-shadow',
-    'tab-section-list-background-color': 'color-background-neutral-subtle',
-    'tab-section-button-background-color': 'color-background',
-    'tab-section-button-selected-background-color': 'color-background',
+    'tab-list-default-background-color': 'color-background',
+    'tab-list-dimmed-background-color': 'color-background-neutral-subtle',
     'tab-button-icon-color': 'color-content-subtle',
     'tab-button-text-color': 'color-content-subtle',
     'tab-button-hover-text-color': 'color-content-hover',

--- a/packages/react/src/themes/tokens/component/tab-tokens.ts
+++ b/packages/react/src/themes/tokens/component/tab-tokens.ts
@@ -1,8 +1,7 @@
 import type { ComponentTokenMap } from '../tokens';
 
 export type TabToken =
-    | 'tab-list-default-background-color'
-    | 'tab-list-dimmed-background-color'
+    | 'tab-list-background-color'
     | 'tab-button-icon-color'
     | 'tab-button-text-color'
     | 'tab-button-indicator-hover-background-color'
@@ -15,8 +14,7 @@ export type TabToken =
     | 'tab-border-bottom-color';
 
 export const defaultTabTokens: ComponentTokenMap<TabToken> = {
-    'tab-list-default-background-color': 'color-background',
-    'tab-list-dimmed-background-color': 'color-background-neutral-subtle',
+    'tab-list-background-color': 'color-background',
     'tab-button-icon-color': 'color-content-subtle',
     'tab-button-text-color': 'color-content-subtle',
     'tab-button-hover-text-color': 'color-content-hover',

--- a/packages/storybook/stories/tabs.mdx
+++ b/packages/storybook/stories/tabs.mdx
@@ -14,7 +14,7 @@ import * as TabsStories from './tabs.stories';
 
 ## Definition
 Tabs allow users to alternate between different contents that are parts of the same context [1]. 
-<Canvas of={TabsStories.Global} />
+<Canvas of={TabsStories.Medium} />
 
 ## Usage
 
@@ -32,10 +32,10 @@ Tabs allow users to alternate between different contents that are parts of the s
 ## Variants
 
 ### Global Tabs
-<Canvas of={TabsStories.Global} />
+<Canvas of={TabsStories.Medium} />
 
 ### Section Tabs
-<Canvas of={TabsStories.Default} />
+<Canvas of={TabsStories.Small} />
 
 ### Tabs with Add and Remove
 <Canvas of={TabsStories.AddAndDeleteTabs} />

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -87,13 +87,15 @@ type Story = StoryObj<typeof Tabs>;
 
 export const Default: Story = {
     ...TabsMeta,
+    args: {
+        size: 'default',
+    },
 };
 
-export const Global: Story = {
+export const Small: Story = {
     ...TabsMeta,
     args: {
-        global: true,
-        tablistType: 'dimmed',
+        size: 'small',
     },
 };
 
@@ -120,6 +122,7 @@ export const AddAndDeleteTabs: Story = {
             <Tabs
                 tabs={currentTabs}
                 onRemove={handleRemove}
+                size="default"
                 addButton={{
                     label: 'Add new tab',
                     tooltipContent: 'Add a new tab',
@@ -146,9 +149,9 @@ export const Scrollable: Story = {
 
         return (
             <div style={{ maxWidth: '600px' }}>
-                <Tabs tabs={customTabs} />
+                <Tabs tabs={customTabs} size="default" />
                 <br />
-                <Tabs tabs={customTabs} global />
+                <Tabs tabs={customTabs} size="small" />
             </div>
         );
     },

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -85,10 +85,10 @@ const TabsMeta: Meta<typeof Tabs> = {
 export default TabsMeta;
 type Story = StoryObj<typeof Tabs>;
 
-export const Default: Story = {
+export const Medium: Story = {
     ...TabsMeta,
     args: {
-        size: 'default',
+        size: 'medium',
     },
 };
 
@@ -122,7 +122,7 @@ export const AddAndDeleteTabs: Story = {
             <Tabs
                 tabs={currentTabs}
                 onRemove={handleRemove}
-                size="default"
+                size="medium"
                 addButton={{
                     label: 'Add new tab',
                     tooltipContent: 'Add a new tab',
@@ -149,7 +149,7 @@ export const Scrollable: Story = {
 
         return (
             <div style={{ maxWidth: '600px' }}>
-                <Tabs tabs={customTabs} size="default" />
+                <Tabs tabs={customTabs} size="medium" />
                 <br />
                 <Tabs tabs={customTabs} size="small" />
             </div>

--- a/packages/storybook/stories/tabs.stories.tsx
+++ b/packages/storybook/stories/tabs.stories.tsx
@@ -93,6 +93,7 @@ export const Global: Story = {
     ...TabsMeta,
     args: {
         global: true,
+        tablistType: 'dimmed',
     },
 };
 


### PR DESCRIPTION
DS-1294

**BREAKING:**
- retrait du boolean "global"
- changement aux tokens
---
Le style visuel du composant "Sectional Tab" a été modifié dans Figma. Le visuel est identique pour les deux variantes à l'exception de la taille des éléments. Le background, les couleurs et indicateurs sont les même. J'ai également ajouté l'option d'avoir ou non un `padding` avant les tabs du tablist. Ça va permettre de respecter certains visuels où les tabs arrive flush avec son _container_.

[EDIT]
J'ai dû modifier un peu l'ordre des éléments lorsqu'il y a un scroll et le bouton "add new Tab".

+ modifier tooltip sur le bouton Add new tabs pour qu'il ne soit affiché que lorsque le bouton est disabled
