### PR TITLE
fix(PromotionalBanner): ajouter une classe pour permettre d'ajuster la largeur du PromotionalButton (DS-1585)

### DIFF
--- a/packages/react/src/components/promotional-banner/index.ts
+++ b/packages/react/src/components/promotional-banner/index.ts
@@ -1,2 +1,5 @@
 export { PromotionalBanner } from './promotional-banner';
 export type { PromotionalBannerProps } from './promotional-banner';
+
+export { promotionalBannerClasses } from './promotional-banner-classes';
+export type { PromotionalBannerClasses } from './promotional-banner-classes';

--- a/packages/react/src/components/promotional-banner/promotional-banner-classes.ts
+++ b/packages/react/src/components/promotional-banner/promotional-banner-classes.ts
@@ -1,0 +1,16 @@
+import { generateComponentClasses } from '../../utils/component-classes';
+
+const COMPONENT_NAME = 'PromotionalBanner';
+
+export interface PromotionalBannerClasses {
+    button: string;
+}
+
+export type PromotionalBannerClassKeys = keyof PromotionalBannerClasses;
+
+export const promotionalBannerClasses: PromotionalBannerClasses = generateComponentClasses(
+    COMPONENT_NAME,
+    [
+        'button',
+    ],
+);

--- a/packages/react/src/components/promotional-banner/promotional-banner.tsx
+++ b/packages/react/src/components/promotional-banner/promotional-banner.tsx
@@ -7,6 +7,7 @@ import { Logo, type LogoName } from '../logo';
 import { PromotionalButton, type PromotionalButtonProps } from '../promotional-button';
 import { Tooltip } from '../tooltip';
 import { backgroundGradientEnd, backgroundGradientStart } from './colors';
+import { promotionalBannerClasses } from './promotional-banner-classes';
 
 const Banner = styled.div`
     align-items: center;
@@ -49,6 +50,7 @@ const StyledLogo = styled(Logo)`
 `;
 
 export interface PromotionalBannerProps {
+    className?: string;
     button: PromotionalButtonProps;
     logo: LogoName;
 
@@ -56,6 +58,7 @@ export interface PromotionalBannerProps {
 }
 
 export const PromotionalBanner: FC<PropsWithChildren<PromotionalBannerProps>> = ({
+    className,
     children,
     button,
     logo,
@@ -63,13 +66,14 @@ export const PromotionalBanner: FC<PropsWithChildren<PromotionalBannerProps>> = 
 }) => {
     const { t } = useTranslation('promotional-banner');
     return (
-        <Banner>
+        <Banner className={className}>
             <Text>
                 {logo && <StyledLogo name={logo} />}
                 {children}
             </Text>
             <Buttons>
                 <PromotionalButton
+                    className={promotionalBannerClasses.button}
                     label={button.label}
                     loading={button.loading}
                     loadingLabel={button.loadingLabel}

--- a/packages/react/src/components/promotional-button/promotional-button.tsx
+++ b/packages/react/src/components/promotional-button/promotional-button.tsx
@@ -46,6 +46,7 @@ const StyledButton = styled(Button)`
 `;
 
 export interface PromotionalButtonProps {
+    className?: string;
     label: string;
     loading?: boolean;
     loadingLabel?: string;
@@ -54,6 +55,7 @@ export interface PromotionalButtonProps {
 }
 
 export const PromotionalButton: FC<PromotionalButtonProps> = ({
+    className,
     label,
     loading = false,
     loadingLabel,
@@ -61,6 +63,7 @@ export const PromotionalButton: FC<PromotionalButtonProps> = ({
 }) => (
     <StyledButton
         buttonType="secondary"
+        className={className}
         disabled={loading}
         leftIconName="equisoft"
         loading={loading}


### PR DESCRIPTION
C'est une partie de la solution. Il va rester à ce que le bouton soit plus responsive quand il a une largeur fixe, pour que les icônes restent aux extrémités.