### PR TITLE
fix(Dropdowns): fix keyboard interaction with all dropdowns

### DIFF
--- a/packages/legacy-tests/src/components/menu/menu.test.tsx
+++ b/packages/legacy-tests/src/components/menu/menu.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactWrapper } from 'enzyme';
 import { Menu, MenuOption } from '~/components/menu/menu';
 import { getByTestId } from '../../test-utils/enzyme-selectors';
 import { expectFocusToBeOn } from '../../test-utils/enzyme-utils';
@@ -49,6 +50,12 @@ describe('Menu', () => {
         optionsWithSubMenu = givenOptionsWithSubMenu(options);
     });
 
+    function sendKeyTimes(wrapper: ReactWrapper, times: number, key: 'ArrowUp' | 'ArrowDown'): void {
+        for (let i = 0; i < times; i += 1) {
+            getByTestId(wrapper, 'menu').simulate('keydown', { key });
+        }
+    }
+
     it('should call onClick callback when option is clicked', () => {
         const wrapper = mountWithTheme(<Menu options={options} />);
 
@@ -84,7 +91,7 @@ describe('Menu', () => {
     });
 
     it('should open subMenu when ArrowRight key is pressed given option as subMenu', () => {
-        const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} initialFocusIndex={0} />);
+        const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'ArrowRight' });
 
@@ -127,7 +134,7 @@ describe('Menu', () => {
     });
 
     it('should collapse subMenu when ArrowLeft key is pressed inside subMenu', () => {
-        const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} initialFocusIndex={0} />);
+        const wrapper = mountWithTheme(<Menu options={optionsWithSubMenu} />);
 
         getByTestId(wrapper, 'menu').simulate('keydown', { key: 'ArrowRight' });
         getByTestId(wrapper, 'menu-option-0-sub-menu').simulate('keydown', { key: 'ArrowLeft' });
@@ -149,7 +156,7 @@ describe('Menu', () => {
         it('should be on the first option when initialFocus is set to 0', () => {
             const wrapper = mountWithTheme(
                 <div id="root">
-                    <Menu options={options} initialFocusIndex={0} />
+                    <Menu options={options} />
                 </div>,
                 { attachTo: divElement },
             );
@@ -159,7 +166,7 @@ describe('Menu', () => {
 
         it('should be on the next option when ArrowDown key is pressed', () => {
             const wrapper = mountWithTheme(
-                <Menu options={options} initialFocusIndex={0} />,
+                <Menu options={options} />,
                 { attachTo: divElement },
             );
 
@@ -170,9 +177,10 @@ describe('Menu', () => {
 
         it('should be on the first option when ArrowDown key is pressed on last option', () => {
             const wrapper = mountWithTheme(
-                <Menu options={options} initialFocusIndex={options.length - 1} />,
+                <Menu options={options} />,
                 { attachTo: divElement },
             );
+            sendKeyTimes(wrapper, options.length - 1, 'ArrowDown');
 
             getByTestId(wrapper, 'menu').simulate('keydown', { key: 'ArrowDown' });
 
@@ -181,18 +189,19 @@ describe('Menu', () => {
 
         it('should be on the previous option when ArrowUp key is pressed', () => {
             const wrapper = mountWithTheme(
-                <Menu options={options} initialFocusIndex={1} />,
+                <Menu options={options} />,
                 { attachTo: divElement },
             );
+            sendKeyTimes(wrapper, 2, 'ArrowDown');
 
             getByTestId(wrapper, 'menu').simulate('keydown', { key: 'ArrowUp' });
 
-            expectFocusToBeOn(getByTestId(wrapper, `menu-option-${0}`));
+            expectFocusToBeOn(getByTestId(wrapper, `menu-option-1`));
         });
 
         it('should be on the last option when ArrowUp key is pressed on first option', () => {
             const wrapper = mountWithTheme(
-                <Menu options={options} initialFocusIndex={0} />,
+                <Menu options={options} />,
                 { attachTo: divElement },
             );
 
@@ -203,7 +212,7 @@ describe('Menu', () => {
 
         it('should be on the first option starting with typed character', () => {
             const wrapper = mountWithTheme(
-                <Menu options={options} initialFocusIndex={0} />,
+                <Menu options={options} />,
                 { attachTo: divElement },
             );
 
@@ -214,7 +223,7 @@ describe('Menu', () => {
 
         it('should be on the first element of subMenu when ArrowRight key is pressed given option as subMenu', () => {
             const wrapper = mountWithTheme(
-                <Menu options={optionsWithSubMenu} initialFocusIndex={0} />,
+                <Menu options={optionsWithSubMenu} />,
                 { attachTo: divElement },
             );
 
@@ -225,7 +234,7 @@ describe('Menu', () => {
 
         it('should be on the subMenu parent option when ArrowLeft key is pressed inside subMenu', () => {
             const wrapper = mountWithTheme(
-                <Menu options={optionsWithSubMenu} initialFocusIndex={0} />,
+                <Menu options={optionsWithSubMenu} />,
                 { attachTo: divElement },
             );
 
@@ -237,7 +246,7 @@ describe('Menu', () => {
 
         it('should stay inside the menu when the subMenu is open by hovering with the mouse', () => {
             const wrapper = mountWithTheme(
-                <Menu options={optionsWithSubMenu} initialFocusIndex={0} />,
+                <Menu options={optionsWithSubMenu} />,
                 { attachTo: divElement },
             );
 

--- a/packages/legacy-tests/src/components/menu/menu.test.tsx.snap
+++ b/packages/legacy-tests/src/components/menu/menu.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`Menu matches the snapshot (menu with groups) 1`] = `
   width: 100%;
 }
 
+.c2.eds-util-focus-visible,
 .c2:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;
@@ -205,6 +206,7 @@ exports[`Menu matches the snapshot (menu with icons) 1`] = `
   width: 100%;
 }
 
+.c1.eds-util-focus-visible,
 .c1:focus-visible {
   box-shadow: 0 0 0 0 transparent;
   outline: 2px solid #006296;

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.test.tsx.snap
@@ -428,7 +428,7 @@ exports[`BentoMenuButton Matches Snapshot (productGroups and externalLinks) 1`] 
     >
       <button
         aria-expanded="true"
-        class="c1 c2"
+        class="c1 c2 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -1205,7 +1205,7 @@ exports[`BentoMenuButton Matches Snapshot (productLinks and externalLinks) 1`] =
     >
       <button
         aria-expanded="true"
-        class="c1 c2"
+        class="c1 c2 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -1565,7 +1565,7 @@ exports[`BentoMenuButton Matches Snapshot (tag="nav") 1`] = `
 >
   <button
     aria-expanded="false"
-    class="c1 c2"
+    class="c1 c2 eds-DropdownMenuButton-button"
     data-testid="menu-button"
     type="button"
   >

--- a/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
+++ b/packages/react/src/components/bento-menu-button/bento-menu-button.tsx
@@ -104,10 +104,10 @@ export const BentoMenuButton: FunctionComponent<PropsWithChildren<BentoMenuButto
                 render={(close) => (
                     <>
                         {productLinkGroups.length > 0 && (
-                            productLinkGroups.map((productLinkGroup) => (
+                            productLinkGroups.map((productLinkGroup, i) => (
                                 <ProductGroup
                                     key={productLinkGroup.name}
-                                    firstItemRef={firstItemRef}
+                                    firstItemRef={i === 0 ? firstItemRef : undefined}
                                     label={productLinkGroup.label}
                                     name={productLinkGroup.name}
                                     onClick={close}

--- a/packages/react/src/components/breadcrumb/breadcrumb.tsx
+++ b/packages/react/src/components/breadcrumb/breadcrumb.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { useShadowRoot } from 'react-shadow';
 import styled from 'styled-components';
 import { useDropdown } from '../../hooks/use-dropdown';
-import { getRootElement } from '../../utils/dom';
+import { activeElementIsInside, getRootElement } from '../../utils/dom';
 import { eventIsInside } from '../../utils/events';
 import { IconButton } from '../buttons';
 import { Icon } from '../icon';
@@ -97,8 +97,6 @@ function truncateLabel(label: string): string {
 
 export const Breadcrumb: FC<BreadcrumbProps> = ({ className, history }) => {
     const [isOpen, setOpen] = useState(false);
-    const [focusedValue, setFocusedValue] = useState('');
-
     const navRef = useRef<HTMLDivElement>(null);
     const shadowRoot = useShadowRoot();
     const {
@@ -126,13 +124,10 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ className, history }) => {
     }, [buttonRef, isOpen, navListRef]);
 
     useEffect(() => {
-        if (history.length > 0) {
-            setFocusedValue(isOpen ? history[1].value : '');
-        }
         document.addEventListener('mouseup', handleClickOutside);
 
         return () => document.removeEventListener('mouseup', handleClickOutside);
-    }, [handleClickOutside, isOpen, history]);
+    }, [handleClickOutside]);
 
     function handleNavListKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
         if (event.key === 'Escape') {
@@ -142,7 +137,7 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ className, history }) => {
 
         if (isOpen) {
             setTimeout(() => {
-                const isFocusInsideNav = navRef.current?.contains(document.activeElement);
+                const isFocusInsideNav = activeElementIsInside(navListRef.current);
 
                 if (!isFocusInsideNav) {
                     setOpen(false);
@@ -187,7 +182,6 @@ export const Breadcrumb: FC<BreadcrumbProps> = ({ className, history }) => {
                                     ordered
                                     data-testid="nav-list"
                                     ref={refs.setFloating}
-                                    focusedValue={focusedValue}
                                     onChange={() => setOpen(false)}
                                     onKeyDown={handleNavListKeyDown}
                                     options={hiddenRoutes}

--- a/packages/react/src/components/date-picker/date-picker.test.tsx
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx
@@ -3,70 +3,70 @@ import { Datepicker } from './date-picker';
 
 describe('Datepicker', () => {
     test('matches snapshot (data-testid)', () => {
-        const { container } = renderWithProviders(
+        const { baseElement } = renderWithProviders(
             <Datepicker data-testid="some-data-test-id" label="date" />,
             'desktop',
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (desktop)', () => {
-        const { container } = renderWithProviders(<Datepicker label="date" />, 'desktop');
+        const { baseElement } = renderWithProviders(<Datepicker label="date" />, 'desktop');
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (mobile)', () => {
-        const { container } = renderWithProviders(<Datepicker label="date" />, 'mobile');
+        const { baseElement } = renderWithProviders(<Datepicker label="date" />, 'mobile');
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('has openToDate', () => {
-        const { container } = renderWithProviders(
+        const { baseElement } = renderWithProviders(
             <Datepicker label="date" openToDate={new Date('1995-05-05, 12:00')} />,
             'mobile',
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (open, desktop)', () => {
-        const { container } = renderWithProviders(
+        const { baseElement } = renderWithProviders(
             <Datepicker label="date" open maxDate={new Date('2010-10-10, 12:00')} />,
             'desktop',
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (open, mobile)', () => {
-        const { container } = renderWithProviders(
+        const { baseElement } = renderWithProviders(
             <Datepicker label="date" startOpen maxDate={new Date('2010-10-10, 12:00')} />,
             'mobile',
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (open, hasTodayButton)', () => {
-        const { container } = renderWithProviders(
+        const { baseElement } = renderWithProviders(
             <Datepicker label="date" hasTodayButton startOpen maxDate={new Date('2010-10-10, 12:00')} />,
         );
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (invalid)', () => {
-        const { container } = renderWithProviders(<Datepicker label="date" valid={false} />);
+        const { baseElement } = renderWithProviders(<Datepicker label="date" valid={false} />);
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 
     test('matches snapshot (disabled)', () => {
-        const { container } = renderWithProviders(<Datepicker label="date" disabled />);
+        const { baseElement } = renderWithProviders(<Datepicker label="date" disabled />);
 
-        expect(container.firstChild).toMatchSnapshot();
+        expect(baseElement).toMatchSnapshot();
     });
 });

--- a/packages/react/src/components/date-picker/date-picker.test.tsx.snap
+++ b/packages/react/src/components/date-picker/date-picker.test.tsx.snap
@@ -342,49 +342,65 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
-    <div>
-      <div
-        class="react-datepicker__input-container"
+.c8 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="c0"
+    >
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
+        date
+      </label>
+      <div
+        class="c3 c4"
+      >
+        <div>
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-label="Choose date"
+          class="c6 c7"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="24"
+            width="24"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-label="Choose date"
-      class="c6 c7"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c8"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (data-testid) 1`] = `
@@ -729,51 +745,67 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
+.c8 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+<body>
+  <div>
     <div
-      class="react-datepicker-wrapper"
+      class="c0"
     >
-      <div
-        class="react-datepicker__input-container"
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput"
-          data-testid="some-data-test-id"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
+        date
+      </label>
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="react-datepicker-wrapper"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput"
+              data-testid="some-data-test-id"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-label="Choose date"
+          class="c6 c7"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="16"
+            width="16"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-label="Choose date"
-      class="c6 c7"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c8"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (desktop) 1`] = `
@@ -1118,51 +1150,67 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
+.c8 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+<body>
+  <div>
     <div
-      class="react-datepicker-wrapper"
+      class="c0"
     >
-      <div
-        class="react-datepicker__input-container"
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
+        date
+      </label>
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="react-datepicker-wrapper"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-label="Choose date"
+          class="c6 c7"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="16"
+            width="16"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-label="Choose date"
-      class="c6 c7"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c8"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (disabled) 1`] = `
@@ -1507,53 +1555,69 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
+.c8 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+<body>
+  <div>
     <div
-      class="react-datepicker-wrapper"
+      class="c0"
     >
-      <div
-        class="react-datepicker__input-container"
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput"
-          data-testid="text-input"
-          disabled=""
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
+        date
+      </label>
+      <div
+        class="c3 c4"
+      >
+        <div
+          class="react-datepicker-wrapper"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput"
+              data-testid="text-input"
+              disabled=""
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-disabled="true"
+          aria-label="Choose date"
+          class="c6 c7"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="16"
+            width="16"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-disabled="true"
-      aria-label="Choose date"
-      class="c6 c7"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c8"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (invalid) 1`] = `
@@ -1924,65 +1988,81 @@ label + .c5 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <span
-    class="c3"
-    data-testid="invalid-field"
-    id="uuid1_invalid"
-  >
-    <svg
-      class="c4"
-      color="currentColor"
-      focusable="false"
-      height="16"
-      width="16"
-    />
-    Invalid date
-  </span>
-  <div
-    class="c5 c6"
-  >
+.c10 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+<body>
+  <div>
     <div
-      class="react-datepicker-wrapper"
+      class="c0"
     >
-      <div
-        class="react-datepicker__input-container"
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c7 datePickerInput"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
+        date
+      </label>
+      <span
+        class="c3"
+        data-testid="invalid-field"
+        id="uuid1_invalid"
+      >
+        <svg
+          class="c4"
+          color="currentColor"
+          focusable="false"
+          height="16"
+          width="16"
         />
+        Invalid date
+      </span>
+      <div
+        class="c5 c6"
+      >
+        <div
+          class="react-datepicker-wrapper"
+        >
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c7 datePickerInput"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-label="Choose date"
+          class="c8 c9"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="16"
+            width="16"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-label="Choose date"
-      class="c8 c9"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c10"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (mobile) 1`] = `
@@ -2327,49 +2407,65 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
-    <div>
-      <div
-        class="react-datepicker__input-container"
+.c8 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="c0"
+    >
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
+        date
+      </label>
+      <div
+        class="c3 c4"
+      >
+        <div>
+          <div
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <button
+          aria-label="Choose date"
+          class="c6 c7"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="24"
+            width="24"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-label="Choose date"
-      class="c6 c7"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c8"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (open, desktop) 1`] = `
@@ -2869,807 +2965,819 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
+.c18 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+<body>
+  <div>
     <div
-      class="react-datepicker-wrapper"
+      class="c0"
     >
-      <div
-        class="react-datepicker__input-container"
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      class="react-datepicker__tab-loop"
-    >
+        date
+      </label>
       <div
-        class="react-datepicker__tab-loop__start"
-        tabindex="0"
-      />
-      <div
-        class="react-datepicker-popper popper"
-        data-placement="bottom-start"
-        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+        class="c3 c4"
       >
         <div
-          style="display: contents;"
+          class="react-datepicker-wrapper"
         >
           <div
-            style="display: contents;"
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="react-datepicker__tab-loop"
+        >
+          <div
+            class="react-datepicker__tab-loop__start"
+            tabindex="0"
+          />
+          <div
+            class="react-datepicker-popper popper"
+            data-placement="bottom-start"
+            style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
           >
             <div
-              aria-label="Choose date"
-              aria-live="polite"
-              aria-modal="true"
-              class="react-datepicker"
-              role="dialog"
+              style="display: contents;"
             >
-              <span
-                aria-live="polite"
-                class="react-datepicker__aria-live"
-                role="alert"
-              />
               <div
-                class="react-datepicker__month-container"
+                style="display: contents;"
               >
                 <div
-                  class="react-datepicker__header react-datepicker__header--custom"
+                  aria-label="Choose date"
+                  aria-live="polite"
+                  aria-modal="true"
+                  class="react-datepicker"
+                  role="dialog"
                 >
+                  <span
+                    aria-live="polite"
+                    class="react-datepicker__aria-live"
+                    role="alert"
+                  />
                   <div
-                    class="c6"
-                    data-testid="calendar-header"
+                    class="react-datepicker__month-container"
                   >
-                    <button
-                      aria-label="Go to previous month"
-                      class="c7 c8 c9"
-                      data-testid="month-previous"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        color="currentColor"
-                        focusable="false"
-                        height="16"
-                        width="16"
-                      />
-                    </button>
                     <div
-                      class="c10"
+                      class="react-datepicker__header react-datepicker__header--custom"
                     >
                       <div
-                        class="c11"
-                        style="margin-right: 8px;"
+                        class="c6"
+                        data-testid="calendar-header"
                       >
+                        <button
+                          aria-label="Go to previous month"
+                          class="c7 c8 c9"
+                          data-testid="month-previous"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            color="currentColor"
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
+                        </button>
                         <div
-                          class="c12 c13"
+                          class="c10"
                         >
                           <div
-                            aria-controls="uuid2_listbox"
-                            aria-expanded="false"
-                            aria-invalid="false"
-                            aria-label="Select a month"
-                            aria-labelledby="uuid2_label uuid2_listbox_october_label"
-                            aria-readonly="false"
-                            aria-required="false"
-                            class="c14"
-                            data-testid="month-select"
-                            id="uuid2"
-                            role="combobox"
-                            tabindex="0"
+                            class="c11"
+                            style="margin-right: 8px;"
                           >
-                            <input
-                              data-testid="input"
-                              type="hidden"
-                              value="october"
-                            />
-                            <span
-                              class="c15"
+                            <div
+                              class="c12 c13"
                             >
-                              Oct
+                              <div
+                                aria-controls="uuid2_listbox"
+                                aria-expanded="false"
+                                aria-invalid="false"
+                                aria-label="Select a month"
+                                aria-labelledby="uuid2_label uuid2_listbox_october_label"
+                                aria-readonly="false"
+                                aria-required="false"
+                                class="c14"
+                                data-testid="month-select"
+                                id="uuid2"
+                                role="combobox"
+                                tabindex="0"
+                              >
+                                <input
+                                  data-testid="input"
+                                  type="hidden"
+                                  value="october"
+                                />
+                                <span
+                                  class="c15"
+                                >
+                                  Oct
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  class="c16"
+                                  color="currentColor"
+                                  data-testid="arrow"
+                                  focusable="false"
+                                  height="16"
+                                  width="16"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="c11"
+                          >
+                            <div
+                              class="c12 c13"
+                            >
+                              <div
+                                aria-controls="uuid3_listbox"
+                                aria-expanded="false"
+                                aria-invalid="false"
+                                aria-label="Select a year"
+                                aria-labelledby="uuid3_label uuid3_listbox_2010_label"
+                                aria-readonly="false"
+                                aria-required="false"
+                                class="c14"
+                                data-testid="year-select"
+                                id="uuid3"
+                                role="combobox"
+                                tabindex="0"
+                              >
+                                <input
+                                  data-testid="input"
+                                  type="hidden"
+                                  value="2010"
+                                />
+                                <span
+                                  class="c15"
+                                >
+                                  2010
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  class="c16"
+                                  color="currentColor"
+                                  data-testid="arrow"
+                                  focusable="false"
+                                  height="16"
+                                  width="16"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <button
+                          aria-disabled="true"
+                          aria-label="Go to next month"
+                          class="c7 c8 c9"
+                          data-testid="month-next"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            color="currentColor"
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      role="table"
+                    >
+                      <div
+                        role="rowgroup"
+                      >
+                        <div
+                          class="react-datepicker__day-names"
+                          role="row"
+                        >
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Sunday
                             </span>
-                            <svg
+                            <span
                               aria-hidden="true"
-                              class="c16"
-                              color="currentColor"
-                              data-testid="arrow"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
+                            >
+                              Su
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Monday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Mo
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Tuesday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Tu
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Wednesday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              We
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Thursday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Th
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Friday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Fr
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Saturday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Sa
+                            </span>
                           </div>
                         </div>
                       </div>
                       <div
-                        class="c11"
+                        aria-label="Month October, 2010"
+                        class="react-datepicker__month"
+                        role="rowgroup"
                       >
                         <div
-                          class="c12 c13"
+                          class="react-datepicker__week"
+                          role="row"
                         >
                           <div
-                            aria-controls="uuid3_listbox"
-                            aria-expanded="false"
-                            aria-invalid="false"
-                            aria-label="Select a year"
-                            aria-labelledby="uuid3_label uuid3_listbox_2010_label"
-                            aria-readonly="false"
-                            aria-required="false"
-                            class="c14"
-                            data-testid="year-select"
-                            id="uuid3"
-                            role="combobox"
-                            tabindex="0"
+                            aria-disabled="false"
+                            aria-label="Choose Sunday, September 26th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
                           >
-                            <input
-                              data-testid="input"
-                              type="hidden"
-                              value="2010"
-                            />
-                            <span
-                              class="c15"
-                            >
-                              2010
-                            </span>
-                            <svg
-                              aria-hidden="true"
-                              class="c16"
-                              color="currentColor"
-                              data-testid="arrow"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
+                            26
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Monday, September 27th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            27
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Tuesday, September 28th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            28
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Wednesday, September 29th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            29
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Thursday, September 30th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            30
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Friday, October 1st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--001"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            1
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Saturday, October 2nd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            2
                           </div>
                         </div>
-                      </div>
-                    </div>
-                    <button
-                      aria-disabled="true"
-                      aria-label="Go to next month"
-                      class="c7 c8 c9"
-                      data-testid="month-next"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        color="currentColor"
-                        focusable="false"
-                        height="16"
-                        width="16"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  role="table"
-                >
-                  <div
-                    role="rowgroup"
-                  >
-                    <div
-                      class="react-datepicker__day-names"
-                      role="row"
-                    >
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
                         >
-                          Sunday
-                        </span>
-                        <span
-                          aria-hidden="true"
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Sunday, October 3rd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            3
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Monday, October 4th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--004"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            4
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Tuesday, October 5th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--005"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            5
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Wednesday, October 6th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--006"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            6
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Thursday, October 7th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--007"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            7
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Friday, October 8th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--008"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            8
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Saturday, October 9th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            9
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week react-datepicker__week--keyboard-selected"
+                          role="row"
                         >
-                          Su
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Sunday, October 10th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="0"
+                            title=""
+                          >
+                            10
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, October 11th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            11
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, October 12th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            12
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, October 13th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            13
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, October 14th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            14
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, October 15th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            15
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, October 16th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            16
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
                         >
-                          Monday
-                        </span>
-                        <span
-                          aria-hidden="true"
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Sunday, October 17th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            17
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, October 18th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            18
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, October 19th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            19
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, October 20th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            20
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, October 21st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            21
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, October 22nd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            22
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, October 23rd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            23
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
                         >
-                          Mo
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Sunday, October 24th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            24
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, October 25th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            25
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, October 26th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            26
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, October 27th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            27
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, October 28th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            28
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, October 29th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            29
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, October 30th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            30
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
                         >
-                          Tuesday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Tu
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Wednesday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          We
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Thursday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Th
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Friday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Fr
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Saturday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Sa
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="Month October, 2010"
-                    class="react-datepicker__month"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Sunday, September 26th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Monday, September 27th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Tuesday, September 28th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Wednesday, September 29th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Thursday, September 30th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Friday, October 1st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--001"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Saturday, October 2nd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        2
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Sunday, October 3rd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Monday, October 4th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--004"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        4
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Tuesday, October 5th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--005"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Wednesday, October 6th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--006"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Thursday, October 7th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--007"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Friday, October 8th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--008"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Saturday, October 9th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        9
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week react-datepicker__week--keyboard-selected"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Sunday, October 10th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="0"
-                        title=""
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, October 11th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        11
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, October 12th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, October 13th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, October 14th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, October 15th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, October 16th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        16
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Sunday, October 17th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, October 18th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        18
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, October 19th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, October 20th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, October 21st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, October 22nd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, October 23rd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        23
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Sunday, October 24th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, October 25th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        25
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, October 26th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, October 27th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, October 28th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, October 29th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, October 30th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        30
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Sunday, October 31st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, November 1st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, November 2nd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, November 3rd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, November 4th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        4
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, November 5th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, November 6th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        6
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Sunday, October 31st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            31
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, November 1st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            1
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, November 2nd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            2
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, November 3rd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            3
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, November 4th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            4
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, November 5th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            5
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, November 6th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            6
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
@@ -3677,29 +3785,33 @@ label + .c3 {
               </div>
             </div>
           </div>
+          <div
+            class="react-datepicker__tab-loop__end"
+            tabindex="0"
+          />
         </div>
+        <button
+          aria-label="Choose date"
+          class="c7 c17"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="16"
+            width="16"
+          />
+        </button>
       </div>
-      <div
-        class="react-datepicker__tab-loop__end"
-        tabindex="0"
-      />
     </div>
-    <button
-      aria-label="Choose date"
-      class="c7 c17"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c18"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (open, hasTodayButton) 1`] = `
@@ -4232,849 +4344,865 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
+.c20 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: var(--spacing-2x);
+}
+
+<body>
+  <div>
     <div
-      class="react-datepicker-wrapper"
+      class="c0"
     >
-      <div
-        class="react-datepicker__input-container"
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput react-datepicker-ignore-onclickoutside"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
-      </div>
-    </div>
-    <div
-      class="react-datepicker__tab-loop"
-    >
+        date
+      </label>
       <div
-        class="react-datepicker__tab-loop__start"
-        tabindex="0"
-      />
-      <div
-        class="react-datepicker-popper popper"
-        data-placement="bottom-start"
-        style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+        class="c3 c4"
       >
         <div
-          style="display: contents;"
+          class="react-datepicker-wrapper"
         >
           <div
-            style="display: contents;"
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput react-datepicker-ignore-onclickoutside"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+        </div>
+        <div
+          class="react-datepicker__tab-loop"
+        >
+          <div
+            class="react-datepicker__tab-loop__start"
+            tabindex="0"
+          />
+          <div
+            class="react-datepicker-popper popper"
+            data-placement="bottom-start"
+            style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
           >
             <div
-              aria-label="Choose date"
-              aria-live="polite"
-              aria-modal="true"
-              class="react-datepicker"
-              role="dialog"
+              style="display: contents;"
             >
-              <span
-                aria-live="polite"
-                class="react-datepicker__aria-live"
-                role="alert"
-              />
               <div
-                class="react-datepicker__month-container"
+                style="display: contents;"
               >
                 <div
-                  class="react-datepicker__header react-datepicker__header--custom"
+                  aria-label="Choose date"
+                  aria-live="polite"
+                  aria-modal="true"
+                  class="react-datepicker"
+                  role="dialog"
                 >
+                  <span
+                    aria-live="polite"
+                    class="react-datepicker__aria-live"
+                    role="alert"
+                  />
                   <div
-                    class="c6"
-                    data-testid="calendar-header"
+                    class="react-datepicker__month-container"
                   >
-                    <button
-                      aria-label="Go to previous month"
-                      class="c7 c8 c9"
-                      data-testid="month-previous"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        color="currentColor"
-                        focusable="false"
-                        height="16"
-                        width="16"
-                      />
-                    </button>
                     <div
-                      class="c10"
+                      class="react-datepicker__header react-datepicker__header--custom"
                     >
                       <div
-                        class="c11"
-                        style="margin-right: 8px;"
+                        class="c6"
+                        data-testid="calendar-header"
                       >
+                        <button
+                          aria-label="Go to previous month"
+                          class="c7 c8 c9"
+                          data-testid="month-previous"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            color="currentColor"
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
+                        </button>
                         <div
-                          class="c12 c13"
+                          class="c10"
                         >
                           <div
-                            aria-controls="uuid2_listbox"
-                            aria-expanded="false"
-                            aria-invalid="false"
-                            aria-label="Select a month"
-                            aria-labelledby="uuid2_label uuid2_listbox_october_label"
-                            aria-readonly="false"
-                            aria-required="false"
-                            class="c14"
-                            data-testid="month-select"
-                            id="uuid2"
-                            role="combobox"
-                            tabindex="0"
+                            class="c11"
+                            style="margin-right: 8px;"
                           >
-                            <input
-                              data-testid="input"
-                              type="hidden"
-                              value="october"
-                            />
-                            <span
-                              class="c15"
+                            <div
+                              class="c12 c13"
                             >
-                              Oct
+                              <div
+                                aria-controls="uuid2_listbox"
+                                aria-expanded="false"
+                                aria-invalid="false"
+                                aria-label="Select a month"
+                                aria-labelledby="uuid2_label uuid2_listbox_october_label"
+                                aria-readonly="false"
+                                aria-required="false"
+                                class="c14"
+                                data-testid="month-select"
+                                id="uuid2"
+                                role="combobox"
+                                tabindex="0"
+                              >
+                                <input
+                                  data-testid="input"
+                                  type="hidden"
+                                  value="october"
+                                />
+                                <span
+                                  class="c15"
+                                >
+                                  Oct
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  class="c16"
+                                  color="currentColor"
+                                  data-testid="arrow"
+                                  focusable="false"
+                                  height="16"
+                                  width="16"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="c11"
+                          >
+                            <div
+                              class="c12 c13"
+                            >
+                              <div
+                                aria-controls="uuid3_listbox"
+                                aria-expanded="false"
+                                aria-invalid="false"
+                                aria-label="Select a year"
+                                aria-labelledby="uuid3_label uuid3_listbox_2010_label"
+                                aria-readonly="false"
+                                aria-required="false"
+                                class="c14"
+                                data-testid="year-select"
+                                id="uuid3"
+                                role="combobox"
+                                tabindex="0"
+                              >
+                                <input
+                                  data-testid="input"
+                                  type="hidden"
+                                  value="2010"
+                                />
+                                <span
+                                  class="c15"
+                                >
+                                  2010
+                                </span>
+                                <svg
+                                  aria-hidden="true"
+                                  class="c16"
+                                  color="currentColor"
+                                  data-testid="arrow"
+                                  focusable="false"
+                                  height="16"
+                                  width="16"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <button
+                          aria-disabled="true"
+                          aria-label="Go to next month"
+                          class="c7 c8 c9"
+                          data-testid="month-next"
+                          type="button"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            color="currentColor"
+                            focusable="false"
+                            height="16"
+                            width="16"
+                          />
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      role="table"
+                    >
+                      <div
+                        role="rowgroup"
+                      >
+                        <div
+                          class="react-datepicker__day-names"
+                          role="row"
+                        >
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Sunday
                             </span>
-                            <svg
+                            <span
                               aria-hidden="true"
-                              class="c16"
-                              color="currentColor"
-                              data-testid="arrow"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
+                            >
+                              Su
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Monday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Mo
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Tuesday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Tu
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Wednesday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              We
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Thursday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Th
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Friday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Fr
+                            </span>
+                          </div>
+                          <div
+                            class="react-datepicker__day-name"
+                            role="columnheader"
+                          >
+                            <span
+                              class="react-datepicker__sr-only"
+                            >
+                              Saturday
+                            </span>
+                            <span
+                              aria-hidden="true"
+                            >
+                              Sa
+                            </span>
                           </div>
                         </div>
                       </div>
                       <div
-                        class="c11"
+                        aria-label="Month October, 2010"
+                        class="react-datepicker__month"
+                        role="rowgroup"
                       >
                         <div
-                          class="c12 c13"
+                          class="react-datepicker__week"
+                          role="row"
                         >
                           <div
-                            aria-controls="uuid3_listbox"
-                            aria-expanded="false"
-                            aria-invalid="false"
-                            aria-label="Select a year"
-                            aria-labelledby="uuid3_label uuid3_listbox_2010_label"
-                            aria-readonly="false"
-                            aria-required="false"
-                            class="c14"
-                            data-testid="year-select"
-                            id="uuid3"
-                            role="combobox"
-                            tabindex="0"
+                            aria-disabled="false"
+                            aria-label="Choose Sunday, September 26th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
                           >
-                            <input
-                              data-testid="input"
-                              type="hidden"
-                              value="2010"
-                            />
-                            <span
-                              class="c15"
-                            >
-                              2010
-                            </span>
-                            <svg
-                              aria-hidden="true"
-                              class="c16"
-                              color="currentColor"
-                              data-testid="arrow"
-                              focusable="false"
-                              height="16"
-                              width="16"
-                            />
+                            26
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Monday, September 27th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            27
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Tuesday, September 28th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            28
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Wednesday, September 29th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            29
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Thursday, September 30th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            30
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Friday, October 1st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--001"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            1
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Saturday, October 2nd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            2
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
+                        >
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Sunday, October 3rd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            3
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Monday, October 4th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--004"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            4
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Tuesday, October 5th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--005"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            5
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Wednesday, October 6th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--006"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            6
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Thursday, October 7th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--007"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            7
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Friday, October 8th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--008"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            8
+                          </div>
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Saturday, October 9th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            9
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week react-datepicker__week--keyboard-selected"
+                          role="row"
+                        >
+                          <div
+                            aria-disabled="false"
+                            aria-label="Choose Sunday, October 10th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="0"
+                            title=""
+                          >
+                            10
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, October 11th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            11
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, October 12th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            12
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, October 13th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            13
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, October 14th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            14
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, October 15th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            15
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, October 16th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            16
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
+                        >
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Sunday, October 17th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            17
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, October 18th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            18
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, October 19th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            19
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, October 20th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            20
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, October 21st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            21
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, October 22nd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            22
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, October 23rd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            23
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
+                        >
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Sunday, October 24th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            24
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, October 25th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            25
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, October 26th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            26
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, October 27th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            27
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, October 28th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            28
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, October 29th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            29
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, October 30th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            30
+                          </div>
+                        </div>
+                        <div
+                          class="react-datepicker__week"
+                          role="row"
+                        >
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Sunday, October 31st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            31
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Monday, November 1st, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            1
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Tuesday, November 2nd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            2
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Wednesday, November 3rd, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            3
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Thursday, November 4th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            4
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Friday, November 5th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            5
+                          </div>
+                          <div
+                            aria-disabled="true"
+                            aria-label="Not available Saturday, November 6th, 2010"
+                            aria-selected="false"
+                            class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
+                            role="gridcell"
+                            tabindex="-1"
+                            title=""
+                          >
+                            6
                           </div>
                         </div>
                       </div>
                     </div>
+                  </div>
+                  <div
+                    class="c17"
+                  >
                     <button
-                      aria-disabled="true"
-                      aria-label="Go to next month"
-                      class="c7 c8 c9"
-                      data-testid="month-next"
+                      aria-label="Choose today's date"
+                      class="c7 c18"
+                      data-testid="today-button"
                       type="button"
                     >
-                      <svg
-                        aria-hidden="true"
-                        color="currentColor"
-                        focusable="false"
-                        height="16"
-                        width="16"
-                      />
+                      Today
                     </button>
                   </div>
                 </div>
-                <div
-                  role="table"
-                >
-                  <div
-                    role="rowgroup"
-                  >
-                    <div
-                      class="react-datepicker__day-names"
-                      role="row"
-                    >
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Sunday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Su
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Monday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Mo
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Tuesday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Tu
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Wednesday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          We
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Thursday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Th
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Friday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Fr
-                        </span>
-                      </div>
-                      <div
-                        class="react-datepicker__day-name"
-                        role="columnheader"
-                      >
-                        <span
-                          class="react-datepicker__sr-only"
-                        >
-                          Saturday
-                        </span>
-                        <span
-                          aria-hidden="true"
-                        >
-                          Sa
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div
-                    aria-label="Month October, 2010"
-                    class="react-datepicker__month"
-                    role="rowgroup"
-                  >
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Sunday, September 26th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Monday, September 27th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Tuesday, September 28th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Wednesday, September 29th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Thursday, September 30th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        30
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Friday, October 1st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--001"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Saturday, October 2nd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        2
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Sunday, October 3rd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Monday, October 4th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--004"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        4
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Tuesday, October 5th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--005"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Wednesday, October 6th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--006"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        6
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Thursday, October 7th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--007"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        7
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Friday, October 8th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--008"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        8
-                      </div>
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Saturday, October 9th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        9
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week react-datepicker__week--keyboard-selected"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="false"
-                        aria-label="Choose Sunday, October 10th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="0"
-                        title=""
-                      >
-                        10
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, October 11th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        11
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, October 12th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        12
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, October 13th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        13
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, October 14th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        14
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, October 15th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        15
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, October 16th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        16
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Sunday, October 17th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        17
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, October 18th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        18
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, October 19th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        19
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, October 20th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        20
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, October 21st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        21
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, October 22nd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        22
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, October 23rd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        23
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Sunday, October 24th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        24
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, October 25th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        25
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, October 26th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        26
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, October 27th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        27
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, October 28th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        28
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, October 29th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        29
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, October 30th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        30
-                      </div>
-                    </div>
-                    <div
-                      class="react-datepicker__week"
-                      role="row"
-                    >
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Sunday, October 31st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        31
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Monday, November 1st, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        1
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Tuesday, November 2nd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        2
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Wednesday, November 3rd, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        3
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Thursday, November 4th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        4
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Friday, November 5th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        5
-                      </div>
-                      <div
-                        aria-disabled="true"
-                        aria-label="Not available Saturday, November 6th, 2010"
-                        aria-selected="false"
-                        class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
-                        role="gridcell"
-                        tabindex="-1"
-                        title=""
-                      >
-                        6
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="c17"
-              >
-                <button
-                  aria-label="Choose today's date"
-                  class="c7 c18"
-                  data-testid="today-button"
-                  type="button"
-                >
-                  Today
-                </button>
               </div>
             </div>
           </div>
+          <div
+            class="react-datepicker__tab-loop__end"
+            tabindex="0"
+          />
         </div>
+        <button
+          aria-label="Choose date"
+          class="c7 c19"
+          data-testid="calendar-button"
+          tabindex="0"
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="16"
+            width="16"
+          />
+        </button>
       </div>
-      <div
-        class="react-datepicker__tab-loop__end"
-        tabindex="0"
-      />
     </div>
-    <button
-      aria-label="Choose date"
-      class="c7 c19"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="16"
-        width="16"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c20"
+    data-testid="toasts"
+  />
+</body>
 `;
 
 exports[`Datepicker matches snapshot (open, mobile) 1`] = `
@@ -5574,803 +5702,815 @@ label + .c3 {
   width: var(--size-1x);
 }
 
-<div
-  class="c0"
->
-  <label
-    class="c1 c2"
-    for="uuid1"
-    id="uuid1_label"
-  >
-    date
-  </label>
-  <div
-    class="c3 c4"
-  >
-    <div>
-      <div
-        class="react-datepicker__input-container"
+.c18 {
+  box-sizing: border-box;
+  position: fixed;
+  z-index: 100000;
+  bottom: var(--spacing-2x);
+  right: 0;
+}
+
+<body>
+  <div>
+    <div
+      class="c0"
+    >
+      <label
+        class="c1 c2"
+        for="uuid1"
+        id="uuid1_label"
       >
-        <input
-          class="c5 datePickerInput react-datepicker-ignore-onclickoutside"
-          data-testid="text-input"
-          id="uuid1"
-          placeholder="YYYY-MM-DD"
-          type="text"
-          value=""
-        />
-      </div>
+        date
+      </label>
       <div
-        class="react-datepicker__tab-loop"
+        class="c3 c4"
       >
-        <div
-          class="react-datepicker__tab-loop__start"
-          tabindex="0"
-        />
-        <div
-          class="react-datepicker__portal"
-          tabindex="-1"
-        >
+        <div>
           <div
-            style="display: contents;"
+            class="react-datepicker__input-container"
+          >
+            <input
+              class="c5 datePickerInput react-datepicker-ignore-onclickoutside"
+              data-testid="text-input"
+              id="uuid1"
+              placeholder="YYYY-MM-DD"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="react-datepicker__tab-loop"
           >
             <div
-              style="display: contents;"
+              class="react-datepicker__tab-loop__start"
+              tabindex="0"
+            />
+            <div
+              class="react-datepicker__portal"
+              tabindex="-1"
             >
               <div
-                aria-label="Choose date"
-                aria-live="polite"
-                aria-modal="true"
-                class="react-datepicker"
-                role="dialog"
+                style="display: contents;"
               >
-                <span
-                  aria-live="polite"
-                  class="react-datepicker__aria-live"
-                  role="alert"
-                />
                 <div
-                  class="react-datepicker__month-container"
+                  style="display: contents;"
                 >
                   <div
-                    class="react-datepicker__header react-datepicker__header--custom"
+                    aria-label="Choose date"
+                    aria-live="polite"
+                    aria-modal="true"
+                    class="react-datepicker"
+                    role="dialog"
                   >
+                    <span
+                      aria-live="polite"
+                      class="react-datepicker__aria-live"
+                      role="alert"
+                    />
                     <div
-                      class="c6"
-                      data-testid="calendar-header"
+                      class="react-datepicker__month-container"
                     >
-                      <button
-                        aria-label="Go to previous month"
-                        class="c7 c8 c9"
-                        data-testid="month-previous"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable="false"
-                          height="20"
-                          width="20"
-                        />
-                      </button>
                       <div
-                        class="c10"
+                        class="react-datepicker__header react-datepicker__header--custom"
                       >
                         <div
-                          class="c11"
-                          style="margin-right: 8px;"
+                          class="c6"
+                          data-testid="calendar-header"
                         >
+                          <button
+                            aria-label="Go to previous month"
+                            class="c7 c8 c9"
+                            data-testid="month-previous"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              color="currentColor"
+                              focusable="false"
+                              height="20"
+                              width="20"
+                            />
+                          </button>
                           <div
-                            class="c12 c13"
+                            class="c10"
                           >
                             <div
-                              aria-controls="uuid2_listbox"
-                              aria-expanded="false"
-                              aria-invalid="false"
-                              aria-label="Select a month"
-                              aria-labelledby="uuid2_label uuid2_listbox_october_label"
-                              aria-readonly="false"
-                              aria-required="false"
-                              class="c14"
-                              data-testid="month-select"
-                              id="uuid2"
-                              role="combobox"
-                              tabindex="0"
+                              class="c11"
+                              style="margin-right: 8px;"
                             >
-                              <input
-                                data-testid="input"
-                                type="hidden"
-                                value="october"
-                              />
-                              <span
-                                class="c15"
+                              <div
+                                class="c12 c13"
                               >
-                                Oct
+                                <div
+                                  aria-controls="uuid2_listbox"
+                                  aria-expanded="false"
+                                  aria-invalid="false"
+                                  aria-label="Select a month"
+                                  aria-labelledby="uuid2_label uuid2_listbox_october_label"
+                                  aria-readonly="false"
+                                  aria-required="false"
+                                  class="c14"
+                                  data-testid="month-select"
+                                  id="uuid2"
+                                  role="combobox"
+                                  tabindex="0"
+                                >
+                                  <input
+                                    data-testid="input"
+                                    type="hidden"
+                                    value="october"
+                                  />
+                                  <span
+                                    class="c15"
+                                  >
+                                    Oct
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="c16"
+                                    color="currentColor"
+                                    data-testid="arrow"
+                                    focusable="false"
+                                    height="24"
+                                    width="24"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="c11"
+                            >
+                              <div
+                                class="c12 c13"
+                              >
+                                <div
+                                  aria-controls="uuid3_listbox"
+                                  aria-expanded="false"
+                                  aria-invalid="false"
+                                  aria-label="Select a year"
+                                  aria-labelledby="uuid3_label uuid3_listbox_2010_label"
+                                  aria-readonly="false"
+                                  aria-required="false"
+                                  class="c14"
+                                  data-testid="year-select"
+                                  id="uuid3"
+                                  role="combobox"
+                                  tabindex="0"
+                                >
+                                  <input
+                                    data-testid="input"
+                                    type="hidden"
+                                    value="2010"
+                                  />
+                                  <span
+                                    class="c15"
+                                  >
+                                    2010
+                                  </span>
+                                  <svg
+                                    aria-hidden="true"
+                                    class="c16"
+                                    color="currentColor"
+                                    data-testid="arrow"
+                                    focusable="false"
+                                    height="24"
+                                    width="24"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <button
+                            aria-disabled="true"
+                            aria-label="Go to next month"
+                            class="c7 c8 c9"
+                            data-testid="month-next"
+                            type="button"
+                          >
+                            <svg
+                              aria-hidden="true"
+                              color="currentColor"
+                              focusable="false"
+                              height="20"
+                              width="20"
+                            />
+                          </button>
+                        </div>
+                      </div>
+                      <div
+                        role="table"
+                      >
+                        <div
+                          role="rowgroup"
+                        >
+                          <div
+                            class="react-datepicker__day-names"
+                            role="row"
+                          >
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Sunday
                               </span>
-                              <svg
+                              <span
                                 aria-hidden="true"
-                                class="c16"
-                                color="currentColor"
-                                data-testid="arrow"
-                                focusable="false"
-                                height="24"
-                                width="24"
-                              />
+                              >
+                                Su
+                              </span>
+                            </div>
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Monday
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                Mo
+                              </span>
+                            </div>
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Tuesday
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                Tu
+                              </span>
+                            </div>
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Wednesday
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                We
+                              </span>
+                            </div>
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Thursday
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                Th
+                              </span>
+                            </div>
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Friday
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                Fr
+                              </span>
+                            </div>
+                            <div
+                              class="react-datepicker__day-name"
+                              role="columnheader"
+                            >
+                              <span
+                                class="react-datepicker__sr-only"
+                              >
+                                Saturday
+                              </span>
+                              <span
+                                aria-hidden="true"
+                              >
+                                Sa
+                              </span>
                             </div>
                           </div>
                         </div>
                         <div
-                          class="c11"
+                          aria-label="Month October, 2010"
+                          class="react-datepicker__month"
+                          role="rowgroup"
                         >
                           <div
-                            class="c12 c13"
+                            class="react-datepicker__week"
+                            role="row"
                           >
                             <div
-                              aria-controls="uuid3_listbox"
-                              aria-expanded="false"
-                              aria-invalid="false"
-                              aria-label="Select a year"
-                              aria-labelledby="uuid3_label uuid3_listbox_2010_label"
-                              aria-readonly="false"
-                              aria-required="false"
-                              class="c14"
-                              data-testid="year-select"
-                              id="uuid3"
-                              role="combobox"
-                              tabindex="0"
+                              aria-disabled="false"
+                              aria-label="Choose Sunday, September 26th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
                             >
-                              <input
-                                data-testid="input"
-                                type="hidden"
-                                value="2010"
-                              />
-                              <span
-                                class="c15"
-                              >
-                                2010
-                              </span>
-                              <svg
-                                aria-hidden="true"
-                                class="c16"
-                                color="currentColor"
-                                data-testid="arrow"
-                                focusable="false"
-                                height="24"
-                                width="24"
-                              />
+                              26
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Monday, September 27th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              27
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Tuesday, September 28th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              28
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Wednesday, September 29th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              29
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Thursday, September 30th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              30
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Friday, October 1st, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--001"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              1
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Saturday, October 2nd, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              2
                             </div>
                           </div>
-                        </div>
-                      </div>
-                      <button
-                        aria-disabled="true"
-                        aria-label="Go to next month"
-                        class="c7 c8 c9"
-                        data-testid="month-next"
-                        type="button"
-                      >
-                        <svg
-                          aria-hidden="true"
-                          color="currentColor"
-                          focusable="false"
-                          height="20"
-                          width="20"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                  <div
-                    role="table"
-                  >
-                    <div
-                      role="rowgroup"
-                    >
-                      <div
-                        class="react-datepicker__day-names"
-                        role="row"
-                      >
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
+                          <div
+                            class="react-datepicker__week"
+                            role="row"
                           >
-                            Sunday
-                          </span>
-                          <span
-                            aria-hidden="true"
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Sunday, October 3rd, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              3
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Monday, October 4th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--004"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              4
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Tuesday, October 5th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--005"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              5
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Wednesday, October 6th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--006"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              6
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Thursday, October 7th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--007"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              7
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Friday, October 8th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--008"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              8
+                            </div>
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Saturday, October 9th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              9
+                            </div>
+                          </div>
+                          <div
+                            class="react-datepicker__week react-datepicker__week--keyboard-selected"
+                            role="row"
                           >
-                            Su
-                          </span>
-                        </div>
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
+                            <div
+                              aria-disabled="false"
+                              aria-label="Choose Sunday, October 10th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="0"
+                              title=""
+                            >
+                              10
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Monday, October 11th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              11
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Tuesday, October 12th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              12
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Wednesday, October 13th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              13
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Thursday, October 14th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              14
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Friday, October 15th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              15
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Saturday, October 16th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              16
+                            </div>
+                          </div>
+                          <div
+                            class="react-datepicker__week"
+                            role="row"
                           >
-                            Monday
-                          </span>
-                          <span
-                            aria-hidden="true"
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Sunday, October 17th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              17
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Monday, October 18th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              18
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Tuesday, October 19th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              19
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Wednesday, October 20th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              20
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Thursday, October 21st, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              21
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Friday, October 22nd, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              22
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Saturday, October 23rd, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              23
+                            </div>
+                          </div>
+                          <div
+                            class="react-datepicker__week"
+                            role="row"
                           >
-                            Mo
-                          </span>
-                        </div>
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Sunday, October 24th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              24
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Monday, October 25th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              25
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Tuesday, October 26th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              26
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Wednesday, October 27th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              27
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Thursday, October 28th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              28
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Friday, October 29th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              29
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Saturday, October 30th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              30
+                            </div>
+                          </div>
+                          <div
+                            class="react-datepicker__week"
+                            role="row"
                           >
-                            Tuesday
-                          </span>
-                          <span
-                            aria-hidden="true"
-                          >
-                            Tu
-                          </span>
-                        </div>
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
-                          >
-                            Wednesday
-                          </span>
-                          <span
-                            aria-hidden="true"
-                          >
-                            We
-                          </span>
-                        </div>
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
-                          >
-                            Thursday
-                          </span>
-                          <span
-                            aria-hidden="true"
-                          >
-                            Th
-                          </span>
-                        </div>
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
-                          >
-                            Friday
-                          </span>
-                          <span
-                            aria-hidden="true"
-                          >
-                            Fr
-                          </span>
-                        </div>
-                        <div
-                          class="react-datepicker__day-name"
-                          role="columnheader"
-                        >
-                          <span
-                            class="react-datepicker__sr-only"
-                          >
-                            Saturday
-                          </span>
-                          <span
-                            aria-hidden="true"
-                          >
-                            Sa
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      aria-label="Month October, 2010"
-                      class="react-datepicker__month"
-                      role="rowgroup"
-                    >
-                      <div
-                        class="react-datepicker__week"
-                        role="row"
-                      >
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Sunday, September 26th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--weekend react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          26
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Monday, September 27th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          27
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Tuesday, September 28th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          28
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Wednesday, September 29th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          29
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Thursday, September 30th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          30
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Friday, October 1st, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--001"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          1
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Saturday, October 2nd, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          2
-                        </div>
-                      </div>
-                      <div
-                        class="react-datepicker__week"
-                        role="row"
-                      >
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Sunday, October 3rd, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          3
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Monday, October 4th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--004"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          4
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Tuesday, October 5th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--005"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          5
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Wednesday, October 6th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--006"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          6
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Thursday, October 7th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--007"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          7
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Friday, October 8th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--008"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          8
-                        </div>
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Saturday, October 9th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--009 react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          9
-                        </div>
-                      </div>
-                      <div
-                        class="react-datepicker__week react-datepicker__week--keyboard-selected"
-                        role="row"
-                      >
-                        <div
-                          aria-disabled="false"
-                          aria-label="Choose Sunday, October 10th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--010 react-datepicker__day--keyboard-selected react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="0"
-                          title=""
-                        >
-                          10
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Monday, October 11th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--011 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          11
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Tuesday, October 12th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--012 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          12
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Wednesday, October 13th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--013 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          13
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Thursday, October 14th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--014 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          14
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Friday, October 15th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--015 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          15
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Saturday, October 16th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--016 react-datepicker__day--disabled react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          16
-                        </div>
-                      </div>
-                      <div
-                        class="react-datepicker__week"
-                        role="row"
-                      >
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Sunday, October 17th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--017 react-datepicker__day--disabled react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          17
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Monday, October 18th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--018 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          18
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Tuesday, October 19th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--019 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          19
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Wednesday, October 20th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--020 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          20
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Thursday, October 21st, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--021 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          21
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Friday, October 22nd, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--022 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          22
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Saturday, October 23rd, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--023 react-datepicker__day--disabled react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          23
-                        </div>
-                      </div>
-                      <div
-                        class="react-datepicker__week"
-                        role="row"
-                      >
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Sunday, October 24th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--024 react-datepicker__day--disabled react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          24
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Monday, October 25th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--025 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          25
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Tuesday, October 26th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--026 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          26
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Wednesday, October 27th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--027 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          27
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Thursday, October 28th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--028 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          28
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Friday, October 29th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--029 react-datepicker__day--disabled"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          29
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Saturday, October 30th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--030 react-datepicker__day--disabled react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          30
-                        </div>
-                      </div>
-                      <div
-                        class="react-datepicker__week"
-                        role="row"
-                      >
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Sunday, October 31st, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          31
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Monday, November 1st, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          1
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Tuesday, November 2nd, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          2
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Wednesday, November 3rd, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          3
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Thursday, November 4th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          4
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Friday, November 5th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          5
-                        </div>
-                        <div
-                          aria-disabled="true"
-                          aria-label="Not available Saturday, November 6th, 2010"
-                          aria-selected="false"
-                          class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
-                          role="gridcell"
-                          tabindex="-1"
-                          title=""
-                        >
-                          6
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Sunday, October 31st, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--031 react-datepicker__day--disabled react-datepicker__day--weekend"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              31
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Monday, November 1st, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--001 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              1
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Tuesday, November 2nd, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--002 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              2
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Wednesday, November 3rd, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--003 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              3
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Thursday, November 4th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--004 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              4
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Friday, November 5th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--005 react-datepicker__day--disabled react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              5
+                            </div>
+                            <div
+                              aria-disabled="true"
+                              aria-label="Not available Saturday, November 6th, 2010"
+                              aria-selected="false"
+                              class="react-datepicker__day react-datepicker__day--006 react-datepicker__day--disabled react-datepicker__day--weekend react-datepicker__day--outside-month"
+                              role="gridcell"
+                              tabindex="-1"
+                              title=""
+                            >
+                              6
+                            </div>
+                          </div>
                         </div>
                       </div>
                     </div>
@@ -6378,28 +6518,32 @@ label + .c3 {
                 </div>
               </div>
             </div>
+            <div
+              class="react-datepicker__tab-loop__end"
+              tabindex="0"
+            />
           </div>
         </div>
-        <div
-          class="react-datepicker__tab-loop__end"
+        <button
+          aria-label="Choose date"
+          class="c7 c17"
+          data-testid="calendar-button"
           tabindex="0"
-        />
+          type="button"
+        >
+          <svg
+            color="currentColor"
+            focusable="false"
+            height="24"
+            width="24"
+          />
+        </button>
       </div>
     </div>
-    <button
-      aria-label="Choose date"
-      class="c7 c17"
-      data-testid="calendar-button"
-      tabindex="0"
-      type="button"
-    >
-      <svg
-        color="currentColor"
-        focusable="false"
-        height="24"
-        width="24"
-      />
-    </button>
   </div>
-</div>
+  <div
+    class="c18"
+    data-testid="toasts"
+  />
+</body>
 `;

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button-classes.ts
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button-classes.ts
@@ -1,0 +1,18 @@
+import { generateComponentClasses } from '../../utils/component-classes';
+
+const COMPONENT_NAME = 'DropdownMenuButton';
+
+interface DropdownMenuButtonClasses {
+    button: string;
+    expandIcon: string;
+}
+
+export type DropdownMenuButtonClassKeys = keyof DropdownMenuButtonClasses;
+
+export const dropdownMenuButtonClasses: DropdownMenuButtonClasses = generateComponentClasses(
+    COMPONENT_NAME,
+    [
+        'button',
+        'expandIcon',
+    ],
+);

--- a/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
+++ b/packages/react/src/components/dropdown-menu-button/dropdown-menu-button.test.tsx.snap
@@ -407,7 +407,7 @@ exports[`DropdownMenuButton Matches Snapshot (defaultOpen) 1`] = `
     >
       <button
         aria-expanded="true"
-        class="c1 c2 c3"
+        class="c1 c2 c3 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -1061,7 +1061,7 @@ exports[`DropdownMenuButton Matches Snapshot 1`] = `
     >
       <button
         aria-expanded="true"
-        class="c1 c2 c3"
+        class="c1 c2 c3 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >

--- a/packages/react/src/components/dropdown-menu-button/index.ts
+++ b/packages/react/src/components/dropdown-menu-button/index.ts
@@ -1,2 +1,3 @@
 export { DropdownMenuButton } from './dropdown-menu-button';
-export type { DropdownMenuButtonProps } from './dropdown-menu-button';
+export { dropdownMenuButtonClasses } from './dropdown-menu-button-classes';
+export type { DropdownMenuButtonProps, DropdownMenuCloseFunction } from './dropdown-menu-button';

--- a/packages/react/src/components/listbox/listbox.tsx
+++ b/packages/react/src/components/listbox/listbox.tsx
@@ -4,6 +4,7 @@ import {
     KeyboardEvent,
     Ref,
     RefAttributes,
+    RefObject,
     useCallback,
     useLayoutEffect,
     useRef,
@@ -36,6 +37,7 @@ export interface ListboxProps {
     id?: string;
     options: ListboxOption[];
     className?: string;
+    containerRef?: RefObject<HTMLElement>;
     /**
      * The default selected option. You may specify an array of strings when using multiselect feature.
      */
@@ -209,6 +211,7 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
     ariaLabelledBy,
     id: providedId,
     className,
+    containerRef: providedContainerRef,
     defaultValue,
     focusable = true,
     focusedValue,
@@ -281,7 +284,10 @@ export const Listbox: ForwardRefExoticComponent<ListboxProps & RefAttributes<HTM
         onChange?.(newSelectedOptions);
     }
 
-    const { scrollIntoView } = useScrollIntoView({ container: containerRef });
+    const { scrollIntoView } = useScrollIntoView({
+        container: containerRef,
+        scrollingContainer: providedContainerRef || containerRef,
+    });
 
     const scrollToOption: (
         option?: ListboxOption,

--- a/packages/react/src/components/menu-button/menu-button.tsx
+++ b/packages/react/src/components/menu-button/menu-button.tsx
@@ -70,7 +70,6 @@ export const MenuButton: FunctionComponent<PropsWithChildren<MenuButtonProps>> =
     const { t } = useTranslation('menu-button');
 
     const [visible, setVisible] = useState(!!defaultOpen);
-    const [initialFocusIndex, setInitialFocusIndex] = useState(0);
     const containerRef = useRef<HTMLDivElement>(null);
 
     const placement = menuPlacement === 'right' ? 'bottom-start' : 'bottom-end';
@@ -105,16 +104,8 @@ export const MenuButton: FunctionComponent<PropsWithChildren<MenuButtonProps>> =
         }
     };
 
-    /**
-     * Set focus on first menu item conditionally
-     * depending on whether it's a keypress, or a mouse event
-     */
-    const handleClickInside = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleClickInside = useCallback(() => {
         setVisible(!visible);
-        // event.detail returns an integer, indicating how many clicks there were
-        // If it's 0, no click was made and onClick was fired by a keypress
-        const focusIndex = event.detail === 0 ? 0 : -1;
-        setInitialFocusIndex(focusIndex);
     }, [visible]);
 
     /**
@@ -194,7 +185,6 @@ export const MenuButton: FunctionComponent<PropsWithChildren<MenuButtonProps>> =
                 <StyledMenu
                     ref={refs.setFloating}
                     options={options}
-                    initialFocusIndex={initialFocusIndex}
                     onOptionSelect={handleOnOptionSelect}
                     $left={`${x}px`}
                     $top={`${y}px`}

--- a/packages/react/src/components/user-profile/user-profile.test.tsx.snap
+++ b/packages/react/src/components/user-profile/user-profile.test.tsx.snap
@@ -487,7 +487,7 @@ exports[`UserProfile Matches Snapshot (\`full-name\`) 1`] = `
     >
       <button
         aria-expanded="true"
-        class="c1 c2 c3"
+        class="c1 c2 c3 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -830,7 +830,7 @@ exports[`UserProfile Matches Snapshot (defaultOpen) 1`] = `
     >
       <button
         aria-expanded="false"
-        class="c1 c2 c3"
+        class="c1 c2 c3 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -1350,7 +1350,7 @@ exports[`UserProfile Matches Snapshot (mobile) 1`] = `
     >
       <button
         aria-expanded="true"
-        class="c2 c3"
+        class="c2 c3 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -2023,7 +2023,7 @@ exports[`UserProfile Matches Snapshot (tag="nav") 1`] = `
     >
       <button
         aria-expanded="true"
-        class="c1 c2 c3"
+        class="c1 c2 c3 eds-DropdownMenuButton-button"
         data-testid="menu-button"
         type="button"
       >
@@ -2348,7 +2348,7 @@ exports[`UserProfile Matches Snapshot (variant=\`avatar-only\`) 1`] = `
 >
   <button
     aria-expanded="false"
-    class="c1 c2"
+    class="c1 c2 eds-DropdownMenuButton-button"
     data-testid="menu-button"
     type="button"
   >

--- a/packages/react/src/utils/css-state.ts
+++ b/packages/react/src/utils/css-state.ts
@@ -1,13 +1,33 @@
 import { css, FlattenSimpleInterpolation } from 'styled-components';
 import { ResolvedTheme } from '../themes';
+import { DS_CLASS_PREFIX } from './component-classes';
 
 type FocusType = 'focus' | 'focus-visible' | 'focus-within';
 
 export interface FocusOptions {
     selector?: string;
     focusType?: FocusType;
+    focusTypeClass?: boolean;
     inverted?: boolean;
     insideOnly?: boolean;
+}
+
+function generateFocusClass(focusType: FocusType): string {
+    return `${DS_CLASS_PREFIX}util-${focusType}`;
+}
+
+const focusVisibleClass = generateFocusClass('focus-visible');
+
+export function addFocusVisibleActive(element: HTMLElement | null): void {
+    if (element) {
+        element?.classList?.add(focusVisibleClass);
+    }
+}
+
+export function removeFocusVisibleActive(element: HTMLElement | null): void {
+    if (element) {
+        element?.classList.remove(focusVisibleClass);
+    }
 }
 
 export const focus = (
@@ -15,6 +35,7 @@ export const focus = (
     options: FocusOptions = {},
 ): FlattenSimpleInterpolation => {
     const {
+        focusTypeClass = false,
         selector,
         focusType = 'focus-visible',
         inverted = false,
@@ -30,6 +51,7 @@ export const focus = (
     const baseSelector = selector ?? '';
 
     return css`
+        ${focusTypeClass ? `&.${generateFocusClass(focusType)} ${baseSelector},` : ''}
         &:${focusType} ${baseSelector} {
             box-shadow: 0 0 0 ${outsideFocusBorderWeight} ${outsideFocusBorderColor};
             outline: ${insideFocusBorderWeight} solid ${insideFocusBorderColor};

--- a/packages/react/src/utils/dom.ts
+++ b/packages/react/src/utils/dom.ts
@@ -15,6 +15,11 @@ export function getRootElement(shadowRoot: ShadowRoot | null): Element {
     return document.body;
 }
 
+export function activeElementIsInside(element: HTMLElement | null): boolean {
+    const focusedElement = getRootDocument(element)?.activeElement;
+    return element?.contains(focusedElement || null) ?? false;
+}
+
 export function sanitizeId(id: string): string {
     return id.replace(/\s/g, '_');
 }


### PR DESCRIPTION
Les portals brisent un peu les tabs index alors faut gérer quelques petits trucs manuellement. J'ai revalidé la doc de certains components qui étaient déjà pas corrects avant. Dans la PR ici je gère surtout le "tab-inside", il va me rester le tab qui quitte le component, mais c'est plus complexe. Je vais regarder ça après avoir fini les filtres.

Le gros diff c'est surtout le snapshot du date-picker qui était pas correct.