### PR TITLE
Add z-index to MenuButton component

### DIFF
--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -19,6 +19,7 @@ const StyledMenu = styled(Menu)`
     max-width: ${menuDimensions.maxWidth};
     min-width: ${menuDimensions.minWidth};
     position: absolute;
+    z-index: 1;
     ${({ $placement }) => ($placement === 'left' ? 'right: 0;' : 'left: 0;')}
 `;
 


### PR DESCRIPTION
# Context
Le dropdown des options ne s'affiche pas au-dessus du bouton des autres menus.
![Capture d’écran, le 2025-04-04 à 11 09 24](https://github.com/user-attachments/assets/acb665a3-802c-4580-8af7-28c60a1015fa)

## Maintenant

![Capture d’écran, le 2025-04-04 à 11 16 58](https://github.com/user-attachments/assets/7909b586-d1ee-4670-95e9-550d5e6bcb3d)
![Capture d’écran, le 2025-04-04 à 11 19 05](https://github.com/user-attachments/assets/b964635c-0385-4580-b22c-7ff281c35885)
![Capture d’écran, le 2025-04-04 à 11 17 18](https://github.com/user-attachments/assets/b40f53ab-621c-4a94-8df3-e14f36ff73cf)
