### PR TITLE
fix(Table): apply default text-align left to header

### DIFF
--- a/packages/react/src/components/table/table-row.tsx
+++ b/packages/react/src/components/table/table-row.tsx
@@ -1,9 +1,9 @@
-import { CSSProperties, ReactElement } from 'react';
+import { CSSProperties, ReactElement, useMemo } from 'react';
 import { flexRender, Row } from '@tanstack/react-table';
 import styled, { css, FlattenInterpolation, ThemedStyledProps, ThemeProps } from 'styled-components';
 import { ResolvedTheme } from '../../themes';
 import { focus } from '../../utils/css-state';
-import { isLastColumnInAGroup } from './utils/table-utils';
+import { findNearestTextAlign, isLastColumnInAGroup } from './utils/table-utils';
 import { CustomCell } from './types';
 
 interface StyledTableRowProps {
@@ -94,7 +94,7 @@ export const StyledTableRow = styled.tr<StyledTableRowProps>`
             cursor: pointer;
         }
     `}
-    
+
     ${getRowBackgroundColor}
     ${getCellBackgroundCss}
 `;
@@ -116,10 +116,12 @@ const StyledCell = styled.td<StyledCellProps>`
 
 function getCell<TData extends object, TValue>(cell: CustomCell<TData, TValue>): ReactElement | null {
     const columnDef = cell.column.columnDef;
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const textAlign = useMemo(() => findNearestTextAlign(cell.column), [cell.column]);
     return (
         <StyledCell
             $sticky={columnDef.sticky || false}
-            $textAlign={columnDef.textAlign}
+            $textAlign={textAlign}
             $startOffset={cell.column.getStart()}
             key={cell.id}
             id={cell.id}

--- a/packages/react/src/components/table/table.test.tsx
+++ b/packages/react/src/components/table/table.test.tsx
@@ -85,6 +85,7 @@ const columnsWithHeadersGrouped: TableColumn<TestData>[] = [
                 accessorKey: 'column3',
             },
         ],
+        textAlign: 'right',
     },
 ];
 

--- a/packages/react/src/components/table/table.test.tsx.snap
+++ b/packages/react/src/components/table/table.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`Table has aria-label on header columns 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -34,6 +35,7 @@ exports[`Table has aria-label on header columns 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -159,6 +161,7 @@ exports[`Table has clickable rows styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -221,6 +224,7 @@ exports[`Table has clickable rows styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -352,6 +356,7 @@ exports[`Table has column with headers grouped 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
   border-right: 1px solid #DBDEE1;
 }
 
@@ -368,9 +373,27 @@ exports[`Table has column with headers grouped 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: right;
+  border-right: 1px solid #DBDEE1;
 }
 
 .c4:before {
+  border-bottom: 1px solid #DBDEE1;
+  bottom: 0;
+  content: '';
+  position: absolute;
+  right: 0;
+  width: 100%;
+}
+
+.c5 {
+  background-color: inherit;
+  box-sizing: border-box;
+  position: relative;
+  text-align: left;
+}
+
+.c5:before {
   border-bottom: 1px solid #DBDEE1;
   bottom: 0;
   content: '';
@@ -383,24 +406,32 @@ exports[`Table has column with headers grouped 1`] = `
   background-color: inherit;
 }
 
-.c6 {
+.c7 {
   background-color: inherit;
 }
 
-.c6:not(:first-child) {
+.c7:not(:first-child) {
   border-top: 1px solid #DBDEE1;
 }
 
-.c6 td {
-  background-color: inherit;
-}
-
-.c7 {
+.c7 td {
   background-color: inherit;
 }
 
 .c8 {
   background-color: inherit;
+  text-align: left;
+}
+
+.c9 {
+  background-color: inherit;
+  text-align: left;
+  border-right: 1px solid #DBDEE1;
+}
+
+.c10 {
+  background-color: inherit;
+  text-align: right;
   border-right: 1px solid #DBDEE1;
 }
 
@@ -437,7 +468,7 @@ exports[`Table has column with headers grouped 1`] = `
   background: #FFFFFF;
 }
 
-.c5 {
+.c6 {
   background: transparent;
 }
 
@@ -458,7 +489,7 @@ exports[`Table has column with headers grouped 1`] = `
         Group 1
       </th>
       <th
-        class="c3"
+        class="c4"
         scope="col"
       >
         Group 2
@@ -468,7 +499,7 @@ exports[`Table has column with headers grouped 1`] = `
       class="c2"
     >
       <th
-        class="c4"
+        class="c5"
         scope="col"
       >
         Column 1
@@ -480,7 +511,7 @@ exports[`Table has column with headers grouped 1`] = `
         Column 2
       </th>
       <th
-        class="c3"
+        class="c4"
         scope="col"
       >
         Column 3
@@ -488,68 +519,68 @@ exports[`Table has column with headers grouped 1`] = `
     </tr>
   </thead>
   <tbody
-    class="c5"
+    class="c6"
   >
     <tr
-      class="c6"
+      class="c7"
       data-testid="table-row-0"
     >
       <td
-        class="c7"
+        class="c8"
         id="0_column1"
       >
         Hello
       </td>
       <td
-        class="c8"
+        class="c9"
         id="0_column2"
       >
         World
       </td>
       <td
-        class="c8"
+        class="c10"
         id="0_column3"
       />
     </tr>
     <tr
-      class="c6"
+      class="c7"
       data-testid="table-row-1"
     >
       <td
-        class="c7"
+        class="c8"
         id="1_column1"
       >
         Hello
       </td>
       <td
-        class="c8"
+        class="c9"
         id="1_column2"
       >
         Planet
       </td>
       <td
-        class="c8"
+        class="c10"
         id="1_column3"
       />
     </tr>
     <tr
-      class="c6"
+      class="c7"
       data-testid="table-row-2"
     >
       <td
-        class="c7"
+        class="c8"
         id="2_column1"
       >
         Hello
       </td>
       <td
-        class="c8"
+        class="c9"
         id="2_column2"
       >
         Galaxy
       </td>
       <td
-        class="c8"
+        class="c10"
         id="2_column3"
       />
     </tr>
@@ -739,6 +770,7 @@ exports[`Table has desktop styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -768,6 +800,7 @@ exports[`Table has desktop styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -893,6 +926,7 @@ exports[`Table has error rows styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -934,6 +968,7 @@ exports[`Table has error rows styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -1059,6 +1094,7 @@ exports[`Table has mobile styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -1088,6 +1124,7 @@ exports[`Table has mobile styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -1224,24 +1261,45 @@ exports[`Table has rowNumbers styles 1`] = `
   width: 100%;
 }
 
+.c4 {
+  background-color: inherit;
+  box-sizing: border-box;
+  position: relative;
+  text-align: left;
+}
+
+.c4:before {
+  border-bottom: 1px solid #DBDEE1;
+  bottom: 0;
+  content: '';
+  position: absolute;
+  right: 0;
+  width: 100%;
+}
+
 .c2 {
-  background-color: inherit;
-}
-
-.c5 {
-  background-color: inherit;
-}
-
-.c5:not(:first-child) {
-  border-top: 1px solid #DBDEE1;
-}
-
-.c5 td {
   background-color: inherit;
 }
 
 .c6 {
   background-color: inherit;
+}
+
+.c6:not(:first-child) {
+  border-top: 1px solid #DBDEE1;
+}
+
+.c6 td {
+  background-color: inherit;
+}
+
+.c7 {
+  background-color: inherit;
+}
+
+.c9 {
+  background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -1273,7 +1331,7 @@ exports[`Table has rowNumbers styles 1`] = `
   width: 1px;
 }
 
-.c7 {
+.c8 {
   box-sizing: border-box;
   color: #60666E;
   font-size: 0.75rem;
@@ -1289,7 +1347,7 @@ exports[`Table has rowNumbers styles 1`] = `
   background: #FFFFFF;
 }
 
-.c4 {
+.c5 {
   background: transparent;
 }
 
@@ -1307,13 +1365,13 @@ exports[`Table has rowNumbers styles 1`] = `
         scope="col"
       />
       <th
-        class="c3"
+        class="c4"
         scope="col"
       >
         Column 1
       </th>
       <th
-        class="c3"
+        class="c4"
         scope="col"
       >
         Column 2
@@ -1321,84 +1379,84 @@ exports[`Table has rowNumbers styles 1`] = `
     </tr>
   </thead>
   <tbody
-    class="c4"
+    class="c5"
   >
     <tr
-      class="c5"
+      class="c6"
       data-testid="table-row-0"
     >
       <td
-        class="c6"
+        class="c7"
         id="0_numbers"
       >
         <span
-          class="c7"
+          class="c8"
         >
           1
         </span>
       </td>
       <td
-        class="c6"
+        class="c9"
         id="0_column1"
       >
         Hello
       </td>
       <td
-        class="c6"
+        class="c9"
         id="0_column2"
       >
         World
       </td>
     </tr>
     <tr
-      class="c5"
+      class="c6"
       data-testid="table-row-1"
     >
       <td
-        class="c6"
+        class="c7"
         id="1_numbers"
       >
         <span
-          class="c7"
+          class="c8"
         >
           2
         </span>
       </td>
       <td
-        class="c6"
+        class="c9"
         id="1_column1"
       >
         Hello
       </td>
       <td
-        class="c6"
+        class="c9"
         id="1_column2"
       >
         Planet
       </td>
     </tr>
     <tr
-      class="c5"
+      class="c6"
       data-testid="table-row-2"
     >
       <td
-        class="c6"
+        class="c7"
         id="2_numbers"
       >
         <span
-          class="c7"
+          class="c8"
         >
           3
         </span>
       </td>
       <td
-        class="c6"
+        class="c9"
         id="2_column1"
       >
         Hello
       </td>
       <td
-        class="c6"
+        class="c9"
         id="2_column2"
       >
         Galaxy
@@ -1520,24 +1578,45 @@ exports[`Table has selectable rows styles 1`] = `
   width: 100%;
 }
 
+.c12 {
+  background-color: inherit;
+  box-sizing: border-box;
+  position: relative;
+  text-align: left;
+}
+
+.c12:before {
+  border-bottom: 1px solid #DBDEE1;
+  bottom: 0;
+  content: '';
+  position: absolute;
+  right: 0;
+  width: 100%;
+}
+
 .c2 {
-  background-color: inherit;
-}
-
-.c13 {
-  background-color: inherit;
-}
-
-.c13:not(:first-child) {
-  border-top: 1px solid #DBDEE1;
-}
-
-.c13 td {
   background-color: inherit;
 }
 
 .c14 {
   background-color: inherit;
+}
+
+.c14:not(:first-child) {
+  border-top: 1px solid #DBDEE1;
+}
+
+.c14 td {
+  background-color: inherit;
+}
+
+.c15 {
+  background-color: inherit;
+}
+
+.c16 {
+  background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -1573,7 +1652,7 @@ exports[`Table has selectable rows styles 1`] = `
   background: #FFFFFF;
 }
 
-.c12 {
+.c13 {
   background: transparent;
 }
 
@@ -1620,13 +1699,13 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </th>
       <th
-        class="c3"
+        class="c12"
         scope="col"
       >
         Column 1
       </th>
       <th
-        class="c3"
+        class="c12"
         scope="col"
       >
         Column 2
@@ -1634,14 +1713,14 @@ exports[`Table has selectable rows styles 1`] = `
     </tr>
   </thead>
   <tbody
-    class="c12"
+    class="c13"
   >
     <tr
-      class="c13"
+      class="c14"
       data-testid="table-row-0"
     >
       <td
-        class="c14"
+        class="c15"
         id="0_selection"
       >
         <label
@@ -1674,24 +1753,24 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </td>
       <td
-        class="c14"
+        class="c16"
         id="0_column1"
       >
         Hello
       </td>
       <td
-        class="c14"
+        class="c16"
         id="0_column2"
       >
         World
       </td>
     </tr>
     <tr
-      class="c13"
+      class="c14"
       data-testid="table-row-1"
     >
       <td
-        class="c14"
+        class="c15"
         id="1_selection"
       >
         <label
@@ -1724,24 +1803,24 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </td>
       <td
-        class="c14"
+        class="c16"
         id="1_column1"
       >
         Hello
       </td>
       <td
-        class="c14"
+        class="c16"
         id="1_column2"
       >
         Planet
       </td>
     </tr>
     <tr
-      class="c13"
+      class="c14"
       data-testid="table-row-2"
     >
       <td
-        class="c14"
+        class="c15"
         id="2_selection"
       >
         <label
@@ -1774,13 +1853,13 @@ exports[`Table has selectable rows styles 1`] = `
         </label>
       </td>
       <td
-        class="c14"
+        class="c16"
         id="2_column1"
       >
         Hello
       </td>
       <td
-        class="c14"
+        class="c16"
         id="2_column2"
       >
         Galaxy
@@ -1795,6 +1874,7 @@ exports[`Table has small rowSize styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -1824,6 +1904,7 @@ exports[`Table has small rowSize styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -1957,7 +2038,7 @@ exports[`Table has sorting styles 1`] = `
   display: -ms-flexbox;
   display: flex;
   font: inherit;
-  text-align: left;
+  justify-self: flex-start;
 }
 
 .c4 {
@@ -1975,6 +2056,7 @@ exports[`Table has sorting styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -2008,6 +2090,7 @@ exports[`Table has sorting styles 1`] = `
 
 .c8 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -2157,6 +2240,7 @@ exports[`Table has sticky column styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
   left: 0px;
   position: -webkit-sticky;
   position: sticky;
@@ -2176,6 +2260,7 @@ exports[`Table has sticky column styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
   left: 75px;
   position: -webkit-sticky;
   position: sticky;
@@ -2195,6 +2280,7 @@ exports[`Table has sticky column styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c5:before {
@@ -2224,6 +2310,7 @@ exports[`Table has sticky column styles 1`] = `
 
 .c8 {
   background-color: inherit;
+  text-align: left;
   left: 0px;
   position: -webkit-sticky;
   position: sticky;
@@ -2232,6 +2319,7 @@ exports[`Table has sticky column styles 1`] = `
 
 .c9 {
   background-color: inherit;
+  text-align: left;
   left: 75px;
   position: -webkit-sticky;
   position: sticky;
@@ -2240,6 +2328,7 @@ exports[`Table has sticky column styles 1`] = `
 
 .c10 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -2389,6 +2478,7 @@ exports[`Table has sticky header styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -2422,6 +2512,7 @@ exports[`Table has sticky header styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -2547,6 +2638,7 @@ exports[`Table has striped styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -2580,6 +2672,7 @@ exports[`Table has striped styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {
@@ -2705,6 +2798,7 @@ exports[`Table has tablet styles 1`] = `
   background-color: inherit;
   box-sizing: border-box;
   position: relative;
+  text-align: left;
 }
 
 .c3:before {
@@ -2734,6 +2828,7 @@ exports[`Table has tablet styles 1`] = `
 
 .c6 {
   background-color: inherit;
+  text-align: left;
 }
 
 .c0 {

--- a/packages/react/src/components/table/table.tsx
+++ b/packages/react/src/components/table/table.tsx
@@ -432,7 +432,10 @@ export const Table = <T extends object>({
 
     // extends columns with utility column if needed (for row numbers and row selection)
     const columns = useMemo(() => {
-        const cols = [...providedColumns];
+        const cols: TableColumn<T>[] = providedColumns.map((column) => ({
+            ...column,
+            textAlign: column.textAlign ?? 'left',
+        }));
 
         if (rowSelectionMode) {
             cols.unshift(getSelectionColumn<T>(

--- a/packages/react/src/components/table/utils/table-utils.ts
+++ b/packages/react/src/components/table/utils/table-utils.ts
@@ -1,5 +1,7 @@
 import { type Column, type RowSelectionState } from '@tanstack/react-table';
+import { CSSProperties } from 'react';
 import { type RowSelectionMode, type TableRowId } from '../table';
+import { CustomCell, TableColumn } from '../types';
 
 export function createRowSelectionStateFromSelectedRowIds(
     selectedRowIds: TableRowId[],
@@ -64,4 +66,22 @@ export function isLastColumnInAGroup<TData, TValue>(column: Column<TData, TValue
 
     const parentColumns = column.parent.columns;
     return column === parentColumns[parentColumns.length - 1];
+}
+
+export function findNearestTextAlign<TData extends object, TValue>(
+    column: CustomCell<TData, TValue>['column'],
+): CSSProperties['textAlign'] {
+    if (column.columnDef.textAlign) {
+        return column.columnDef.textAlign;
+    }
+
+    if (column.parent) {
+        const parentColumnDef = column.parent.columnDef as TableColumn<TData>;
+        if (parentColumnDef?.textAlign) {
+            return parentColumnDef.textAlign;
+        }
+        return findNearestTextAlign(column.parent as CustomCell<TData, TValue>['column']);
+    }
+
+    return undefined;
 }

--- a/packages/storybook/stories/data-table.stories.tsx
+++ b/packages/storybook/stories/data-table.stories.tsx
@@ -29,6 +29,7 @@ interface Data {
     column1: string;
     column2: string;
     column3: string;
+    column4?: string;
 }
 
 export const Default: Story = {
@@ -726,11 +727,13 @@ export const SortableRows: Story = {
                 header: 'Column 2',
                 accessorKey: 'column2',
                 sortable: true,
+                textAlign: 'right',
             },
             {
                 header: 'Column 3',
                 accessorKey: 'column3',
                 sortable: true,
+                textAlign: 'center',
             },
             {
                 header: 'Custom sort by length',
@@ -1763,6 +1766,17 @@ export const GroupedHeaders: Story = {
                         accessorKey: 'column3',
                     },
                 ],
+                textAlign: 'center',
+            },
+            {
+                header: 'Group 3',
+                columns: [
+                    {
+                        header: 'Column 4',
+                        accessorKey: 'column4',
+                    },
+                ],
+                textAlign: 'right',
             },
         ];
 
@@ -1771,11 +1785,13 @@ export const GroupedHeaders: Story = {
                 column1: 'a',
                 column2: 'a',
                 column3: 'a',
+                column4: 'a',
             },
             {
                 column1: 'b',
                 column2: 'b',
                 column3: 'b',
+                column4: 'b',
             },
         ];
 


### PR DESCRIPTION
La PR #1153 enlevait le text-align sur tout, mais le browser centre par défaut le th. On veut que le default soit text-align left partout.