### PR TITLE
fix(DropdownList): update listbox position when textbox height changes

### DIFF
--- a/packages/legacy-tests/test/setup.ts
+++ b/packages/legacy-tests/test/setup.ts
@@ -35,3 +35,12 @@ jest.mock('react', () => ({
 Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
     get() { return this.parentElement; },
 });
+
+global.ResizeObserver = class {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    observe(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    unobserve(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    disconnect(): void {}
+};

--- a/packages/react/src/components/dropdown-list/dropdown-list.tsx
+++ b/packages/react/src/components/dropdown-list/dropdown-list.tsx
@@ -432,12 +432,21 @@ export const DropdownList: VoidFunctionComponent<DropdownListProps<boolean | und
             }
         }
 
+        let resizeObserver: ResizeObserver | undefined;
+        if (textboxRef.current) {
+            resizeObserver = new ResizeObserver(() => {
+                updatePosition();
+            });
+            resizeObserver.observe(textboxRef.current);
+        }
+
         window.addEventListener('resize', updatePosition);
         window.addEventListener('scroll', updatePosition, true);
 
         return () => {
             window.removeEventListener('resize', updatePosition);
             window.removeEventListener('scroll', updatePosition, true);
+            resizeObserver?.disconnect();
         };
     }, [open, shadowRoot?.host]);
 

--- a/packages/react/test/setup.ts
+++ b/packages/react/test/setup.ts
@@ -32,3 +32,12 @@ jest.mock('react', () => ({
 Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
     get() { return this.parentElement; },
 });
+
+global.ResizeObserver = class {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    observe(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    unobserve(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    disconnect(): void {}
+};


### PR DESCRIPTION
Ref: https://equisoft.atlassian.net/browse/LG-108
## Contexte 
Depuis la version 9.8.1, le Dropdownlist ne s'ajuste pas lorsque l'on retire/ajout des éléments en multiselect. 

- Ajout d'un ResizeObserver au composant DropdownList pour surveiller les changements de taille du champ texte et mettre à jour la position de la liste déroulante en conséquence. 

Comportement actuel: 
![Screen Recording 2025-07-01 at 12 43 49 PM](https://github.com/user-attachments/assets/af296587-261b-48d8-b821-47ef766a7906)
Avec le fix: 
![Screen Recording 2025-07-01 at 12 39 45 PM](https://github.com/user-attachments/assets/797f3f1f-37ac-400e-968a-c3d09f39e8e9)

## Références
- https://github.com/kronostechnologies/design-elements/pull/1160