### PR TITLE
fix(Tooltip): move aria-describedby to children

### DIFF
--- a/packages/react/src/components/link/link.test.tsx.snap
+++ b/packages/react/src/components/link/link.test.tsx.snap
@@ -880,6 +880,7 @@ exports[`Link Component Styling matches icon only snapshot 1`] = `
     tabindex="-1"
   >
     <a
+      aria-describedby="uuid2"
       aria-disabled="false"
       class="c1"
       data-testid="link"

--- a/packages/react/src/components/link/link.test.tsx.snap
+++ b/packages/react/src/components/link/link.test.tsx.snap
@@ -874,7 +874,6 @@ exports[`Link Component Styling matches icon only snapshot 1`] = `
 }
 
 <span
-    aria-describedby="uuid2"
     class="c0"
     data-testid="tooltip"
     id="tooltip-trigger-uuid2"

--- a/packages/react/src/components/password-input/password-input.test.tsx.snap
+++ b/packages/react/src/components/password-input/password-input.test.tsx.snap
@@ -384,7 +384,6 @@ exports[`PasswordInput matches the snapshot (Disabled) 1`] = `
       class="c3"
     >
       <span
-        aria-describedby="uuid2"
         class="c4"
         data-testid="tooltip"
         id="tooltip-trigger-uuid2"
@@ -855,7 +854,6 @@ exports[`PasswordInput matches the snapshot (Invalid) 1`] = `
       class="c5"
     >
       <span
-        aria-describedby="uuid2"
         class="c6"
         data-testid="tooltip"
         id="tooltip-trigger-uuid2"
@@ -1285,7 +1283,6 @@ exports[`PasswordInput matches the snapshot (Normal) 1`] = `
       class="c3"
     >
       <span
-        aria-describedby="uuid2"
         class="c4"
         data-testid="tooltip"
         id="tooltip-trigger-uuid2"

--- a/packages/react/src/components/password-input/password-input.test.tsx.snap
+++ b/packages/react/src/components/password-input/password-input.test.tsx.snap
@@ -390,6 +390,7 @@ exports[`PasswordInput matches the snapshot (Disabled) 1`] = `
         tabindex="-1"
       >
         <button
+          aria-describedby="uuid2"
           aria-label="Show password in plain text."
           aria-pressed="false"
           class="c5 c6"
@@ -860,6 +861,7 @@ exports[`PasswordInput matches the snapshot (Invalid) 1`] = `
         tabindex="-1"
       >
         <button
+          aria-describedby="uuid2"
           aria-label="Show password in plain text."
           aria-pressed="false"
           class="c7 c8"
@@ -1289,6 +1291,7 @@ exports[`PasswordInput matches the snapshot (Normal) 1`] = `
         tabindex="-1"
       >
         <button
+          aria-describedby="uuid2"
           aria-label="Show password in plain text."
           aria-pressed="false"
           class="c5 c6"

--- a/packages/react/src/components/tooltip/tooltip.test.tsx.snap
+++ b/packages/react/src/components/tooltip/tooltip.test.tsx.snap
@@ -175,7 +175,6 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
   label="Test Content"
 >
   <styled.span
-    aria-describedby="uuid1"
     data-testid="tooltip"
     id="tooltip-trigger-uuid1"
     onBlur={[Function]}
@@ -188,7 +187,6 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
     tabIndex={0}
   >
     <span
-      aria-describedby="uuid1"
       className="c0"
       data-testid="tooltip"
       id="tooltip-trigger-uuid1"
@@ -202,11 +200,13 @@ exports[`Tooltip Has default desktop styles (defaultOpen) 1`] = `
       tabIndex={0}
     >
       <Icon
+        aria-describedby="uuid1"
         color="#1B1C1E"
         name="info"
         size="16"
       >
         <svg
+          aria-describedby="uuid1"
           color="#1B1C1E"
           focusable={false}
           height="16"
@@ -448,7 +448,6 @@ exports[`Tooltip Has default desktop styles 1`] = `
   label="Test Content"
 >
   <styled.span
-    aria-describedby="uuid1"
     data-testid="tooltip"
     id="tooltip-trigger-uuid1"
     onBlur={[Function]}
@@ -461,7 +460,6 @@ exports[`Tooltip Has default desktop styles 1`] = `
     tabIndex={0}
   >
     <span
-      aria-describedby="uuid1"
       className="c0"
       data-testid="tooltip"
       id="tooltip-trigger-uuid1"
@@ -725,7 +723,6 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
   label="Test Content"
 >
   <styled.span
-    aria-describedby="uuid1"
     data-testid="tooltip"
     id="tooltip-trigger-uuid1"
     onBlur={[Function]}
@@ -738,7 +735,6 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
     tabIndex={0}
   >
     <span
-      aria-describedby="uuid1"
       className="c0"
       data-testid="tooltip"
       id="tooltip-trigger-uuid1"
@@ -752,11 +748,13 @@ exports[`Tooltip Has mobile styles (defaultOpen) 1`] = `
       tabIndex={0}
     >
       <Icon
+        aria-describedby="uuid1"
         color="#1B1C1E"
         name="info"
         size="24"
       >
         <svg
+          aria-describedby="uuid1"
           color="#1B1C1E"
           focusable={false}
           height="24"
@@ -998,7 +996,6 @@ exports[`Tooltip Has mobile styles 1`] = `
   label="Test Content"
 >
   <styled.span
-    aria-describedby="uuid1"
     data-testid="tooltip"
     id="tooltip-trigger-uuid1"
     onBlur={[Function]}
@@ -1011,7 +1008,6 @@ exports[`Tooltip Has mobile styles 1`] = `
     tabIndex={0}
   >
     <span
-      aria-describedby="uuid1"
       className="c0"
       data-testid="tooltip"
       id="tooltip-trigger-uuid1"

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -357,7 +357,7 @@ export const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
 
         if (isValidElement(children)) {
             return cloneElement(children as ReactElement, {
-                'aria-describedby':  tooltipId,
+                'aria-describedby': tooltipId,
             });
         }
 

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -11,6 +11,7 @@ import {
     cloneElement,
     isValidElement,
     ReactElement,
+    ReactNode,
 } from 'react';
 import { PopperOptions, TriggerType, usePopperTooltip } from 'react-popper-tooltip';
 import styled, { css } from 'styled-components';
@@ -340,7 +341,7 @@ export const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
         setIsClicked(false);
     }, [isMobile, closeTooltip]);
 
-    const renderChildrenWithAria = () => {
+    const renderChildrenWithAria = (): ReactNode => {
         if (!children) {
             return (
                 <Icon
@@ -356,7 +357,7 @@ export const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
 
         if (isValidElement(children)) {
             return cloneElement(children as ReactElement, {
-                'aria-describedby': isVisible ? tooltipId : undefined,
+                'aria-describedby':  tooltipId,
             });
         }
 

--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -8,6 +8,9 @@ import {
     useRef,
     useMemo,
     useState,
+    cloneElement,
+    isValidElement,
+    ReactElement,
 } from 'react';
 import { PopperOptions, TriggerType, usePopperTooltip } from 'react-popper-tooltip';
 import styled, { css } from 'styled-components';
@@ -337,12 +340,34 @@ export const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
         setIsClicked(false);
     }, [isMobile, closeTooltip]);
 
+    const renderChildrenWithAria = () => {
+        if (!children) {
+            return (
+                <Icon
+                    name="info"
+                    size={isMobile ? '24' : '16'}
+                    color={invertedIcon
+                        ? Theme.component['tooltip-inverted-icon-color']
+                        : Theme.component['tooltip-icon-color']}
+                    aria-describedby={isVisible ? tooltipId : undefined}
+                />
+            );
+        }
+
+        if (isValidElement(children)) {
+            return cloneElement(children as ReactElement, {
+                'aria-describedby': isVisible ? tooltipId : undefined,
+            });
+        }
+
+        return children;
+    };
+
     return (
         <>
             <StyledSpan
                 data-testid="tooltip"
                 className={className}
-                aria-describedby={tooltipId}
                 id={tooltipTriggerId}
                 tabIndex={(children || disabled) ? -1 : 0}
                 onBlur={handleBLur}
@@ -354,15 +379,7 @@ export const Tooltip: FunctionComponent<PropsWithChildren<TooltipProps>> = ({
                 onMouseLeave={handleMouseLeave}
                 ref={popperTooltip.setTriggerRef}
             >
-                {children || (
-                    <Icon
-                        name="info"
-                        size={isMobile ? '24' : '16'}
-                        color={invertedIcon
-                            ? Theme.component['tooltip-inverted-icon-color']
-                            : Theme.component['tooltip-icon-color']}
-                    />
-                )}
+                {renderChildrenWithAria()}
             </StyledSpan>
 
             <TooltipContainer


### PR DESCRIPTION
DS-1333

l'attribut `aria-describedby` était sur le span qui _wrap_ l'élément recevant le tooltip, il fallait le déplacer sur le children puisque c'est cette élément qui reçoit le focus et donc qui doit être décrit par la valeur de l'attribut.