### PR TITLE
fix(Link): add aria-label icon only

### DIFF
--- a/packages/react/src/components/link/link.test.tsx.snap
+++ b/packages/react/src/components/link/link.test.tsx.snap
@@ -882,6 +882,7 @@ exports[`Link Component Styling matches icon only snapshot 1`] = `
   >
     <a
       aria-disabled="false"
+      aria-label="Navigation Link"
       class="c1"
       data-testid="link"
       href="#"

--- a/packages/react/src/components/link/link.tsx
+++ b/packages/react/src/components/link/link.tsx
@@ -43,6 +43,7 @@ export const Link: FC<LinkProps> = ({
             to={external ? undefined : href}
             data-testid="link"
             aria-disabled={disabled ? 'true' : 'false'}
+            aria-label={isIconOnly ? icon.label : undefined}
             id={id}
             href={disabled ? undefined : href}
             onClick={handleClick}


### PR DESCRIPTION
DS-1336

Ajouter un aria-label sur le lien lorsqu'il a seulement une icône.