### PR TITLE
fix(Avatar): allow numeric initials (LG-1262)

### DIFF
--- a/packages/react/src/utils/user.test.ts
+++ b/packages/react/src/utils/user.test.ts
@@ -7,11 +7,11 @@ describe('getInitialsFromUsername', () => {
         expect(initials).toBe('');
     });
 
-    it('should be both first alpha characters from username first and last name '
-        + 'given first and last name with non alpha characters', () => {
+    it('should be both first alphanumeric characters from username first and last name '
+        + 'given first and last name with non alphanumeric characters', () => {
         const initials = getInitialsFromUsername('_John 123Doe');
 
-        expect(initials).toBe('JD');
+        expect(initials).toBe('J1');
     });
 
     it('should be both first characters from username first and last name'
@@ -52,5 +52,23 @@ describe('getInitialsFromUsername', () => {
         const initials = getInitialsFromUsername('Édouard Åhlund');
 
         expect(initials).toBe('EA');
+    });
+
+    it('should be the two first characters given a numeric-only username', () => {
+        const initials = getInitialsFromUsername('42');
+
+        expect(initials).toBe('42');
+    });
+
+    it('should be both first characters given an alphanumeric first and last name', () => {
+        const initials = getInitialsFromUsername('Agent 007');
+
+        expect(initials).toBe('A0');
+    });
+
+    it('should be the two first characters given a single numeric word', () => {
+        const initials = getInitialsFromUsername('7');
+
+        expect(initials).toBe('7');
     });
 });

--- a/packages/react/src/utils/user.ts
+++ b/packages/react/src/utils/user.ts
@@ -1,12 +1,12 @@
 export function getInitialsFromUsername(username: string): string {
-    const usernameWithoutNonAlphaCharacters = username.normalize('NFD').replace(/[^a-zA-Z\s]/g, '');
-    if (usernameWithoutNonAlphaCharacters.length === 0) {
+    const userNameAlphanumerical = username.normalize('NFD').replace(/[^a-zA-Z0-9\s]/g, '');
+    if (userNameAlphanumerical.length === 0) {
         return '';
     }
 
-    const nameParts: string[] = usernameWithoutNonAlphaCharacters.split(/\s/);
-    if (nameParts.length === 1 && usernameWithoutNonAlphaCharacters.length > 0) {
-        return usernameWithoutNonAlphaCharacters.substring(0, 2).toUpperCase();
+    const nameParts: string[] = userNameAlphanumerical.split(/\s/);
+    if (nameParts.length === 1 && userNameAlphanumerical.length > 0) {
+        return userNameAlphanumerical.substring(0, 2).toUpperCase();
     }
 
     return nameParts[0].charAt(0).toUpperCase() + nameParts[nameParts.length - 1].charAt(0).toUpperCase();


### PR DESCRIPTION
Initials regex for function correctly only considered alphabetic characters, now added an option to consider numeric values for generic accounts

<img width="657" height="269" alt="image" src="https://github.com/user-attachments/assets/21124f32-b313-40b3-a5b5-9fad4b3c44d9" />
