### PR TITLE
DOPS-6017 ci: add missing id-token permission on the workflow

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -280,6 +280,9 @@ jobs:
     name: "React: Deploy"
     runs-on: ubuntu-latest
     environment: npm-deployment
+    permissions:
+      id-token: write
+      contents: read
     needs:
       - setup
       - react_eslint


### PR DESCRIPTION
Nécessaire pour tout ce qui est OICD.