### PR TITLE
feat(MenuButton): provide react element to render

### DIFF
--- a/packages/legacy-tests/src/components/menu/menu.test.tsx
+++ b/packages/legacy-tests/src/components/menu/menu.test.tsx
@@ -292,4 +292,23 @@ describe('Menu', () => {
         />);
         expect(tree).toMatchSnapshot();
     });
+
+    it('renders custom content when content prop is provided', () => {
+        const CustomContent = () => <span data-testid="custom-content">Custom!</span>;
+        const tree = renderWithTheme(<Menu
+            options={[
+                {
+                    label: 'Custom',
+                    content: <CustomContent />,
+                    onClick: jest.fn(),
+                },
+                {
+                    label: 'Default',
+                    onClick: jest.fn(),
+                },
+            ]}
+        />);
+        expect(tree.find('[data-testid="custom-content"]').length).toBe(1);
+        expect(tree.text()).toContain('Default');
+    });
 });

--- a/packages/react/src/components/menu/menu.tsx
+++ b/packages/react/src/components/menu/menu.tsx
@@ -134,6 +134,7 @@ export interface MenuOption {
     options?: MenuItem[]; // eslint-disable-line @typescript-eslint/no-use-before-define
     disabled?: boolean;
     onClick?(): void;
+    content?: React.ReactNode;
 }
 
 export interface MenuGroup {
@@ -368,15 +369,21 @@ export const Menu = forwardRef(({
                             ref={opt.ref}
                             $withEmptyIcon={hasAnyOptionWithIcon && !opt.iconName}
                         >
-                            {opt.iconName && (
-                                <StyledIcon
-                                    focusable={false}
-                                    aria-hidden
-                                    name={opt.iconName}
-                                    size="1rem"
-                                />
+                            {opt.content ? (
+                                opt.content
+                            ) : (
+                                <>
+                                    {opt.iconName && (
+                                        <StyledIcon
+                                            focusable={false}
+                                            aria-hidden
+                                            name={opt.iconName}
+                                            size="1rem"
+                                        />
+                                    )}
+                                    <Label>{opt.label}</Label>
+                                </>
                             )}
-                            <Label>{opt.label}</Label>
                             {opt.options && <Icon aria-hidden name="chevronRight" size="1rem" />}
                         </Button>
                         {opt.options && isSubMenuOpen(opt) && (

--- a/packages/storybook/stories/menu-button.mdx
+++ b/packages/storybook/stories/menu-button.mdx
@@ -51,6 +51,27 @@ Menu Button allows users to open a menu with a list of interactive options (acti
 ## Properties
 <ArgTypes of={MenuButton} />
 
+### Custom Content
+You can pass a custom React node to the `content` prop of a menu option to fully control its rendering. This allows you to use custom labels, icons, or any other React elements inside a menu item.
+
+**Example:**
+```jsx
+<MenuButton
+  options={[
+    {
+      content: <><MyCustomIcon /> <span>Custom Label</span></>,
+      onClick: () => alert('Custom!'),
+    },
+    {
+      label: 'Default Label',
+      iconName: 'star',
+      onClick: () => alert('Default!'),
+    },
+  ]}
+/>
+```
+If `content` is provided, it will be rendered instead of the default label and icon.
+
 ## References
 1. [https://carbondesignsystem.com/components/menu-buttons/usage/](https://carbondesignsystem.com/components/menu-buttons/usage/)
 2. [https://medium.com/@h_locke/links-vs-buttons-e8b523660fb3](https://medium.com/@h_locke/links-vs-buttons-e8b523660fb3)

--- a/packages/storybook/stories/menu-button.mdx
+++ b/packages/storybook/stories/menu-button.mdx
@@ -51,8 +51,8 @@ Menu Button allows users to open a menu with a list of interactive options (acti
 ## Properties
 <ArgTypes of={MenuButton} />
 
-### Custom Content
-You can pass a custom React node to the `content` prop of a menu option to fully control its rendering. This allows you to use custom labels, icons, or any other React elements inside a menu item.
+### Menu Option Content
+You can pass a custom React node to the `content` prop of a menu option to fully control its rendering.
 
 **Example:**
 ```jsx


### PR DESCRIPTION
Ref: https://equisoft.atlassian.net/browse/LG-119

## Description

Adding the ability to provide custom react element to be rendered. Default behaviour stays the same, it only renders if `content` is provided to `MenuOption`

Example: 
<img width="235" height="134" alt="image" src="https://github.com/user-attachments/assets/47dacd5c-cbfa-4e20-b2bd-ef20023ec0fd" />
